### PR TITLE
Update Node.js versions of jscpd CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Node.js versions of `jscpd CI` contain EOL versions and do not contain new versions.
Therefore, I change Node.js versions of `jscpd CI` to the following:
* 10.x: Delete due to EOL
* 13.x: Delete due to EOL
* 16.x: Add active LTS
* 17.x: Add current version

FYI: https://nodejs.org/en/about/releases/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/522)
<!-- Reviewable:end -->
