### PR TITLE
Add Xcode reporter

### DIFF
--- a/packages/finder/src/reporters/index.ts
+++ b/packages/finder/src/reporters/index.ts
@@ -5,3 +5,4 @@ export * from './json';
 export * from './xml';
 export * from './silent';
 export * from './threshold';
+export * from './xcode'

--- a/packages/finder/src/reporters/xcode.ts
+++ b/packages/finder/src/reporters/xcode.ts
@@ -1,0 +1,26 @@
+import {IClone, IOptions} from '@jscpd/core';
+import {IReporter} from '..';
+import {getPath} from '../utils/reports';
+
+export class XcodeReporter implements IReporter {
+	constructor(private readonly options: IOptions) {
+	}
+
+	public report(clones: IClone[]): void {
+		clones.forEach((clone: IClone) => {
+			this.cloneFound(clone);
+		});
+		console.log(`Found ${clones.length} clones.`);
+	}
+
+	private cloneFound(clone: IClone): void {
+		const pathA = getPath(clone.duplicationA.sourceId, this.options);
+		const pathB = getPath(clone.duplicationB.sourceId, this.options);
+		const startLineA = clone.duplicationA.start.line;
+		const characterA = clone.duplicationA.start.column;
+		const endLineA = clone.duplicationA.end.line;
+		const startLineB = clone.duplicationB.start.line;
+		const endLineB = clone.duplicationB.end.line;
+		console.log(`${pathA}:${startLineA}:${characterA}: warning: Found ${endLineA - startLineA} lines (${startLineA}-${endLineA}) duplicated on file ${pathB} (${startLineB}-${endLineB})`);
+	}
+}

--- a/packages/finder/src/reporters/xcode.ts
+++ b/packages/finder/src/reporters/xcode.ts
@@ -14,7 +14,7 @@ export class XcodeReporter implements IReporter {
 	}
 
 	private cloneFound(clone: IClone): void {
-		const pathA = getPath(clone.duplicationA.sourceId, this.options);
+		const pathA = getPath(clone.duplicationA.sourceId, {...this.options, absolute: true});
 		const pathB = getPath(clone.duplicationB.sourceId, this.options);
 		const startLineA = clone.duplicationA.start.line;
 		const characterA = clone.duplicationA.start.column;

--- a/packages/jscpd/__tests__/reporters.test.ts
+++ b/packages/jscpd/__tests__/reporters.test.ts
@@ -5,7 +5,7 @@ import sinon = require('sinon');
 import path = require('path');
 
 
-const pathToFixtures = path.join(__dirname + '/../../../fixtures');
+const pathToFixtures = path.join(__dirname, '/../../../fixtures');
 
 describe('jscpd reporters', () => {
 

--- a/packages/jscpd/__tests__/reporters.test.ts
+++ b/packages/jscpd/__tests__/reporters.test.ts
@@ -59,7 +59,7 @@ describe('jscpd reporters', () => {
 	});
 
 	describe('Xcode', () => {
-		it('should generate report with Xcode warnings with second file absoulte path', async () => {
+		it('should generate report with Xcode warnings with second file absolute path', async () => {
 			const log = (console.log as any);
 			const fullPathToFile = path.join(pathToFixtures, '/clike/file2.c');
 			const expected = fullPathToFile + ':18:3: warning: Found 10 lines (18-28) duplicated on file ' + fullPathToFile + ' (8-18)';

--- a/packages/jscpd/__tests__/reporters.test.ts
+++ b/packages/jscpd/__tests__/reporters.test.ts
@@ -2,9 +2,10 @@ import {expect} from 'chai';
 import {jscpd} from '../src';
 import {green, grey} from 'colors/safe';
 import sinon = require('sinon');
+import path = require('path');
 
 
-const pathToFixtures = __dirname + '/../../../fixtures';
+const pathToFixtures = path.join(__dirname + '/../../../fixtures');
 
 describe('jscpd reporters', () => {
 
@@ -54,6 +55,16 @@ describe('jscpd reporters', () => {
 			const log = (console.log as any);
 			await jscpd(['', '', pathToFixtures + '/clike/file2.c', '--reporters', 'consoleFull']);
 			expect(log.calledWith(grey('Found 1 clones.'))).to.be.ok;
+		});
+	});
+
+	describe('Xcode', () => {
+		it('should generate report with Xcode warnings', async () => {
+			const log = (console.log as any);
+			const pathToFile = path.join(pathToFixtures, '/clike/file2.c');
+			const expected = pathToFile + ':18:3: warning: Found 10 lines (18-28) duplicated on file ' + pathToFile + ' (8-18)';
+			await jscpd(['', '', pathToFile, '--reporters', 'xcode', '--absolute']);
+			expect(log.calledWith(expected)).to.be.ok;
 		});
 	});
 

--- a/packages/jscpd/__tests__/reporters.test.ts
+++ b/packages/jscpd/__tests__/reporters.test.ts
@@ -59,11 +59,20 @@ describe('jscpd reporters', () => {
 	});
 
 	describe('Xcode', () => {
-		it('should generate report with Xcode warnings', async () => {
+		it('should generate report with Xcode warnings with second file absoulte path', async () => {
 			const log = (console.log as any);
-			const pathToFile = path.join(pathToFixtures, '/clike/file2.c');
-			const expected = pathToFile + ':18:3: warning: Found 10 lines (18-28) duplicated on file ' + pathToFile + ' (8-18)';
-			await jscpd(['', '', pathToFile, '--reporters', 'xcode', '--absolute']);
+			const fullPathToFile = path.join(pathToFixtures, '/clike/file2.c');
+			const expected = fullPathToFile + ':18:3: warning: Found 10 lines (18-28) duplicated on file ' + fullPathToFile + ' (8-18)';
+			await jscpd(['', '', fullPathToFile, '--reporters', 'xcode', '--absolute']);
+			expect(log.calledWith(expected)).to.be.ok;
+		});
+
+		it('should generate report with Xcode warnings with second file relative path', async () => {
+			const log = (console.log as any);
+			const fullPathToFile = path.join(pathToFixtures, '/clike/file2.c');
+			const relativePath = 'fixtures/clike/file2.c';
+			const expected = fullPathToFile + ':18:3: warning: Found 10 lines (18-28) duplicated on file ' + relativePath + ' (8-18)';
+			await jscpd(['', '', fullPathToFile, '--reporters', 'xcode']);
 			expect(log.calledWith(expected)).to.be.ok;
 		});
 	});

--- a/packages/jscpd/src/init/reporters.ts
+++ b/packages/jscpd/src/init/reporters.ts
@@ -6,6 +6,7 @@ import {
   JsonReporter,
   SilentReporter,
   ThresholdReporter,
+  XcodeReporter,
   XmlReporter,
 } from '@jscpd/finder';
 import {IOptions} from '@jscpd/core';
@@ -20,6 +21,7 @@ const reporters: Record<string, any> = {
   console: ConsoleReporter,
   silent: SilentReporter,
   threshold: ThresholdReporter,
+  xcode: XcodeReporter,
 }
 
 export function registerReporters(options: IOptions, detector: InFilesDetector): void {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pull request introduces a Xcode reporter


* **What is the current behavior?** (You can also link to an open issue here)
No Xcode reporter #219 


* **What is the new behavior (if this is a feature change)?**
The new Xcode reporter reports the duplications on the format `full_path_to_file:line:character: warning: {content}`. Where content is the warning message.
Xcode automatically recognizes warnings on this format and highlight the corresponding file.


* **Other information**:
For Xcode to link to the correct file the full path needs to be provided. Running `jscpd` with the `--absolute` option works, but is there a better way to get the full path, or maybe enforce `--absolute` for this specific reporter?

P.S: I have never written TypeScript before. This is a small change, but if anyone spots something odd please point it out!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/372)
<!-- Reviewable:end -->
