### PR TITLE
Custom reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ languages:
 exclude:
   - "**/*.min.js"
   - "**/*.mm.js"
-reporter:
-  - json
+reporter: json
 ```
 and run `jscpd` command, you will check code for duplicates according config from .cpd.yaml
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Options:
  - -l, --min-lines  | [NUMBER]  | 5             | min size of duplication in code lines
  - -t, --min-tokens | [NUMBER]  | 70            | min size of duplication in code tokens
  - -f, --files      | [STRING]  | *             | glob pattern for find code
- - -r, --reporter   | [STRING]  | xml           | reporter name or **absolute** path
+ - -r, --reporter   | [STRING]  | xml           | reporter name or path
  - -e, --exclude    | [STRING]  | -             | directory to ignore
  - -g, --languages  | [STRING]  | All supported | list of languages which scan for duplicates, separated with coma
  - -o, --output     | [PATH]    | -             | path to report file
@@ -110,7 +110,7 @@ Options:
 Reporters
 ---------
 
-`jscpd` shipped with two standard reporters `xml` and [`json`](test/reporters/json-report.schema.json). It is possible to write custom reporter script too. For hooking reporter up wrap it into npm module and provide name as `reporter` parameter, or alternatively provide **absolute** pathname e.g. `/c/Users/myuser/scripts/jscpd-custom-reporter.coffee` (works with javascript too).
+`jscpd` shipped with two standard reporters `xml` and [`json`](test/reporters/json-report.schema.json). It is possible to write custom reporter script too. For hooking reporter up wrap it into node module and provide path to it as `reporter` parameter e.g. `./scripts/jscpd-custom-reporter.coffee` (works with javascript too).
 
 Custom reporter is a function which is executed into context of `Report` (`report.coffee`) class and thus has access to the report object and options. Expected output is array with following elements:
 

--- a/src/report.coffee
+++ b/src/report.coffee
@@ -21,7 +21,11 @@ class Report
     switch reporter
       when 'xml' then reporter = './reporters/xml-pmd'
       when 'json' then reporter = './reporters/json'
-      else reporter = path.join(process.cwd(), reporter)
+      else
+        cwd = process.cwd()
+        reporter = path.normalize reporter
+        isAbsolute = reporter.indexOf(cwd) is 0
+        reporter = path.join(cwd, reporter) unless isAbsolute
 
     @reporter = require reporter
     @stdReporter = require './reporters/_std-log'

--- a/src/report.coffee
+++ b/src/report.coffee
@@ -1,5 +1,7 @@
 fs = require 'fs'
 logger = require 'winston'
+path = require 'path'
+
 
 
 class Report
@@ -20,6 +22,7 @@ class Report
     switch reporter
       when 'xml' then reporter = './reporters/xml-pmd'
       when 'json' then reporter = './reporters/json'
+      else reporter = path.join(process.cwd(), reporter)
 
     @reporter = require reporter
     @stdReporter = require './reporters/_std-log'

--- a/src/report.coffee
+++ b/src/report.coffee
@@ -18,7 +18,6 @@ class Report
       logger.warn "output file extention '#{@options.output}'
                   does not match reporter '#{reporter}'"
 
-
     switch reporter
       when 'xml' then reporter = './reporters/xml-pmd'
       when 'json' then reporter = './reporters/json'

--- a/test/reporters/cusom.test.coffee
+++ b/test/reporters/cusom.test.coffee
@@ -26,7 +26,7 @@ describe "cusom reporter", ->
     result = jscpd::run
       path: "test/fixtures/"
       languages: ['go']
-      reporter: './test/reporters/custom-reporter.js'
+      reporter: process.cwd() + '/test/reporters/custom-reporter.js'
 
     result.report.should.be.exist
     result.map.should.be.exist

--- a/test/reporters/cusom.test.coffee
+++ b/test/reporters/cusom.test.coffee
@@ -12,7 +12,7 @@ describe "cusom reporter", ->
     result = jscpd::run
       path: "test/fixtures/"
       languages: ['go']
-      reporter: '../test/reporters/custom-reporter.coffee'
+      reporter: './test/reporters/custom-reporter.coffee'
 
     result.report.should.be.exist
     result.map.should.be.exist
@@ -26,7 +26,7 @@ describe "cusom reporter", ->
     result = jscpd::run
       path: "test/fixtures/"
       languages: ['go']
-      reporter: '../test/reporters/custom-reporter.js'
+      reporter: './test/reporters/custom-reporter.js'
 
     result.report.should.be.exist
     result.map.should.be.exist


### PR DESCRIPTION
Moving out from reporters as a npm module, doing current working directory relative path `require` instead, works with absolute path as well.