### PR TITLE
Fix path.join issue

### DIFF
--- a/src/report.coffee
+++ b/src/report.coffee
@@ -25,7 +25,7 @@ class Report
         cwd = process.cwd()
         reporter = path.normalize reporter
         isAbsolute = reporter.indexOf(cwd) is 0
-        reporter = path.join(cwd, reporter) unless isAbsolute
+        reporter = path.resolve(cwd, reporter) unless isAbsolute
 
     @reporter = require reporter
     @stdReporter = require './reporters/_std-log'


### PR DESCRIPTION
`path.resolve` is safer than `path.join`.

Relative code: https://github.com/xcatliu/cqc/blob/master/package.json#L27

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/111)
<!-- Reviewable:end -->
