### PR TITLE
Fast fix for the colors.js mess

### DIFF
--- a/packages/finder/package.json
+++ b/packages/finder/package.json
@@ -36,7 +36,7 @@
     "blamer": "^1.0.1",
     "bytes": "^3.1.0",
     "cli-table3": "^0.6.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "fast-glob": "^3.2.2",
     "fs-extra": "^9.0.0",
     "markdown-table": "^2.0.0",

--- a/packages/html-reporter/package.json
+++ b/packages/html-reporter/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/kucherenko/jscpd/issues"
   },
   "dependencies": {
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "fs-extra": "^9.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,7 +2490,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@*, colors@^1.1.2, colors@^1.4.0:
+colors@*, colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Using `"colors": "^1.4.0"` triggers the following mess: https://thenewstack.io/the-kik-kerfuffle/


* **What is the new behavior (if this is a feature change)?**
Reverting to `"colors": "1.4.0"` will at least allow the module to work until `colors.js` is fixed or replaced.


* **Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/504)
<!-- Reviewable:end -->
