### PR TITLE
fix: @jscpd/finder

### DIFF
--- a/packages/finder/__tests__/in-files-detector.test.ts
+++ b/packages/finder/__tests__/in-files-detector.test.ts
@@ -5,7 +5,7 @@ import {MemoryStore, Statistic} from "@jscpd/core";
 
 describe('jscpd finder: in-files-detector', () => {
   it('should not detect for empty files list', async () => {
-    const detector = new InFilesDetector(new Tokenizer(), new MemoryStore(), new Statistic({}), {});
+    const detector = new InFilesDetector(new Tokenizer(), new MemoryStore(), new Statistic(), {});
     const detected = await detector.detect([]);
     expect(detected).to.deep.equal([]);
   });

--- a/packages/finder/package.json
+++ b/packages/finder/package.json
@@ -5,8 +5,8 @@
   "author": "Andrey Kucherenko <kucherenko.andrey@gmail.com>",
   "homepage": "https://github.com/kucherenko/jscpd#readme",
   "license": "MIT",
-  "main": "dist/index",
-  "types": "dist/index",
+  "main": "src/index",
+  "types": "src/index",
   "directories": {
     "src": "src",
     "test": "__tests__"


### PR DESCRIPTION
https://github.com/kucherenko/jscpd/runs/5976675334?check_suite_focus=true

```
yarn run v1.22.18
$ run-s build test cov:html cov:check
$ lerna run build
lerna notice cli v3.20.2
lerna info ci enabled
lerna info Executing command in 8 packages: "yarn run build"
lerna ERR! yarn run build exited 2 in '@jscpd/badge-reporter'
lerna ERR! yarn run build stdout:
$ yarn clean && yarn compile
$ rm -rf ./dist
$ tsc -p tsconfig.build.json
Error: src/index.ts(2,25): error TS2307: Cannot find module '@jscpd/finder'.
```

I do the following in `@jscpd/finder` to get rid of the above error:
* Change `main` and `types` in `package.json` to `src/index` (Revert part of  https://github.com/kucherenko/jscpd/commit/5d7bace6d57dc1afd8a8b1b65943c5eaae62671c )
* Set no parameters in `Statistic` (The missing correction of https://github.com/kucherenko/jscpd/pull/507 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/521)
<!-- Reviewable:end -->
