### PR TITLE
Return report & code map results instead of just report

### DIFF
--- a/src/jscpd.coffee
+++ b/src/jscpd.coffee
@@ -109,8 +109,10 @@ class jscpd
 
       logger.profile 'Generate report time:'
       logger.info 'Start report generation...\n'
-      result = report.generate codeMap
+      reportResult = report.generate codeMap
       logger.profile 'Generate report time:'
-      result
+      result =
+        report: reportResult,
+        result: codeMap
 
 module.exports = jscpd


### PR DESCRIPTION
This is just a little change that returns the code map result instead of just the report result.
This would ease consumer libs to do actions based on code results.

One use-case would be to set a threshold value in the grunt-jscpd plugin to make the task fails when there are too much copy pasted detected  
