### PR TITLE
Add mention to minTokens to the readme file

### DIFF
--- a/packages/jscpd/README.md
+++ b/packages/jscpd/README.md
@@ -93,6 +93,9 @@ Minimal block size of code in tokens. The block of code less than `min-tokens` w
  - Cli options: `--min-tokens`, `-k`
  - Type: **number**
  - Default: **50**
+ 
+ *This option is called ``minTokens`` in the config file.*
+ 
 ### Min Lines
 
 Minimal block size of code in lines. The block of code less than `min-lines` will be skipped.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** Docs.

* **What is the current behavior?**
The ``--min-tokens`` parameter through CLI seems inaccessible through config, but that's because it's called ``minTokens`` instead of ``min-tokens``.

The other properties I used are called verbatim as their CLI counterparts (format, reporters, output, absolute), as they are 1-word.

* **What is the new behavior (if this is a feature change)?**
I've added a mention to it in the docs, since that's the easiest I could o, but if this is improved somehow, the docs may not need to reflect this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/540)
<!-- Reviewable:end -->
