### PR TITLE
Use minimatch to exclude files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "colors": "^1.1.2",
     "glob": ">=5.0.x",
     "js-yaml": ">=3.4.x",
+    "minimatch": "^3.0.4",
     "shelljs": "^0.7.8",
     "underscore": ">=1.8.x",
     "winston": ">=1.0.x"

--- a/src/preprocessors/files.coffee
+++ b/src/preprocessors/files.coffee
@@ -1,19 +1,18 @@
 _ = require "underscore"
 path = require "path"
 glob = require "glob"
+minimatch = require "minimatch"
 
 findFiles = (jscpd) ->
   files = []
-  excluded_files = []
 
   for pattern in jscpd.options.patterns
     files = _.union files, glob.sync(pattern, cwd: jscpd.options.path)
 
   if jscpd.options.exclude and jscpd.options.exclude.length > 0
     for pattern in jscpd.options.exclude
-      excluded_files = _.union excluded_files, glob.sync(pattern, cwd: jscpd.options.path)
+      files = _.filter files, (file) -> !minimatch file, pattern
 
-  files = _.difference files, excluded_files
   files = _.map files, (file) -> path.normalize "#{jscpd.options.path}/#{file}"
   return files
 


### PR DESCRIPTION
There is a problem with excluding. jscpd resolves `exclude` patterns
but there may be cases then `include` and `exclude` options have
no overlap. Also now it calculate difference between 2 lists but it's
slow in case of 2 big lists. This commit use minimatch module (it's
always installed cause it's glob's dependency) for filtering mathed
files. It allow prevent extra sync interaction with fs that should
make jscpd much faster on slow hdd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/122)
<!-- Reviewable:end -->
