### PR TITLE
Exclude symlinks when noSymlinks is true

### DIFF
--- a/packages/finder/src/files.ts
+++ b/packages/finder/src/files.ts
@@ -17,6 +17,16 @@ function isFile(path: string): boolean {
   }
 }
 
+function isSymlink(path: string): boolean {
+  try {
+    const stat: Stats = lstatSync(path);
+    return stat.isSymbolicLink();
+  } catch (e) {
+    // lstatSync throws an error if path doesn't exist
+    return false;
+  }
+}
+
 function skipNotSupportedFormats(options: IOptions): (entry: Entry) => boolean {
   return (entry: Entry): boolean => {
     const {path} = entry;
@@ -64,7 +74,13 @@ function addContentToEntry(entry: Entry): EntryWithContent {
 
 export function getFilesToDetect(options: IOptions): EntryWithContent[] {
   const pattern = options.pattern || '**/*';
-  const patterns = options.path.map((path: string) => {
+  let patterns = options.path;
+
+  if (options.noSymlinks) {
+    patterns = patterns.filter((path: string) => !isSymlink(path));
+  }
+
+  patterns = patterns.map((path: string) => {
     if (isFile(path)) {
       return path;
     }


### PR DESCRIPTION
Fix https://github.com/kucherenko/jscpd/issues/481

I allow the `noSymlinks` option to exclude the symlink itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/520)
<!-- Reviewable:end -->
