### PR TITLE
Run jscpd CI for pull_request and drop Node.js 16.x and 17.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: jscpd CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
`jscpd CI` can check if jscpd's packages can install and jscpd can build and test.
If we can confirm these in PR, it will be easier to guarantee the quality of the code.
Therefore, I run it for `pull_request`.

In https://github.com/kucherenko/jscpd/pull/522, I added Node.js 16.x and 17.x.
However, These versions can't build.
Therefore, I delete these versions once.