### PR TITLE
fix: support locally installed reporter and mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
   directories:
   - "$HOME/.npm"
 script:
-  - npm install jscpd-badge-reporter -g
   - npm run all
   - npm run build
 after_success:

--- a/src/utils/use.ts
+++ b/src/utils/use.ts
@@ -4,7 +4,7 @@ const detectInstalled = require('detect-installed');
 
 export function useReporter(name: string) {
   const reporterName = `jscpd-${name}-reporter`;
-  if (!detectInstalled.sync(reporterName)) {
+  if (!detectInstalled.sync(reporterName, { local: true })) {
     throw new Error(`Reporter "${reporterName}" does not found, please check that you have installed reporter package`);
   }
   return require(reporterName).default;
@@ -12,7 +12,7 @@ export function useReporter(name: string) {
 
 export function useMode(name: string): IMode {
   const modeName = `jscpd-${name}-mode`;
-  if (!detectInstalled.sync(modeName)) {
+  if (!detectInstalled.sync(modeName, { local: true })) {
     throw new Error(`Mode "${modeName}" does not found, please check that you have installed mode package`);
   }
   return require(modeName).default;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

support locally installed reporter and mode

* **What is the current behavior?** (You can also link to an open issue here)

currently, reporter and mode have to be globally installed to be used.

* **What is the new behavior (if this is a feature change)?**

we can install reporter and mode locally, thus can benefit from lock file.

* **Other information**:

I'm curious about why `detect-installed` is used. IMO `useReporter` can be written like
```ts
export function useReporter(name: string) {
  try {
    return require(reporterName).default;
  } catch (e) {
    throw new Error(`Reporter "${reporterName}" does not found, please check that you have installed reporter package`);
  }
}
```
