### PR TITLE
Allow for .cpd.yml in addition to .cpd.yaml

### DIFF
--- a/src/jscpd.coffee
+++ b/src/jscpd.coffee
@@ -17,17 +17,15 @@ class jscpd
 
   readConfig: (file) ->
     file = path.normalize file
-    doc = {}
     try
       doc = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
       logger.info "Used config from #{file}"
     catch e
       logger.warn "File #{file} not found in current directory, or it is broken"
-    doc
 
   run: (options)->
     cwd = options.path
-    config = @readConfig("#{cwd}/.cpd.yaml")
+    config = @readConfig("#{cwd}/.cpd.yaml") || @readConfig("#{cwd}/.cpd.yml") || {}
 
     options = _.extend
       'min-lines': 5


### PR DESCRIPTION
We are using `.yml` suffixed-files in our repo, so we thought it would be great if you could support both extensions.  I tested it by moving `test/.cpd.yaml` to `test/.cpd.yml` and running `npm test`.