### PR TITLE
fix: add support for trailling slash gitignore pattern

### DIFF
--- a/src/jscpd.ts
+++ b/src/jscpd.ts
@@ -94,7 +94,9 @@ export class JSCPD {
     const ignore: string[] = this._options.ignore || [];
 
     if (this._options.gitignore && existsSync(pathToFiles + '/.gitignore')) {
-      ignore.push(...gitignoreToGlob(pathToFiles + '/.gitignore'));
+      let gitignorePatterns:string[] = gitignoreToGlob(pathToFiles + '/.gitignore')||[];
+      gitignorePatterns = gitignorePatterns.map(pattern => (pattern.substr(pattern.length - 1) === '/' ? `${pattern}**/*` : pattern))
+      ignore.push(...gitignorePatterns);
       ignore.map(pattern => pattern.replace('!', ''));
     }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
gitignore pattern with a trailing slash like `node_modules/` is not working


* **What is the new behavior (if this is a feature change)?**
gitignore pattern with a trailing slash like `node_modules/` should work


* **Other information**:
Issue: https://github.com/kucherenko/jscpd/issues/179

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/180)
<!-- Reviewable:end -->
