### PR TITLE
Ensure that ignore config is respected

### DIFF
--- a/packages/finder/src/files.ts
+++ b/packages/finder/src/files.ts
@@ -82,10 +82,12 @@ export function getFilesToDetect(options: IOptions): EntryWithContent[] {
 
   patterns = patterns.map((path: string) => {
     const currentPath = realpathSync(path);
+
     if (isFile(currentPath)) {
-      return currentPath;
+      return path;
     }
-    return currentPath.substr(path.length - 1) === '/' ? `${currentPath}${pattern}` : `${currentPath}/${pattern}`;
+
+    return path.endsWith('/') ? `${path}${pattern}` : `${path}/${pattern}`;
   });
 
   return sync(


### PR DESCRIPTION
Fixes issue introduced in [v3.5.0](https://github.com/kucherenko/jscpd/tree/v3.5.0) by https://github.com/kucherenko/jscpd/commit/f514336d88aedce92c5e710d2904da9439ff12fb, where the `ignore` patterns are not ignored.

See https://github.com/kucherenko/jscpd/issues/496#issuecomment-1264700992 for more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/547)
<!-- Reviewable:end -->
