### PR TITLE
fix: 🐛 allow empty string in calculateLocation()

### DIFF
--- a/packages/tokenizer/src/tokenize.ts
+++ b/packages/tokenizer/src/tokenize.ts
@@ -75,7 +75,7 @@ export function tokenize(code: string, language: string): IToken[] {
 
   function calculateLocation(token: IToken, position: number): IToken {
     const result: IToken = token;
-    const lines: string[] = result.value && result.value.split ? result.value.split('\n') : [];
+    const lines: string[] = typeof result.value === 'string' && result.value.split ? result.value.split('\n') : [];
     const newLines = lines.length - 1;
     const start = {
       line,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/kucherenko/jscpd/issues/421

* **What is the new behavior (if this is a feature change)?**

Even input empty string in calculateLocation(), this function doesn't throw the following error. 

```
TypeError: Cannot read property 'length' of undefined
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/423)
<!-- Reviewable:end -->
