### PR TITLE
Add Mega-Linter in list of "who uses jscpd"

### DIFF
--- a/packages/jscpd/README.md
+++ b/packages/jscpd/README.md
@@ -495,6 +495,7 @@ In case of detect clones in browser or not node.js environment you can build you
 
 ## Who uses jscpd
  - [Code-Inspector](https://www.code-inspector.com/) is a code analysis and technical debt management service.
+ - [Mega-Linter](https://github.com/nvuillam/mega-linter#readme) is a 100% open-source linters aggregator for CI (Github Action & other CI tools) or to run locally
  - [vscode-jscpd](https://marketplace.visualstudio.com/items?itemName=paulhoughton.vscode-jscpd) VSCode Copy/Paste detector plugin.
 
 ## Contributors

--- a/packages/jscpd/README.md
+++ b/packages/jscpd/README.md
@@ -495,7 +495,7 @@ In case of detect clones in browser or not node.js environment you can build you
 
 ## Who uses jscpd
  - [Code-Inspector](https://www.code-inspector.com/) is a code analysis and technical debt management service.
- - [Mega-Linter](https://github.com/nvuillam/mega-linter#readme) is a 100% open-source linters aggregator for CI (Github Action & other CI tools) or to run locally
+ - [Mega-Linter](https://nvuillam.github.io/mega-linter/) is a 100% open-source linters aggregator for CI (Github Action & other CI tools) or to run locally
  - [vscode-jscpd](https://marketplace.visualstudio.com/items?itemName=paulhoughton.vscode-jscpd) VSCode Copy/Paste detector plugin.
 
 ## Contributors


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Documentation

 **Other information**:

If you see errors and have a banner instead of a logo for jscpd in Mega-Linter documentation, please notify me :)

https://github.com/nvuillam/mega-linter/blob/master/docs/descriptors/copypaste_jscpd.md#readme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/406)
<!-- Reviewable:end -->
