### PR TITLE
fix(handlebars): add hbs file extension

### DIFF
--- a/src/tokenizer/formats/formats.ts
+++ b/src/tokenizer/formats/formats.ts
@@ -162,7 +162,7 @@ export const FORMATS: {
     exts: ['haml']
   },
   handlebars: {
-    exts: ['hb', 'handlebars']
+    exts: ['hb', 'hbs', 'handlebars']
   },
   haskell: {
     exts: ['hs', 'lhs ']


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behaviour?** (You can also link to an open issue here)
Files with the hbs extension are not part of the handlebars format.


* **What is the new behaviour (if this is a feature change)?**
The handlebars format now includes the hbs extension.


* **Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/283)
<!-- Reviewable:end -->
