### PR TITLE
fix: pin colors@1.4.0 to fix security vuln

### DIFF
--- a/packages/jscpd/package.json
+++ b/packages/jscpd/package.json
@@ -38,7 +38,7 @@
     "@jscpd/finder": "^3.4.1",
     "@jscpd/html-reporter": "^3.4.1",
     "@jscpd/tokenizer": "^3.4.1",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^5.0.0",
     "fs-extra": "^9.1.0",
     "gitignore-to-glob": "^0.3.0"


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR pins the color package to `1.4.0` as advised on the [snyk page](https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/503)
<!-- Reviewable:end -->
