### PR TITLE
Tests for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "coveralls": "2.11.x"
   },
   "scripts": {
-    "test": "mocha --compilers coffee:coffee-script/register -R spec $(find test -name '*.test.coffee')"
+    "test": "bash scripts/test.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-mocha --compilers coffee:coffee-script/register -R spec $(find test -name '*.test.coffee')
+_MOCHA=node_modules/mocha/bin/mocha
+
+_MOCHA --compilers coffee:coffee-script/register -R spec $(find test -name '*.test.coffee')

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+mocha --compilers coffee:coffee-script/register -R spec $(find test -name '*.test.coffee')

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-_MOCHA=node_modules/mocha/bin/mocha
+MOCHA=node_modules/mocha/bin/mocha
 
-_MOCHA --compilers coffee:coffee-script/register -R spec $(find test -name '*.test.coffee')
+$MOCHA --compilers coffee:coffee-script/register -R spec $(find test -name '*.test.coffee')


### PR DESCRIPTION
Preventing failing `npm run test` on Windows (required bash). Has been tested only on Arch Linux so far, and Windows 8.1 with gitbash.