### PR TITLE
feat: add detect clones and statistic api

### DIFF
--- a/examples/api/example-detectClonesAndStatistic.ts
+++ b/examples/api/example-detectClonesAndStatistic.ts
@@ -1,0 +1,11 @@
+import {detectClonesAndStatistic} from "jscpd";
+
+(async () => {
+  const data = await detectClonesAndStatistic({
+    path: [
+      __dirname + '/../fixtures'
+    ],
+    silent: true
+  });
+  console.log(data);
+})()

--- a/packages/jscpd/__tests__/options.test.ts
+++ b/packages/jscpd/__tests__/options.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {isAbsolute} from 'path';
 import {IClone} from '@jscpd/core';
-import {jscpd, detectClones} from '../src';
+import {jscpd, detectClones, detectClonesAndStatistic} from '../src';
 import {bold, yellow} from 'colors/safe';
 import sinon = require('sinon');
 
@@ -139,6 +139,17 @@ describe('jscpd options', () => {
     it('should not print information about clones', async () => {
       // console.log = _log;
       await detectClones({
+        silent: true,
+        pattern: fileWithClones,
+      });
+      const log = (console.log as any);
+      _log(log.firstCall);
+      expect(log.callCount).to.equal(0);
+    });
+
+    it('should not print information about clones and statistic', async () => {
+      // console.log = _log;
+      await detectClonesAndStatistic({
         silent: true,
         pattern: fileWithClones,
       });

--- a/packages/jscpd/src/index.ts
+++ b/packages/jscpd/src/index.ts
@@ -1,4 +1,4 @@
-import { getDefaultOptions, IClone, IOptions, IStore, Statistic } from '@jscpd/core';
+import { getDefaultOptions, IClone, IOptions, IStore, Statistic, IStatistic } from '@jscpd/core';
 import { grey, italic } from 'colors/safe';
 import { EntryWithContent, getFilesToDetect, InFilesDetector } from '@jscpd/finder';
 import { initCli, initOptionsFromCli } from './init';
@@ -12,7 +12,7 @@ import { registerHooks } from './init/hooks';
 
 const TIMER_LABEL = 'Detection time:';
 
-export const detectClones = (opts: IOptions, store: IStore<IMapFrame> | undefined = undefined): Promise<IClone[]> => {
+export const detectClones = (opts: IOptions, store: IStore<IMapFrame> | undefined = undefined, statisticInstance: Statistic | undefined = undefined): Promise<IClone[]> => {
   const options: Partial<IOptions> = {...getDefaultOptions(), ...opts};
   options.format = options.format || getSupportedFormats();
 
@@ -22,7 +22,7 @@ export const detectClones = (opts: IOptions, store: IStore<IMapFrame> | undefine
   }
   options.hashFunction = options.hashFunction || hashFunction;
   const currentStore: IStore<IMapFrame> = store || getStore(options.store);
-  const statistic = new Statistic();
+  const statistic = statisticInstance || new Statistic();
   const tokenizer = new Tokenizer();
   const detector = new InFilesDetector(tokenizer, currentStore, statistic, options);
 
@@ -38,6 +38,13 @@ export const detectClones = (opts: IOptions, store: IStore<IMapFrame> | undefine
       console.timeEnd(italic(grey(TIMER_LABEL)));
     }
     return clones;
+  });
+}
+
+export const detectClonesAndStatistic = (opts: IOptions, store: IStore<IMapFrame> | undefined = undefined): Promise<{clones: IClone[], statisticData: IStatistic}> => {
+  const statistic =  new Statistic();
+  return detectClones(opts, store, statistic).then((clones: IClone[]) => {
+    return {clones, statisticData: statistic.getStatistic()};
   });
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature: add detect clone and statistic api

* **What is the current behavior?** (You can also link to an open issue here)

Currently, get statistic data is not convenient. If you want to get statistic, you must write some code with @jscpd/core, @jscpd/finder and @jscpd/tokenizer.

issue: https://github.com/kucherenko/jscpd/issues/536

* **What is the new behavior (if this is a feature change)?**
```js
import {detectClonesAndStatistic} from "jscpd";

(async () => {
  const data = await detectClonesAndStatistic({
    path: [
      __dirname + '/../fixtures'
    ],
    silent: true
  });
  console.log(data.clones);
 console.log(data.statisticData);
})()
```

* **Other information**:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/549)
<!-- Reviewable:end -->
