### PR TITLE
fix: escape html tags in order to solve html reporter rendering problems

### DIFF
--- a/packages/html-reporter/src/index.ts
+++ b/packages/html-reporter/src/index.ts
@@ -4,6 +4,23 @@ import {IReporter, JsonReporter} from "@jscpd/finder";
 import {copySync, writeFileSync, readFileSync} from "fs-extra";
 import {green, red} from "colors/safe";
 
+function escapeHtml(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  return value.replace(/[&<>`"'/]/g, function(result) {
+    return {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '`': '&#x60;',
+      '"': '&quot;',
+      "'": '&#x27;',
+      '/': '&#x2f;',
+    }[result];
+  })
+}
+
 export default class HtmlReporter implements IReporter {
   constructor(private options: IOptions) {
   }
@@ -11,6 +28,9 @@ export default class HtmlReporter implements IReporter {
   public report(clones: IClone[], statistic: IStatistic): void {
     const jsonReporter = new JsonReporter(this.options);
     const json = jsonReporter.generateJson(clones, statistic);
+    json.duplicates.forEach(item => {
+      item.fragment = escapeHtml(item.fragment);
+    });
     if (this.options.output) {
       const src = join(__dirname, '../html/');
       const destination = join(this.options.output, 'html/');


### PR DESCRIPTION
[issue](https://github.com/kucherenko/jscpd/issues/476)

Escaped some special characters like '&', '<', '>', '`', '"', ''', '/'.  then html reporter rendering will not be infected by html tags

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/533)
<!-- Reviewable:end -->
