### PR TITLE
Make error message more clear

### DIFF
--- a/src/jscpd.coffee
+++ b/src/jscpd.coffee
@@ -22,7 +22,7 @@ class jscpd
       doc = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
       logger.info "Used config from #{file}"
     catch e
-      logger.warn "File #{file} not found in current directory"
+      logger.warn "File #{file} not found in current directory, or it is broken"
     doc
 
   run: (options)->


### PR DESCRIPTION
Hello,

In my case I had tabs instead of spaces in my `.cpd.yaml`, it was preventing config from loading, but due to error message I spent some time on checking whether I named file correctly.

I propose to extend error message.