### PR TITLE
fix: Drop unused constructor

### DIFF
--- a/packages/core/src/statistic.ts
+++ b/packages/core/src/statistic.ts
@@ -22,9 +22,6 @@ export class Statistic implements ISubscriber {
 		total: Statistic.getDefaultStatistic(),
 	};
 
-	constructor(private readonly options) {
-	}
-
 	public subscribe(): Partial<Record<DetectorEvents, IHandler>> {
     return {
       CLONE_FOUND: this.cloneFound.bind(this),

--- a/packages/jscpd/src/index.ts
+++ b/packages/jscpd/src/index.ts
@@ -22,7 +22,7 @@ export const detectClones = (opts: IOptions, store: IStore<IMapFrame> | undefine
   }
   options.hashFunction = options.hashFunction || hashFunction;
   const currentStore: IStore<IMapFrame> = store || getStore(options.store);
-  const statistic = new Statistic(options);
+  const statistic = new Statistic();
   const tokenizer = new Tokenizer();
   const detector = new InFilesDetector(tokenizer, currentStore, statistic, options);
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a chore fix, just removed the unused constructor and options that have not been used in the `Statistic` class.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/507)
<!-- Reviewable:end -->
