### PR TITLE
remove vscode extension link

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ In case of deep customisation of detection process you can build your own tool w
  - [Github Super Linter](https://github.com/github/super-linter) is combination of multiple linters to install as a GitHub Action
  - [Code-Inspector](https://www.code-inspector.com/) is a code analysis and technical debt management service.
  - [Mega-Linter](https://nvuillam.github.io/mega-linter/) is a 100% open-source linters aggregator for CI (Github Action & other CI tools) or to run locally
- - [vscode-jscpd](https://marketplace.visualstudio.com/items?itemName=paulhoughton.vscode-jscpd) VSCode Copy/Paste detector plugin.
  - [Codacy](http://docs.codacy.com/getting-started/supported-languages-and-tools/) automatically analyzes your source code and identifies issues as you go, helping you develop software more efficiently with fewer issues down the line.
  - [Natural](https://github.com/NaturalNode/natural) is a general natural language facility for nodejs. It offers a broad range of functionalities for natural language processing.
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This removes a link to a vscode extension under "Who uses jscpd."


* **What is the current behavior?** (You can also link to an open issue here)
The link 404s


* **What is the new behavior (if this is a feature change)?**
The link is removed.


* **Other information**:
The extension seems to have been abandoned. The git repo for it hasn't had a commit since 2018.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/537)
<!-- Reviewable:end -->
