### PR TITLE
fix: wrong code report escaping

### DIFF
--- a/fixtures/htmlmixed/file1.html
+++ b/fixtures/htmlmixed/file1.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <div>
+    <script>alert('test')</script>
     <h1>Test File</h1>
     <p>Ololo</p>
 </div>

--- a/fixtures/htmlmixed/file2.html
+++ b/fixtures/htmlmixed/file2.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <div>
+    <script>alert('test')</script>
     <h1>Test File</h1>
     <p>Ololo</p>
 </div>

--- a/packages/html-reporter/mockups/public/jscpd-report.json
+++ b/packages/html-reporter/mockups/public/jscpd-report.json
@@ -1,182 +1,79 @@
 {
   "statistics": {
-    "detectionDate": "2020-08-19T17:00:50.186Z",
+    "detectionDate": "2022-12-07T10:17:56.646Z",
     "formats": {
       "c": {
         "sources": {
           "fixtures/z80/file2.z80": {
             "lines": 11,
+            "tokens": 79,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/z80/file1.z80": {
             "lines": 11,
+            "tokens": 79,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/folder1/file2.c": {
             "lines": 28,
+            "tokens": 243,
             "sources": 1,
             "clones": 4,
             "duplicatedLines": 66,
+            "duplicatedTokens": 593,
             "percentage": 235.71,
+            "percentageTokens": 244.03,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file2.c": {
             "lines": 28,
+            "tokens": 243,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 28,
+            "duplicatedTokens": 243,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file1.c": {
             "lines": 18,
+            "tokens": 136,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 18,
+            "duplicatedTokens": 136,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 96,
+          "tokens": 780,
           "sources": 5,
           "clones": 3,
           "duplicatedLines": 56,
+          "duplicatedTokens": 486,
           "percentage": 58.33,
-          "newDuplicatedLines": 0,
-          "newClones": 0
-        }
-      },
-      "property": {
-        "sources": {
-          "fixtures/z80/file2.z80": {
-            "lines": 1,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/z80/file1.z80": {
-            "lines": 1,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/objective-c/file_2.m": {
-            "lines": 2,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/objective-c/file_2.h": {
-            "lines": 6,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/objective-c/file_1.m": {
-            "lines": 2,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/objective-c/file_1.h": {
-            "lines": 6,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/clike/file2.hpp": {
-            "lines": 87,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/clike/file2.cs": {
-            "lines": 146,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/clike/file2.cpp": {
-            "lines": 87,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/clike/file1.hpp": {
-            "lines": 87,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/clike/file1.cs": {
-            "lines": 156,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/clike/file1.cpp": {
-            "lines": 87,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          }
-        },
-        "total": {
-          "lines": 668,
-          "sources": 12,
-          "clones": 0,
-          "duplicatedLines": 0,
-          "percentage": 0,
+          "percentageTokens": 62.31,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -185,29 +82,38 @@
         "sources": {
           "fixtures/yaml/file2.yml": {
             "lines": 17,
+            "tokens": 129,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 17,
+            "duplicatedTokens": 129,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/yaml/file1.yml": {
             "lines": 22,
+            "tokens": 163,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 17,
+            "duplicatedTokens": 129,
             "percentage": 77.27,
+            "percentageTokens": 79.14,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 39,
+          "tokens": 292,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 17,
+          "duplicatedTokens": 129,
           "percentage": 43.59,
+          "percentageTokens": 44.18,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -216,137 +122,182 @@
         "sources": {
           "fixtures/xml/file2.xsl": {
             "lines": 42,
+            "tokens": 372,
             "sources": 1,
             "clones": 3,
             "duplicatedLines": 68,
+            "duplicatedTokens": 595,
             "percentage": 161.9,
+            "percentageTokens": 159.95,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/xml/file2.svg": {
             "lines": 92,
+            "tokens": 583,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 87,
+            "duplicatedTokens": 545,
             "percentage": 94.57,
+            "percentageTokens": 93.48,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/xml/file1.xsl": {
             "lines": 46,
+            "tokens": 440,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 46,
+            "duplicatedTokens": 437,
             "percentage": 100,
+            "percentageTokens": 99.32,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/xml/file1.svg": {
             "lines": 87,
+            "tokens": 547,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 87,
+            "duplicatedTokens": 545,
             "percentage": 100,
+            "percentageTokens": 99.63,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/vue/file2.vue": {
             "lines": 240,
+            "tokens": 1552,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 241,
+            "duplicatedTokens": 1555,
             "percentage": 100.42,
+            "percentageTokens": 100.19,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/vue/file1.vue": {
             "lines": 261,
+            "tokens": 1659,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 241,
+            "duplicatedTokens": 1555,
             "percentage": 92.34,
+            "percentageTokens": 93.73,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/mixed-formats/file.html": {
             "lines": 73,
+            "tokens": 403,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/ignore/file2.htm": {
             "lines": 23,
+            "tokens": 172,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 46,
+            "duplicatedTokens": 344,
             "percentage": 200,
+            "percentageTokens": 200,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/ignore/file1.htm": {
             "lines": 29,
+            "tokens": 8,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/htmlmixed/file2.html": {
-            "lines": 16,
+            "lines": 17,
+            "tokens": 123,
             "sources": 1,
             "clones": 1,
-            "duplicatedLines": 14,
-            "percentage": 87.5,
+            "duplicatedLines": 15,
+            "duplicatedTokens": 115,
+            "percentage": 88.24,
+            "percentageTokens": 93.5,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/htmlmixed/file2.htm": {
             "lines": 23,
+            "tokens": 172,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 23,
+            "duplicatedTokens": 172,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/htmlmixed/file1.html": {
-            "lines": 15,
+            "lines": 16,
+            "tokens": 121,
             "sources": 1,
             "clones": 1,
-            "duplicatedLines": 14,
-            "percentage": 93.33,
+            "duplicatedLines": 15,
+            "duplicatedTokens": 115,
+            "percentage": 93.75,
+            "percentageTokens": 95.04,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/htmlmixed/file1.htm": {
             "lines": 23,
+            "tokens": 172,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 23,
+            "duplicatedTokens": 172,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/markup.html": {
             "lines": 25,
+            "tokens": 141,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
-          "lines": 995,
+          "lines": 997,
+          "tokens": 6465,
           "sources": 14,
           "clones": 8,
-          "duplicatedLines": 445,
-          "percentage": 44.72,
+          "duplicatedLines": 446,
+          "duplicatedTokens": 3075,
+          "percentage": 44.73,
+          "percentageTokens": 47.56,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -355,29 +306,38 @@
         "sources": {
           "fixtures/twig/file_2.twig": {
             "lines": 31,
+            "tokens": 275,
             "sources": 1,
             "clones": 3,
             "duplicatedLines": 58,
+            "duplicatedTokens": 509,
             "percentage": 187.1,
+            "percentageTokens": 185.09,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/twig/file_1.twig": {
             "lines": 28,
+            "tokens": 249,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 28,
+            "duplicatedTokens": 249,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 59,
+          "tokens": 524,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 43,
+          "duplicatedTokens": 379,
           "percentage": 72.88,
+          "percentageTokens": 72.33,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -386,65 +346,86 @@
         "sources": {
           "fixtures/text/file2.txt": {
             "lines": 60,
+            "tokens": 553,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 71,
+            "duplicatedTokens": 683,
             "percentage": 118.33,
+            "percentageTokens": 123.51,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/text/file1.txt": {
             "lines": 11,
+            "tokens": 130,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 11,
+            "duplicatedTokens": 130,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/markdown/file2.md": {
             "lines": 212,
+            "tokens": 1744,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 174,
+            "duplicatedTokens": 1611,
             "percentage": 82.08,
+            "percentageTokens": 92.37,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/markdown/file1.md": {
             "lines": 189,
+            "tokens": 1709,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 174,
+            "duplicatedTokens": 1611,
             "percentage": 92.06,
+            "percentageTokens": 94.27,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/ignore-case/file2.txt": {
             "lines": 60,
+            "tokens": 553,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 60,
+            "duplicatedTokens": 553,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/ignore-case/file1.txt": {
             "lines": 11,
+            "tokens": 130,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 543,
+          "tokens": 4819,
           "sources": 6,
           "clones": 3,
           "duplicatedLines": 245,
+          "duplicatedTokens": 2294,
           "percentage": 45.12,
+          "percentageTokens": 47.6,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -453,29 +434,38 @@
         "sources": {
           "fixtures/swift/file2.swift": {
             "lines": 26,
+            "tokens": 174,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 21,
+            "duplicatedTokens": 136,
             "percentage": 80.77,
+            "percentageTokens": 78.16,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/swift/file1.swift": {
             "lines": 29,
+            "tokens": 151,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 21,
+            "duplicatedTokens": 136,
             "percentage": 72.41,
+            "percentageTokens": 90.07,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 55,
+          "tokens": 325,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 21,
+          "duplicatedTokens": 136,
           "percentage": 38.18,
+          "percentageTokens": 41.85,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -484,29 +474,38 @@
         "sources": {
           "fixtures/sass/file2.sass": {
             "lines": 47,
+            "tokens": 157,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 24,
+            "duplicatedTokens": 87,
             "percentage": 51.06,
+            "percentageTokens": 55.41,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/sass/file1.sass": {
             "lines": 44,
+            "tokens": 153,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 24,
+            "duplicatedTokens": 87,
             "percentage": 54.55,
+            "percentageTokens": 56.86,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 91,
+          "tokens": 310,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 24,
+          "duplicatedTokens": 87,
           "percentage": 26.37,
+          "percentageTokens": 28.06,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -515,29 +514,38 @@
         "sources": {
           "fixtures/rust/file2.rs": {
             "lines": 300,
+            "tokens": 2908,
             "sources": 1,
             "clones": 8,
             "duplicatedLines": 371,
+            "duplicatedTokens": 3651,
             "percentage": 123.67,
+            "percentageTokens": 125.55,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/rust/file1.rs": {
             "lines": 415,
+            "tokens": 4208,
             "sources": 1,
             "clones": 4,
             "duplicatedLines": 321,
+            "duplicatedTokens": 3121,
             "percentage": 77.35,
+            "percentageTokens": 74.17,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 715,
+          "tokens": 7116,
           "sources": 2,
           "clones": 6,
           "duplicatedLines": 346,
+          "duplicatedTokens": 3386,
           "percentage": 48.39,
+          "percentageTokens": 47.58,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -546,29 +554,38 @@
         "sources": {
           "fixtures/ruby/file2.rb": {
             "lines": 39,
+            "tokens": 180,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 39,
+            "duplicatedTokens": 180,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/ruby/file1.rb": {
             "lines": 39,
+            "tokens": 180,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 39,
+            "duplicatedTokens": 180,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 78,
+          "tokens": 360,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 39,
+          "duplicatedTokens": 180,
           "percentage": 50,
+          "percentageTokens": 50,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -577,29 +594,38 @@
         "sources": {
           "fixtures/r/file2.r": {
             "lines": 63,
+            "tokens": 584,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 63,
+            "duplicatedTokens": 584,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/r/file1.r": {
             "lines": 63,
+            "tokens": 584,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 63,
+            "duplicatedTokens": 584,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 126,
+          "tokens": 1168,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 63,
+          "duplicatedTokens": 584,
           "percentage": 50,
+          "percentageTokens": 50,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -608,29 +634,38 @@
         "sources": {
           "fixtures/python/file2.py": {
             "lines": 30,
+            "tokens": 141,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 26,
+            "duplicatedTokens": 112,
             "percentage": 86.67,
+            "percentageTokens": 79.43,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/python/file1.py": {
             "lines": 27,
+            "tokens": 128,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 26,
+            "duplicatedTokens": 112,
             "percentage": 96.3,
+            "percentageTokens": 87.5,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 57,
+          "tokens": 269,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 26,
+          "duplicatedTokens": 112,
           "percentage": 45.61,
+          "percentageTokens": 41.64,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -639,29 +674,38 @@
         "sources": {
           "fixtures/puppet/file2.pp": {
             "lines": 57,
+            "tokens": 372,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 59,
+            "duplicatedTokens": 382,
             "percentage": 103.51,
+            "percentageTokens": 102.69,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/puppet/file1.pp": {
             "lines": 63,
+            "tokens": 419,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 59,
+            "duplicatedTokens": 382,
             "percentage": 93.65,
+            "percentageTokens": 91.17,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 120,
+          "tokens": 791,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 59,
+          "duplicatedTokens": 382,
           "percentage": 49.17,
+          "percentageTokens": 48.29,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -670,29 +714,38 @@
         "sources": {
           "fixtures/pug/file2.pug": {
             "lines": 282,
+            "tokens": 467,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 273,
+            "duplicatedTokens": 391,
             "percentage": 96.81,
+            "percentageTokens": 83.73,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/pug/file1.pug": {
             "lines": 290,
+            "tokens": 467,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 273,
+            "duplicatedTokens": 391,
             "percentage": 94.14,
+            "percentageTokens": 83.73,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 572,
+          "tokens": 934,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 273,
+          "duplicatedTokens": 391,
           "percentage": 47.73,
+          "percentageTokens": 41.86,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -701,29 +754,38 @@
         "sources": {
           "fixtures/php/file2.php": {
             "lines": 57,
+            "tokens": 228,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 50,
+            "duplicatedTokens": 203,
             "percentage": 87.72,
+            "percentageTokens": 89.04,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/php/file1.php": {
             "lines": 84,
+            "tokens": 423,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 50,
+            "duplicatedTokens": 203,
             "percentage": 59.52,
+            "percentageTokens": 47.99,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 141,
+          "tokens": 651,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 50,
+          "duplicatedTokens": 203,
           "percentage": 35.46,
+          "percentageTokens": 31.18,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -732,47 +794,62 @@
         "sources": {
           "fixtures/perl/file2.pm": {
             "lines": 187,
+            "tokens": 1014,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 143,
+            "duplicatedTokens": 663,
             "percentage": 76.47,
+            "percentageTokens": 65.38,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/perl/file2.pl": {
             "lines": 128,
+            "tokens": 529,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 122,
+            "duplicatedTokens": 485,
             "percentage": 95.31,
+            "percentageTokens": 91.68,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/perl/file1.pm": {
             "lines": 154,
+            "tokens": 727,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 143,
+            "duplicatedTokens": 663,
             "percentage": 92.86,
+            "percentageTokens": 91.2,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/perl/file1.pl": {
             "lines": 136,
+            "tokens": 598,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 122,
+            "duplicatedTokens": 485,
             "percentage": 89.71,
+            "percentageTokens": 81.1,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 605,
+          "tokens": 2868,
           "sources": 4,
           "clones": 2,
           "duplicatedLines": 265,
+          "duplicatedTokens": 1148,
           "percentage": 43.8,
+          "percentageTokens": 40.03,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -781,155 +858,278 @@
         "sources": {
           "fixtures/one-file/one-file.js": {
             "lines": 67,
+            "tokens": 567,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 58,
+            "duplicatedTokens": 500,
             "percentage": 86.57,
+            "percentageTokens": 88.18,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/mixed-formats/file.js": {
             "lines": 36,
+            "tokens": 281,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/jsx/file2.tsx": {
             "lines": 0,
+            "tokens": 8,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/jsx/file2.jsx": {
             "lines": 0,
+            "tokens": 8,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/jsx/file1.tsx": {
             "lines": 0,
+            "tokens": 8,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/jsx/file1.jsx": {
             "lines": 0,
+            "tokens": 8,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/javascript/file_4.js": {
             "lines": 82,
+            "tokens": 576,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 54,
+            "duplicatedTokens": 346,
             "percentage": 65.85,
+            "percentageTokens": 60.07,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/javascript/file_3.js": {
             "lines": 51,
+            "tokens": 566,
             "sources": 1,
-            "clones": 4,
-            "duplicatedLines": 160,
-            "percentage": 313.73,
+            "clones": 6,
+            "duplicatedLines": 270,
+            "duplicatedTokens": 2796,
+            "percentage": 529.41,
+            "percentageTokens": 493.99,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/javascript/file_2.mjs": {
+            "lines": 55,
+            "tokens": 558,
+            "sources": 1,
+            "clones": 2,
+            "duplicatedLines": 54,
+            "duplicatedTokens": 556,
+            "percentage": 98.18,
+            "percentageTokens": 99.64,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/javascript/file_2.js": {
             "lines": 55,
+            "tokens": 558,
             "sources": 1,
-            "clones": 2,
-            "duplicatedLines": 54,
-            "percentage": 98.18,
+            "clones": 1,
+            "duplicatedLines": 55,
+            "duplicatedTokens": 558,
+            "percentage": 100,
+            "percentageTokens": 100,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/javascript/file_2.cjs": {
+            "lines": 55,
+            "tokens": 558,
+            "sources": 1,
+            "clones": 1,
+            "duplicatedLines": 55,
+            "duplicatedTokens": 558,
+            "percentage": 100,
+            "percentageTokens": 100,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/javascript/file_1.mjs": {
+            "lines": 54,
+            "tokens": 568,
+            "sources": 1,
+            "clones": 4,
+            "duplicatedLines": 213,
+            "duplicatedTokens": 2270,
+            "percentage": 394.44,
+            "percentageTokens": 399.65,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/javascript/file_1.js": {
             "lines": 54,
+            "tokens": 568,
             "sources": 1,
-            "clones": 2,
-            "duplicatedLines": 105,
-            "percentage": 194.44,
+            "clones": 1,
+            "duplicatedLines": 54,
+            "duplicatedTokens": 568,
+            "percentage": 100,
+            "percentageTokens": 100,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/javascript/file_1.cjs": {
+            "lines": 54,
+            "tokens": 568,
+            "sources": 1,
+            "clones": 1,
+            "duplicatedLines": 54,
+            "duplicatedTokens": 568,
+            "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/javascript/file2.js": {
             "lines": 26,
+            "tokens": 157,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 23,
+            "duplicatedTokens": 154,
             "percentage": 88.46,
+            "percentageTokens": 98.09,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/javascript/file1.js": {
             "lines": 23,
+            "tokens": 154,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 23,
+            "duplicatedTokens": 154,
             "percentage": 100,
+            "percentageTokens": 100,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/ignore-pattern/file_2.js": {
+            "lines": 25,
+            "tokens": 229,
+            "sources": 1,
+            "clones": 0,
+            "duplicatedLines": 0,
+            "duplicatedTokens": 0,
+            "percentage": 0,
+            "percentageTokens": 0,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/ignore-pattern/file_1.js": {
+            "lines": 23,
+            "tokens": 237,
+            "sources": 1,
+            "clones": 0,
+            "duplicatedLines": 0,
+            "duplicatedTokens": 0,
+            "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/ignore/file_2.js": {
             "lines": 57,
+            "tokens": 6,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/ignore/file_1.js": {
             "lines": 56,
+            "tokens": 6,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/folder2/file_2.js": {
             "lines": 55,
+            "tokens": 558,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 55,
+            "duplicatedTokens": 558,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/folder1/file_1.js": {
             "lines": 54,
+            "tokens": 568,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 54,
+            "duplicatedTokens": 568,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
-          "lines": 616,
-          "sources": 16,
-          "clones": 8,
-          "duplicatedLines": 293,
-          "percentage": 47.56,
+          "lines": 882,
+          "tokens": 7315,
+          "sources": 22,
+          "clones": 12,
+          "duplicatedLines": 511,
+          "duplicatedTokens": 5077,
+          "percentage": 57.94,
+          "percentageTokens": 69.41,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -938,29 +1138,38 @@
         "sources": {
           "fixtures/objective-c/file_2.m": {
             "lines": 87,
+            "tokens": 571,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 50,
+            "duplicatedTokens": 338,
             "percentage": 57.47,
+            "percentageTokens": 59.19,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/objective-c/file_1.m": {
             "lines": 63,
+            "tokens": 345,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 50,
+            "duplicatedTokens": 338,
             "percentage": 79.37,
+            "percentageTokens": 97.97,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 150,
+          "tokens": 916,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 50,
+          "duplicatedTokens": 338,
           "percentage": 33.33,
+          "percentageTokens": 36.9,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -969,47 +1178,62 @@
         "sources": {
           "fixtures/objective-c/file_2.h": {
             "lines": 36,
+            "tokens": 105,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 34,
+            "duplicatedTokens": 103,
             "percentage": 94.44,
+            "percentageTokens": 98.1,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/objective-c/file_1.h": {
             "lines": 63,
+            "tokens": 334,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 34,
+            "duplicatedTokens": 103,
             "percentage": 53.97,
+            "percentageTokens": 30.84,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file2.h": {
             "lines": 28,
+            "tokens": 243,
             "sources": 1,
             "clones": 3,
             "duplicatedLines": 38,
+            "duplicatedTokens": 350,
             "percentage": 135.71,
+            "percentageTokens": 144.03,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file1.h": {
             "lines": 18,
+            "tokens": 136,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 18,
+            "duplicatedTokens": 136,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 145,
+          "tokens": 818,
           "sources": 4,
           "clones": 3,
           "duplicatedLines": 62,
+          "duplicatedTokens": 346,
           "percentage": 42.76,
+          "percentageTokens": 42.3,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1018,47 +1242,110 @@
         "sources": {
           "fixtures/modes/file2.ts": {
             "lines": 85,
+            "tokens": 505,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 91,
+            "duplicatedTokens": 511,
             "percentage": 107.06,
+            "percentageTokens": 101.19,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/modes/file1.ts": {
             "lines": 91,
+            "tokens": 511,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 91,
+            "duplicatedTokens": 511,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/javascript/file2.ts": {
             "lines": 375,
+            "tokens": 2510,
             "sources": 1,
-            "clones": 2,
-            "duplicatedLines": 262,
-            "percentage": 69.87,
+            "clones": 6,
+            "duplicatedLines": 1536,
+            "duplicatedTokens": 11395,
+            "percentage": 409.6,
+            "percentageTokens": 453.98,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/javascript/file2.mts": {
+            "lines": 375,
+            "tokens": 2510,
+            "sources": 1,
+            "clones": 1,
+            "duplicatedLines": 375,
+            "duplicatedTokens": 2510,
+            "percentage": 100,
+            "percentageTokens": 100,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/javascript/file2.cts": {
+            "lines": 375,
+            "tokens": 2510,
+            "sources": 1,
+            "clones": 1,
+            "duplicatedLines": 375,
+            "duplicatedTokens": 2510,
+            "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/javascript/file1.ts": {
             "lines": 262,
+            "tokens": 2125,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 262,
+            "duplicatedTokens": 2125,
             "percentage": 100,
+            "percentageTokens": 100,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/javascript/file1.mts": {
+            "lines": 262,
+            "tokens": 2125,
+            "sources": 1,
+            "clones": 1,
+            "duplicatedLines": 262,
+            "duplicatedTokens": 2125,
+            "percentage": 100,
+            "percentageTokens": 100,
+            "newDuplicatedLines": 0,
+            "newClones": 0
+          },
+          "fixtures/javascript/file1.cts": {
+            "lines": 262,
+            "tokens": 2125,
+            "sources": 1,
+            "clones": 1,
+            "duplicatedLines": 262,
+            "duplicatedTokens": 2125,
+            "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
-          "lines": 813,
-          "sources": 4,
-          "clones": 3,
-          "duplicatedLines": 353,
-          "percentage": 43.42,
+          "lines": 2087,
+          "tokens": 14921,
+          "sources": 8,
+          "clones": 7,
+          "duplicatedLines": 1627,
+          "duplicatedTokens": 11906,
+          "percentage": 77.96,
+          "percentageTokens": 79.79,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1067,78 +1354,62 @@
         "sources": {
           "fixtures/mixed-formats/file.css": {
             "lines": 22,
+            "tokens": 148,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/css/file2.css": {
             "lines": 19,
+            "tokens": 179,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 43,
+            "duplicatedTokens": 408,
             "percentage": 226.32,
+            "percentageTokens": 227.93,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/css/file10.css": {
             "lines": 24,
+            "tokens": 228,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 19,
+            "duplicatedTokens": 180,
             "percentage": 79.17,
+            "percentageTokens": 78.95,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/css/file1.css": {
             "lines": 24,
+            "tokens": 228,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 24,
+            "duplicatedTokens": 228,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 89,
+          "tokens": 783,
           "sources": 4,
           "clones": 2,
           "duplicatedLines": 43,
+          "duplicatedTokens": 408,
           "percentage": 48.31,
-          "newDuplicatedLines": 0,
-          "newClones": 0
-        }
-      },
-      "important": {
-        "sources": {
-          "fixtures/markdown/file2.md": {
-            "lines": 197,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          },
-          "fixtures/markdown/file1.md": {
-            "lines": 182,
-            "sources": 1,
-            "clones": 0,
-            "duplicatedLines": 0,
-            "percentage": 0,
-            "newDuplicatedLines": 0,
-            "newClones": 0
-          }
-        },
-        "total": {
-          "lines": 379,
-          "sources": 2,
-          "clones": 0,
-          "duplicatedLines": 0,
-          "percentage": 0,
+          "percentageTokens": 52.11,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1147,29 +1418,38 @@
         "sources": {
           "fixtures/jsx/file2.tsx": {
             "lines": 36,
+            "tokens": 254,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 36,
+            "duplicatedTokens": 243,
             "percentage": 100,
+            "percentageTokens": 95.67,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/jsx/file1.tsx": {
             "lines": 38,
+            "tokens": 264,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 36,
+            "duplicatedTokens": 243,
             "percentage": 94.74,
+            "percentageTokens": 92.05,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 74,
+          "tokens": 518,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 36,
+          "duplicatedTokens": 243,
           "percentage": 48.65,
+          "percentageTokens": 46.91,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1178,29 +1458,38 @@
         "sources": {
           "fixtures/jsx/file2.jsx": {
             "lines": 38,
+            "tokens": 264,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 22,
+            "duplicatedTokens": 172,
             "percentage": 57.89,
+            "percentageTokens": 65.15,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/jsx/file1.jsx": {
             "lines": 33,
+            "tokens": 229,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 22,
+            "duplicatedTokens": 172,
             "percentage": 66.67,
+            "percentageTokens": 75.11,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 71,
+          "tokens": 493,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 22,
+          "duplicatedTokens": 172,
           "percentage": 30.99,
+          "percentageTokens": 34.89,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1209,47 +1498,62 @@
         "sources": {
           "fixtures/haxe/file2.hxml": {
             "lines": 11,
+            "tokens": 74,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 11,
+            "duplicatedTokens": 74,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/haxe/file2.hx": {
             "lines": 61,
+            "tokens": 466,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 102,
+            "duplicatedTokens": 794,
             "percentage": 167.21,
+            "percentageTokens": 170.39,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/haxe/file1.hxml": {
             "lines": 13,
+            "tokens": 90,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 11,
+            "duplicatedTokens": 74,
             "percentage": 84.62,
+            "percentageTokens": 82.22,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/haxe/file1.hx": {
             "lines": 102,
+            "tokens": 792,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 102,
+            "duplicatedTokens": 794,
             "percentage": 100,
+            "percentageTokens": 100.25,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 187,
+          "tokens": 1422,
           "sources": 4,
           "clones": 3,
           "duplicatedLines": 113,
+          "duplicatedTokens": 868,
           "percentage": 60.43,
+          "percentageTokens": 61.04,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1258,29 +1562,38 @@
         "sources": {
           "fixtures/haskell/file2.hs": {
             "lines": 188,
+            "tokens": 1525,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 188,
+            "duplicatedTokens": 1525,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/haskell/file1.hs": {
             "lines": 203,
+            "tokens": 1675,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 188,
+            "duplicatedTokens": 1525,
             "percentage": 92.61,
+            "percentageTokens": 91.04,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 391,
+          "tokens": 3200,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 188,
+          "duplicatedTokens": 1525,
           "percentage": 48.08,
+          "percentageTokens": 47.66,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1289,29 +1602,38 @@
         "sources": {
           "fixtures/go/file2.go": {
             "lines": 32,
+            "tokens": 222,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 29,
+            "duplicatedTokens": 212,
             "percentage": 90.63,
+            "percentageTokens": 95.5,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/go/file1.go": {
             "lines": 31,
+            "tokens": 254,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 29,
+            "duplicatedTokens": 212,
             "percentage": 93.55,
+            "percentageTokens": 83.46,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 63,
+          "tokens": 476,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 29,
+          "duplicatedTokens": 212,
           "percentage": 46.03,
+          "percentageTokens": 44.54,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1320,29 +1642,38 @@
         "sources": {
           "fixtures/erlang/file2.erl": {
             "lines": 120,
+            "tokens": 919,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 120,
+            "duplicatedTokens": 919,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/erlang/file1.erl": {
             "lines": 120,
+            "tokens": 919,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 120,
+            "duplicatedTokens": 919,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 240,
+          "tokens": 1838,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 120,
+          "duplicatedTokens": 919,
           "percentage": 50,
+          "percentageTokens": 50,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1351,29 +1682,38 @@
         "sources": {
           "fixtures/dart/file2.dart": {
             "lines": 117,
+            "tokens": 854,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 120,
+            "duplicatedTokens": 862,
             "percentage": 102.56,
+            "percentageTokens": 100.94,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/dart/file1.dart": {
             "lines": 147,
+            "tokens": 1082,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 120,
+            "duplicatedTokens": 862,
             "percentage": 81.63,
+            "percentageTokens": 79.67,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 264,
+          "tokens": 1936,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 120,
+          "duplicatedTokens": 862,
           "percentage": 45.45,
+          "percentageTokens": 44.52,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1382,29 +1722,38 @@
         "sources": {
           "fixtures/d/file2.d": {
             "lines": 168,
+            "tokens": 1448,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 168,
+            "duplicatedTokens": 1448,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/d/file1.d": {
             "lines": 168,
+            "tokens": 1448,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 168,
+            "duplicatedTokens": 1448,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 336,
+          "tokens": 2896,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 168,
+          "duplicatedTokens": 1448,
           "percentage": 50,
+          "percentageTokens": 50,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1413,29 +1762,38 @@
         "sources": {
           "fixtures/css/file2.less": {
             "lines": 19,
+            "tokens": 180,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 19,
+            "duplicatedTokens": 181,
             "percentage": 100,
+            "percentageTokens": 100.56,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/css/file1.less": {
             "lines": 35,
+            "tokens": 338,
             "sources": 1,
             "clones": 3,
             "duplicatedLines": 43,
+            "duplicatedTokens": 395,
             "percentage": 122.86,
+            "percentageTokens": 116.86,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 54,
+          "tokens": 518,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 31,
+          "duplicatedTokens": 288,
           "percentage": 57.41,
+          "percentageTokens": 55.6,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1444,29 +1802,38 @@
         "sources": {
           "fixtures/coffeescript/file2.coffee": {
             "lines": 14,
+            "tokens": 115,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 12,
+            "duplicatedTokens": 108,
             "percentage": 85.71,
+            "percentageTokens": 93.91,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/coffeescript/file1.coffee": {
             "lines": 76,
+            "tokens": 559,
             "sources": 1,
             "clones": 3,
             "duplicatedLines": 74,
+            "duplicatedTokens": 550,
             "percentage": 97.37,
+            "percentageTokens": 98.39,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 90,
+          "tokens": 674,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 43,
+          "duplicatedTokens": 329,
           "percentage": 47.78,
+          "percentageTokens": 48.81,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1475,29 +1842,38 @@
         "sources": {
           "fixtures/clike/file2.scala": {
             "lines": 28,
+            "tokens": 97,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 28,
+            "duplicatedTokens": 97,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file1.scala": {
             "lines": 28,
+            "tokens": 97,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 28,
+            "duplicatedTokens": 97,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 56,
+          "tokens": 194,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 28,
+          "duplicatedTokens": 97,
           "percentage": 50,
+          "percentageTokens": 50,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1506,29 +1882,38 @@
         "sources": {
           "fixtures/clike/file2.java": {
             "lines": 232,
+            "tokens": 851,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 229,
+            "duplicatedTokens": 804,
             "percentage": 98.71,
+            "percentageTokens": 94.48,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file1.java": {
             "lines": 220,
+            "tokens": 795,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 229,
+            "duplicatedTokens": 804,
             "percentage": 104.09,
+            "percentageTokens": 101.13,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 452,
+          "tokens": 1646,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 229,
+          "duplicatedTokens": 804,
           "percentage": 50.66,
+          "percentageTokens": 48.85,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1537,29 +1922,38 @@
         "sources": {
           "fixtures/clike/file2.hpp": {
             "lines": 72,
+            "tokens": 1018,
             "sources": 1,
             "clones": 3,
             "duplicatedLines": 114,
+            "duplicatedTokens": 1622,
             "percentage": 158.33,
+            "percentageTokens": 159.33,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file1.hpp": {
             "lines": 72,
+            "tokens": 1018,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 72,
+            "duplicatedTokens": 1018,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 144,
+          "tokens": 2036,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 93,
+          "duplicatedTokens": 1320,
           "percentage": 64.58,
+          "percentageTokens": 64.83,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1568,29 +1962,38 @@
         "sources": {
           "fixtures/clike/file2.cs": {
             "lines": 174,
+            "tokens": 923,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 176,
+            "duplicatedTokens": 928,
             "percentage": 101.15,
+            "percentageTokens": 100.54,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file1.cs": {
             "lines": 184,
+            "tokens": 968,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 176,
+            "duplicatedTokens": 928,
             "percentage": 95.65,
+            "percentageTokens": 95.87,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 358,
+          "tokens": 1891,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 176,
+          "duplicatedTokens": 928,
           "percentage": 49.16,
+          "percentageTokens": 49.07,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1599,29 +2002,38 @@
         "sources": {
           "fixtures/clike/file2.cpp": {
             "lines": 72,
+            "tokens": 1018,
             "sources": 1,
             "clones": 3,
             "duplicatedLines": 114,
+            "duplicatedTokens": 1622,
             "percentage": 158.33,
+            "percentageTokens": 159.33,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/clike/file1.cpp": {
             "lines": 72,
+            "tokens": 1018,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 72,
+            "duplicatedTokens": 1018,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 144,
+          "tokens": 2036,
           "sources": 2,
           "clones": 2,
           "duplicatedLines": 93,
+          "duplicatedTokens": 1320,
           "percentage": 64.58,
+          "percentageTokens": 64.83,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1630,47 +2042,62 @@
         "sources": {
           "fixtures/brainfuck/file2.bf": {
             "lines": 40,
+            "tokens": 788,
             "sources": 1,
             "clones": 4,
             "duplicatedLines": 115,
+            "duplicatedTokens": 2311,
             "percentage": 287.5,
+            "percentageTokens": 293.27,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/brainfuck/file2.b": {
             "lines": 40,
+            "tokens": 788,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 40,
+            "duplicatedTokens": 788,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/brainfuck/file1.bf": {
             "lines": 35,
+            "tokens": 735,
             "sources": 1,
             "clones": 2,
             "duplicatedLines": 35,
+            "duplicatedTokens": 735,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/brainfuck/file1.b": {
             "lines": 40,
+            "tokens": 788,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 40,
+            "duplicatedTokens": 788,
             "percentage": 100,
+            "percentageTokens": 100,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 155,
+          "tokens": 3099,
           "sources": 4,
           "clones": 4,
           "duplicatedLines": 115,
+          "duplicatedTokens": 2311,
           "percentage": 74.19,
+          "percentageTokens": 74.57,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1679,29 +2106,38 @@
         "sources": {
           "fixtures/apl/file2.apl": {
             "lines": 21,
+            "tokens": 260,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 20,
+            "duplicatedTokens": 259,
             "percentage": 95.24,
+            "percentageTokens": 99.62,
             "newDuplicatedLines": 0,
             "newClones": 0
           },
           "fixtures/apl/file1.apl": {
             "lines": 24,
+            "tokens": 306,
             "sources": 1,
             "clones": 1,
             "duplicatedLines": 20,
+            "duplicatedTokens": 259,
             "percentage": 83.33,
+            "percentageTokens": 84.64,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 45,
+          "tokens": 566,
           "sources": 2,
           "clones": 1,
           "duplicatedLines": 20,
+          "duplicatedTokens": 259,
           "percentage": 44.44,
+          "percentageTokens": 45.76,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
@@ -1710,31 +2146,40 @@
         "sources": {
           "fixtures/.jscpd.json": {
             "lines": 5,
+            "tokens": 21,
             "sources": 1,
             "clones": 0,
             "duplicatedLines": 0,
+            "duplicatedTokens": 0,
             "percentage": 0,
+            "percentageTokens": 0,
             "newDuplicatedLines": 0,
             "newClones": 0
           }
         },
         "total": {
           "lines": 5,
+          "tokens": 21,
           "sources": 1,
           "clones": 0,
           "duplicatedLines": 0,
+          "duplicatedTokens": 0,
           "percentage": 0,
+          "percentageTokens": 0,
           "newDuplicatedLines": 0,
           "newClones": 0
         }
       }
     },
     "total": {
-      "lines": 10281,
-      "sources": 134,
-      "clones": 81,
-      "duplicatedLines": 4397,
-      "percentage": 42.77,
+      "lines": 10776,
+      "tokens": 77885,
+      "sources": 130,
+      "clones": 89,
+      "duplicatedLines": 5890,
+      "duplicatedTokens": 44952,
+      "percentage": 54.66,
+      "percentageTokens": 57.72,
       "newDuplicatedLines": 0,
       "newClones": 0
     }
@@ -1751,11 +2196,13 @@
         "end": 18,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 18,
-          "column": 23
+          "column": 6,
+          "position": 129
         }
       },
       "secondFile": {
@@ -1764,11 +2211,13 @@
         "end": 18,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 18,
-          "column": 23
+          "column": 6,
+          "position": 129
         }
       }
     },
@@ -1783,11 +2232,13 @@
         "end": 43,
         "startLoc": {
           "line": 32,
-          "column": 137
+          "column": 4,
+          "position": 290
         },
         "endLoc": {
           "line": 43,
-          "column": 3
+          "column": 3,
+          "position": 369
         }
       },
       "secondFile": {
@@ -1796,11 +2247,13 @@
         "end": 31,
         "startLoc": {
           "line": 20,
-          "column": 15
+          "column": 5,
+          "position": 152
         },
         "endLoc": {
           "line": 31,
-          "column": 6
+          "column": 2,
+          "position": 232
         }
       }
     },
@@ -1815,11 +2268,13 @@
         "end": 47,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 47,
-          "column": 3
+          "column": 3,
+          "position": 437
         }
       },
       "secondFile": {
@@ -1828,11 +2283,13 @@
         "end": 35,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 35,
-          "column": 6
+          "column": 2,
+          "position": 300
         }
       }
     },
@@ -1847,11 +2304,13 @@
         "end": 88,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 88,
-          "column": 3
+          "column": 3,
+          "position": 545
         }
       },
       "secondFile": {
@@ -1860,11 +2319,13 @@
         "end": 87,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 87,
-          "column": 6
+          "column": 2,
+          "position": 545
         }
       }
     },
@@ -1879,11 +2340,13 @@
         "end": 75,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 75,
-          "column": 12
+          "column": 8,
+          "position": 456
         }
       },
       "secondFile": {
@@ -1892,11 +2355,13 @@
         "end": 75,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 75,
-          "column": 21
+          "column": 17,
+          "position": 456
         }
       }
     },
@@ -1911,11 +2376,13 @@
         "end": 262,
         "startLoc": {
           "line": 95,
-          "column": 5
+          "column": 5,
+          "position": 560
         },
         "endLoc": {
           "line": 262,
-          "column": 10
+          "column": 2,
+          "position": 1659
         }
       },
       "secondFile": {
@@ -1924,11 +2391,13 @@
         "end": 241,
         "startLoc": {
           "line": 74,
-          "column": 5
+          "column": 5,
+          "position": 453
         },
         "endLoc": {
           "line": 241,
-          "column": 10
+          "column": 2,
+          "position": 1552
         }
       }
     },
@@ -1943,11 +2412,13 @@
         "end": 32,
         "startLoc": {
           "line": 17,
-          "column": 2
+          "column": 2,
+          "position": 141
         },
         "endLoc": {
           "line": 32,
-          "column": 3
+          "column": 3,
+          "position": 271
         }
       },
       "secondFile": {
@@ -1956,11 +2427,13 @@
         "end": 23,
         "startLoc": {
           "line": 14,
-          "column": 3
+          "column": 3,
+          "position": 115
         },
         "endLoc": {
           "line": 23,
-          "column": 2
+          "column": 2,
+          "position": 192
         }
       }
     },
@@ -1975,11 +2448,13 @@
         "end": 29,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 29,
-          "column": 15
+          "column": 3,
+          "position": 249
         }
       },
       "secondFile": {
@@ -1988,11 +2463,13 @@
         "end": 32,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 32,
-          "column": 15
+          "column": 3,
+          "position": 275
         }
       }
     },
@@ -2007,11 +2484,13 @@
         "end": 12,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 12,
-          "column": 31
+          "column": 8,
+          "position": 130
         }
       },
       "secondFile": {
@@ -2020,11 +2499,13 @@
         "end": 12,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 12,
-          "column": 31
+          "column": 8,
+          "position": 130
         }
       }
     },
@@ -2039,11 +2520,13 @@
         "end": 30,
         "startLoc": {
           "line": 9,
-          "column": 1
+          "column": 1,
+          "position": 15
         },
         "endLoc": {
           "line": 30,
-          "column": 2
+          "column": 2,
+          "position": 151
         }
       },
       "secondFile": {
@@ -2052,11 +2535,13 @@
         "end": 24,
         "startLoc": {
           "line": 2,
-          "column": 1
+          "column": 1,
+          "position": 1
         },
         "endLoc": {
           "line": 24,
-          "column": 9
+          "column": 5,
+          "position": 139
         }
       }
     },
@@ -2071,11 +2556,13 @@
         "end": 45,
         "startLoc": {
           "line": 21,
-          "column": 1
+          "column": 1,
+          "position": 66
         },
         "endLoc": {
           "line": 45,
-          "column": 33
+          "column": 11,
+          "position": 153
         }
       },
       "secondFile": {
@@ -2084,11 +2571,13 @@
         "end": 48,
         "startLoc": {
           "line": 24,
-          "column": 1
+          "column": 1,
+          "position": 70
         },
         "endLoc": {
           "line": 48,
-          "column": 33
+          "column": 11,
+          "position": 157
         }
       }
     },
@@ -2103,11 +2592,13 @@
         "end": 230,
         "startLoc": {
           "line": 220,
-          "column": 21
+          "column": 18,
+          "position": 2078
         },
         "endLoc": {
           "line": 230,
-          "column": 26
+          "column": 14,
+          "position": 2189
         }
       },
       "secondFile": {
@@ -2116,11 +2607,13 @@
         "end": 158,
         "startLoc": {
           "line": 148,
-          "column": 28
+          "column": 25,
+          "position": 1363
         },
         "endLoc": {
           "line": 158,
-          "column": 27
+          "column": 15,
+          "position": 1474
         }
       }
     },
@@ -2135,11 +2628,13 @@
         "end": 271,
         "startLoc": {
           "line": 256,
-          "column": 96
+          "column": 75,
+          "position": 2424
         },
         "endLoc": {
           "line": 271,
-          "column": 4
+          "column": 4,
+          "position": 2578
         }
       },
       "secondFile": {
@@ -2148,11 +2643,13 @@
         "end": 219,
         "startLoc": {
           "line": 204,
-          "column": 60
+          "column": 23,
+          "position": 1919
         },
         "endLoc": {
           "line": 219,
-          "column": 8
+          "column": 8,
+          "position": 2073
         }
       }
     },
@@ -2167,11 +2664,13 @@
         "end": 131,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 131,
-          "column": 45
+          "column": 42,
+          "position": 1158
         }
       },
       "secondFile": {
@@ -2180,11 +2679,13 @@
         "end": 132,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 132,
-          "column": 44
+          "column": 41,
+          "position": 1159
         }
       }
     },
@@ -2199,11 +2700,13 @@
         "end": 206,
         "startLoc": {
           "line": 199,
-          "column": 50
+          "column": 7,
+          "position": 1940
         },
         "endLoc": {
           "line": 206,
-          "column": 4
+          "column": 4,
+          "position": 2026
         }
       },
       "secondFile": {
@@ -2212,11 +2715,13 @@
         "end": 147,
         "startLoc": {
           "line": 140,
-          "column": 53
+          "column": 10,
+          "position": 1272
         },
         "endLoc": {
           "line": 147,
-          "column": 8
+          "column": 8,
+          "position": 1358
         }
       }
     },
@@ -2231,11 +2736,13 @@
         "end": 239,
         "startLoc": {
           "line": 232,
-          "column": 93
+          "column": 2,
+          "position": 2334
         },
         "endLoc": {
           "line": 239,
-          "column": 65
+          "column": 2,
+          "position": 2421
         }
       },
       "secondFile": {
@@ -2244,11 +2751,13 @@
         "end": 139,
         "startLoc": {
           "line": 132,
-          "column": 47
+          "column": 2,
+          "position": 1163
         },
         "endLoc": {
           "line": 139,
-          "column": 65
+          "column": 2,
+          "position": 1250
         }
       }
     },
@@ -2263,11 +2772,13 @@
         "end": 416,
         "startLoc": {
           "line": 239,
-          "column": 58
+          "column": 3,
+          "position": 2418
         },
         "endLoc": {
           "line": 416,
-          "column": 2
+          "column": 2,
+          "position": 4208
         }
       },
       "secondFile": {
@@ -2276,11 +2787,13 @@
         "end": 301,
         "startLoc": {
           "line": 123,
-          "column": 53
+          "column": 2,
+          "position": 1117
         },
         "endLoc": {
           "line": 301,
-          "column": 2
+          "column": 2,
+          "position": 2908
         }
       }
     },
@@ -2295,11 +2808,13 @@
         "end": 40,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 40,
-          "column": 4
+          "column": 4,
+          "position": 180
         }
       },
       "secondFile": {
@@ -2308,11 +2823,13 @@
         "end": 40,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 40,
-          "column": 4
+          "column": 4,
+          "position": 180
         }
       }
     },
@@ -2327,11 +2844,13 @@
         "end": 64,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 64,
-          "column": 9
+          "column": 2,
+          "position": 584
         }
       },
       "secondFile": {
@@ -2340,11 +2859,13 @@
         "end": 64,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 64,
-          "column": 9
+          "column": 2,
+          "position": 584
         }
       }
     },
@@ -2359,11 +2880,13 @@
         "end": 27,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 27,
-          "column": 3
+          "column": 3,
+          "position": 112
         }
       },
       "secondFile": {
@@ -2372,11 +2895,13 @@
         "end": 26,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 26,
-          "column": 8
+          "column": 4,
+          "position": 112
         }
       }
     },
@@ -2391,11 +2916,13 @@
         "end": 40,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 40,
-          "column": 39
+          "column": 37,
+          "position": 238
         }
       },
       "secondFile": {
@@ -2404,11 +2931,13 @@
         "end": 40,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 40,
-          "column": 18
+          "column": 16,
+          "position": 238
         }
       }
     },
@@ -2423,11 +2952,13 @@
         "end": 64,
         "startLoc": {
           "line": 44,
-          "column": 32
+          "column": 2,
+          "position": 275
         },
         "endLoc": {
           "line": 64,
-          "column": 2
+          "column": 2,
+          "position": 419
         }
       },
       "secondFile": {
@@ -2436,11 +2967,13 @@
         "end": 58,
         "startLoc": {
           "line": 38,
-          "column": 38
+          "column": 2,
+          "position": 228
         },
         "endLoc": {
           "line": 58,
-          "column": 2
+          "column": 2,
+          "position": 372
         }
       }
     },
@@ -2455,11 +2988,13 @@
         "end": 274,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 274,
-          "column": 14
+          "column": 14,
+          "position": 391
         }
       },
       "secondFile": {
@@ -2468,11 +3003,13 @@
         "end": 266,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 266,
-          "column": 14
+          "column": 14,
+          "position": 391
         }
       }
     },
@@ -2487,11 +3024,13 @@
         "end": 51,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 51,
-          "column": 28
+          "column": 8,
+          "position": 203
         }
       },
       "secondFile": {
@@ -2500,11 +3039,13 @@
         "end": 51,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 51,
-          "column": 29
+          "column": 9,
+          "position": 203
         }
       }
     },
@@ -2519,11 +3060,13 @@
         "end": 144,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 144,
-          "column": 67
+          "column": 65,
+          "position": 663
         }
       },
       "secondFile": {
@@ -2532,11 +3075,13 @@
         "end": 144,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 144,
-          "column": 33
+          "column": 31,
+          "position": 663
         }
       }
     },
@@ -2551,11 +3096,13 @@
         "end": 123,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 123,
-          "column": 5
+          "column": 3,
+          "position": 485
         }
       },
       "secondFile": {
@@ -2564,11 +3111,13 @@
         "end": 123,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 123,
-          "column": 6
+          "column": 4,
+          "position": 485
         }
       }
     },
@@ -2583,11 +3132,13 @@
         "end": 61,
         "startLoc": {
           "line": 32,
-          "column": 1
+          "column": 1,
+          "position": 252
         },
         "endLoc": {
           "line": 61,
-          "column": 7
+          "column": 5,
+          "position": 502
         }
       },
       "secondFile": {
@@ -2596,18 +3147,20 @@
         "end": 29,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 29,
-          "column": 2
+          "column": 2,
+          "position": 248
         }
       }
     },
     {
       "format": "objectivec",
       "lines": 51,
-      "fragment": "@interface IGListAdapterProxy () {\n    __weak id _collectionViewTarget;\n    __weak id _scrollViewTarget;\n    __weak IGListAdapter *_interceptor;\n}\n\n@end\n\n@implementation IGListAdapterProxy\n\n- (instancetype)initWithCollectionViewTarget:(nullable id<UICollectionViewDelegate>)collectionViewTarget\n                            scrollViewTarget:(nullable id<UIScrollViewDelegate>)scrollViewTarget\n                                 interceptor:(IGListAdapter *)interceptor {\n    IGParameterAssert(interceptor != nil);\n    // -[NSProxy init] is undefined\n    if (self) {\n        _collectionViewTarget = collectionViewTarget;\n        _scrollViewTarget = scrollViewTarget;\n        _interceptor = interceptor;\n    }\n    return self;\n}\n\n- (BOOL)respondsToSelector:(SEL)aSelector {\n    return isInterceptedSelector(aSelector)\n    || [_collectionViewTarget respondsToSelector:aSelector]\n    || [_scrollViewTarget respondsToSelector:aSelector];\n}\n\n- (id)forwardingTargetForSelector:(SEL)aSelector {\n    if (isInterceptedSelector(aSelector)) {\n        return _interceptor;\n    }\n\n    // since UICollectionViewDelegate is a superset of UIScrollViewDelegate, first check if the method exists in\n    // _scrollViewTarget, otherwise use the _collectionViewTarget\n    return [_scrollViewTarget respondsToSelector:aSelector] ? _scrollViewTarget : _collectionViewTarget;\n}\n\n// handling unimplemented methods and nil target/interceptor\n// https://github.com/Flipboard/FLAnimatedImage/blob/76a31aefc645cc09463a62d42c02954a30434d7d/FLAnimatedImage/FLAnimatedImage.m#L786-L807\n- (void)forwardInvocation:(NSInvocation *)invocation {\n    void *nullPointer = NULL;\n    [invocation setReturnValue:&nullPointer];\n}\n\n- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {\n    return [NSObject instanceMethodSignatureForSelector:@selector(init)];\n}\n\n@end",
+      "fragment": "ort \"IGListAdapterProxy.h\"\n\n#import <IGListKit/IGListAssert.h>\n\n@interface IGListAdapterProxy () {\n    __weak id _collectionViewTarget;\n    __weak id _scrollViewTarget;\n    __weak IGListAdapter *_interceptor;\n}\n\n@end\n\n@implementation IGListAdapterProxy\n\n- (instancetype)initWithCollectionViewTarget:(nullable id<UICollectionViewDelegate>)collectionViewTarget\n                            scrollViewTarget:(nullable id<UIScrollViewDelegate>)scrollViewTarget\n                                 interceptor:(IGListAdapter *)interceptor {\n    IGParameterAssert(interceptor != nil);\n    // -[NSProxy init] is undefined\n    if (self) {\n        _collectionViewTarget = collectionViewTarget;\n        _scrollViewTarget = scrollViewTarget;\n        _interceptor = interceptor;\n    }\n    return self;\n}\n\n- (BOOL)respondsToSelector:(SEL)aSelector {\n    return isInterceptedSelector(aSelector)\n    || [_collectionViewTarget respondsToSelector:aSelector]\n    || [_scrollViewTarget respondsToSelector:aSelector];\n}\n\n- (id)forwardingTargetForSelector:(SEL)aSelector {\n    if (isInterceptedSelector(aSelector)) {\n        return _interceptor;\n    }\n\n    // since UICollectionViewDelegate is a superset of UIScrollViewDelegate, first check if the method exists in\n    // _scrollViewTarget, otherwise use the _collectionViewTarget\n    return [_scrollViewTarget respondsToSelector:aSelector] ? _scrollViewTarget : _collectionViewTarget;\n}\n\n// handling unimplemented methods and nil target/interceptor\n// https://github.com/Flipboard/FLAnimatedImage/blob/76a31aefc645cc09463a62d42c02954a30434d7d/FLAnimatedImage/FLAnimatedImage.m#L786-L807\n- (void)forwardInvocation:(NSInvocation *)invocation {\n    void *nullPointer = NULL;\n    [invocation setReturnValue:&nullPointer];\n}\n\n- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {\n    return [NSObj",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/objective-c/file_1.m",
@@ -2615,11 +3168,13 @@
         "end": 64,
         "startLoc": {
           "line": 14,
-          "column": 1
+          "column": 1,
+          "position": 7
         },
         "endLoc": {
           "line": 64,
-          "column": 5
+          "column": 5,
+          "position": 345
         }
       },
       "secondFile": {
@@ -2628,18 +3183,20 @@
         "end": 88,
         "startLoc": {
           "line": 38,
-          "column": 1
+          "column": 1,
+          "position": 233
         },
         "endLoc": {
           "line": 88,
-          "column": 5
+          "column": 5,
+          "position": 571
         }
       }
     },
     {
       "format": "c-header",
       "lines": 35,
-      "fragment": "/**\n * Copyright (c) 2016-present, Facebook, Inc.\n * All rights reserved.\n *\n * This source code is licensed under the BSD-style license found in the\n * LICENSE file in the root directory of this source tree. An additional grant\n * of patent rights can be found in the PATENTS file in the same directory.\n */\n\n#import <IGListKit/IGListAdapter.h>\n#import <IGListKit/IGListCollectionContext.h>\n\n#import \"IGListAdapterProxy.h\"\n#import \"IGListDisplayHandler.h\"\n#import \"IGListSectionMap.h\"\n#import \"IGListWorkingRangeHandler.h\"\n\nNS_ASSUME_NONNULL_BEGIN\n\n/// Generate a string representation of a reusable view class when registering with a UICollectionView.\nNS_INLINE NSString *IGListReusableViewIdentifier(Class viewClass, NSString * _Nullable kind) {\n  return [NSString stringWithFormat:@\"%@%@\", kind ?: @\"\", NSStringFromClass(viewClass)];\n}\n\n@interface IGListAdapter ()\n<\nUICollectionViewDataSource,\nUICollectionViewDelegateFlowLayout,\nIGListCollectionContext\n>\n{\n    __weak UICollectionView *_collectionView;\n}\n\n@property",
+      "fragment": "/**\n * Copyright (c) 2016-present, Facebook, Inc.\n * All rights reserved.\n *\n * This source code is licensed under the BSD-style license found in the\n * LICENSE file in the root directory of this source tree. An additional grant\n * of patent rights can be found in the PATENTS file in the same directory.\n */\n\n#import <IGListKit/IGListAdapter.h>\n#import <IGListKit/IGListCollectionContext.h>\n\n#import \"IGListAdapterProxy.h\"\n#import \"IGListDisplayHandler.h\"\n#import \"IGListSectionMap.h\"\n#import \"IGListWorkingRangeHandler.h\"\n\nNS_ASSUME_NONNULL_BEGIN\n\n/// Generate a string representation of a reusable view class when registering with a UICollectionView.\nNS_INLINE NSString *IGListReusableViewIdentifier(Class viewClass, NSString * _Nullable kind) {\n  return [NSString stringWithFormat:@\"%@%@\", kind ?: @\"\", NSStrin",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/objective-c/file_1.h",
@@ -2647,11 +3204,13 @@
         "end": 35,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 35,
-          "column": 10
+          "column": 10,
+          "position": 103
         }
       },
       "secondFile": {
@@ -2660,11 +3219,13 @@
         "end": 37,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 37,
-          "column": 22
+          "column": 22,
+          "position": 105
         }
       }
     },
@@ -2679,11 +3240,13 @@
         "end": 92,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 92,
-          "column": 2
+          "column": 2,
+          "position": 511
         }
       },
       "secondFile": {
@@ -2692,18 +3255,20 @@
         "end": 86,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 86,
-          "column": 2
+          "column": 2,
+          "position": 505
         }
       }
     },
     {
       "format": "markdown",
       "lines": 175,
-      "fragment": "`jscpd` is a tool for detect copy/paste \"design pattern\" in programming source code.\n\n| _Supported languages_ |              |               |\n|-----------------------|--------------|---------------|\n| JavaScript            | Java         | YAML          |\n| CoffeeScript          | C++          | Haxe          |\n| PHP                   | C#           | TypeScript    |\n| Go                    | Python       | Mixed HTML    |\n| Ruby                  | C            | SCSS          |\n| Less                  | CSS          | erlang        |\n| Swift                 | xml/xslt     | Objective-C   |\n| Puppet                | Twig         | Vue.js        |\n| Scala                 | Lua          |               |\n\nIf you need support language not from list feel free to create [request](https://github.com/kucherenko/jscpd/issues/new).\n\n## Status\n\n[![Dependency Status](https://gemnasium.com/kucherenko/jscpd.png)](https://gemnasium.com/kucherenko/jscpd)\n[![Build Status](https://travis-ci.org/kucherenko/jscpd.png?branch=master)](https://travis-ci.org/kucherenko/jscpd)\n[![Coverage Status](https://coveralls.io/repos/kucherenko/jscpd/badge.png?branch=master)](https://coveralls.io/r/kucherenko/jscpd?branch=master)\n[![Stories in Ready](https://badge.waffle.io/kucherenko/jscpd.png?label=ready)](https://waffle.io/kucherenko/jscpd)\n\n[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/kucherenko/jscpd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)\n\n[![NPM](https://nodei.co/npm/jscpd.png)](https://nodei.co/npm/jscpd/)\n\n## Installation\n\n    npm install jscpd -g\n\n## Usage\n\n    jscpd --path my_project/ --languages javascript,coffee\n\n    jscpd -f \"**/*.js\" -e \"**/node_modules/**\"\n\n    jscpd --files \"**/*.js\" --exclude \"**/*.min.js\" --output report.xml\n\n    jscpd --files \"**/*.js\" --exclude \"**/*.min.js\" --reporter json --output report.json\n    \n    jscpd --languages-exts javascript:es5,es6,es7,js;php:php5\n    \n    jscpd --config test/.cpd.yaml\n\nor\n\nIf you have file `.cpd.yaml` in your directory\n```yaml\n#.cpd.yaml\nlanguages:\n  - javascript\n  - coffeescript\n  - typescript\n  - php\n  - python\n  - jsx\n  - haxe\n  - yaml\n  - css\n  - ruby\n  - go\n  - swift\n  - twig\n  - java\n  - clike    # c++, c, objective-c source\n  - csharp      # c# source\n  - htmlmixed   # html mixed source like knockout.js templates\nfiles:\n  - \"test/**/*\"\nexclude:\n  - \"**/*.min.js\"\n  - \"**/*.mm.js\"\nreporter: json\n\nlanguages-exts:\n    coffeescript:\n        - coffeee\n    javascript:\n        - es\n        - es5\n        - es6\n        - es7\n```\nand run `jscpd` command, you will check code for duplicates according config from .cpd.yaml\n\nor\n\n```coffeescript\n# coffeescript\njscpd = require('jscpd')\nresult = jscpd::run\n  path: 'my/project/folder'\n  files: '**/*.js'\n  exclude: ['**/*.min.js', '**/node_modules/**']\n  reporter: json\n```\n\nPlease see the [minimatch documentation](https://github.com/isaacs/minimatch) for more details.\n\n\n## Options:\n\n| Option             | Type      | Default       | Description\n|--------------------|-----------|---------------|-------------------------------------------------------------\n| -l, --min-lines    | [NUMBER]  | 5             | min size of duplication in code lines\n| -t, --min-tokens   | [NUMBER]  | 70            | min size of duplication in code tokens\n| -f, --files        | [STRING]  | *             | glob pattern for find code\n| -r, --reporter     | [STRING]  | xml           | reporter name or path\n| -x, --xsl-href     | [STRING]  | -             | path to xsl file for include to xml report\n| -e, --exclude      | [STRING]  | -             | directory to ignore\n|    --languages-exts| [STRING]  | -             | list of languages with file extensions (e.g. language:ext1,ext2;language:ext3)\n| -g, --languages    | [STRING]  | All supported | list of languages which scan for duplicates, separated with comma\n| -o, --output       | [PATH]    | -             | path to report file\n| -c, --config       | [PATH]    | -             | path to config yml file  (e.g. .cpd.yml)\n|     --verbose      |           | -             | show full info about copies\n|     --skip-comments| false     | -             | skip comments in code when duplications finding\n| -b, --blame        | false     | -             | blame authors of duplications (get information about authors from git)\n| -p, --path         | [PATH]    | Current dir   | path to code\n|     --limit        | [NUMBER]  | 50            | limit of allowed duplications, if real duplications percent more then limit jscpd exit with error\n| -d, --debug        |           | -             | show debug information (options list and selected files)\n| -v, --version      |           | -             | Display the current version\n| -h, --help         |           | -             | Display help and usage details\n\nVerbose output:\n\n![verbose duplication](https://raw.githubusercontent.com/kucherenko/jscpd/develop/images/jscpd_verbose_screenshot.png)\n\nBlame mode use information from git blame and concat it with duplications report:\n\n![blame duplication](https://raw.githubusercontent.com/kucherenko/jscpd/develop/images/jscpd_blame_screenshot.png)\n\n## Reporters\n\n`jscpd` shipped with two standard reporters `xml` and [`json`](test/reporters/json-report.schema.json). It is possible to write custom reporter script too. For hooking reporter up wrap it into node module and provide path to it as `reporter` parameter e.g. `./scripts/jscpd-custom-reporter.coffee` (works with javascript too).\n\nCustom reporter is a function which is executed into context of `Report` (`report.coffee`) class and thus has access to the report object and options. Expected output is array with following elements:\n\n`[raw, dump, log]`\n\n- `raw` is raw report object which will be passed through.\n- `dump` is report which will be written into output file if any provided.\n- `log` custom log output for cli.\n\nAt least one of `raw` or `dump` needs to be provided, `log` is fully optional.\n\n\n## XSLT reports support\n\nYou can point xsl file for add it to xml report\n\n```\njscpd -x reporters-xslt/simple.xsl -p test/fixtures/ -r xml -o report.xml\n```\n\nIn this case report.xml will include following lines:\n\n```\n<?xml version='1.0' encoding='UTF-8' ?>\n<?xml-stylesheet type=\"text/xsl\" href=\"reporters-xslt/simple.xsl\"?>\n<pmd-cpd>\n    <!-- ... -->\n</pmd-cpd>\n```\nIf you open xml file in browser template from `reporters-xslt/simple.xsl` will apply to your xml and show pretty html report.\nYou can find example of xsl template in reporters-xslt folder.\n\n## Errors\n\n - **JSCPD Error 01**: {language} in not supported  -  error will show if you try to find duplication in not supported language\n - **JSCPD Error 02**: can't read config file {path} - you use wrong path to file or file is broken\n\n## TODO\n\n[Project plans](https://github.com/kucherenko/jscpd/blob/master/todo.md)",
+      "fragment": "Copy/paste detector for programming source code.\n\n`jscpd` is a tool for detect copy/paste \"design pattern\" in programming source code.\n\n| _Supported languages_ |              |               |\n|-----------------------|--------------|---------------|\n| JavaScript            | Java         | YAML          |\n| CoffeeScript          | C++          | Haxe          |\n| PHP                   | C#           | TypeScript    |\n| Go                    | Python       | Mixed HTML    |\n| Ruby                  | C            | SCSS          |\n| Less                  | CSS          | erlang        |\n| Swift                 | xml/xslt     | Objective-C   |\n| Puppet                | Twig         | Vue.js        |\n| Scala                 | Lua          |               |\n\nIf you need support language not from list feel free to create [request](https://github.com/kucherenko/jscpd/issues/new).\n\n## Status\n\n[![Dependency Status](https://gemnasium.com/kucherenko/jscpd.png)](https://gemnasium.com/kucherenko/jscpd)\n[![Build Status](https://travis-ci.org/kucherenko/jscpd.png?branch=master)](https://travis-ci.org/kucherenko/jscpd)\n[![Coverage Status](https://coveralls.io/repos/kucherenko/jscpd/badge.png?branch=master)](https://coveralls.io/r/kucherenko/jscpd?branch=master)\n[![Stories in Ready](https://badge.waffle.io/kucherenko/jscpd.png?label=ready)](https://waffle.io/kucherenko/jscpd)\n\n[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/kucherenko/jscpd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)\n\n[![NPM](https://nodei.co/npm/jscpd.png)](https://nodei.co/npm/jscpd/)\n\n## Installation\n\n    npm install jscpd -g\n\n## Usage\n\n    jscpd --path my_project/ --languages javascript,coffee\n\n    jscpd -f \"**/*.js\" -e \"**/node_modules/**\"\n\n    jscpd --files \"**/*.js\" --exclude \"**/*.min.js\" --output report.xml\n\n    jscpd --files \"**/*.js\" --exclude \"**/*.min.js\" --reporter json --output report.json\n\n    jscpd --languages-exts javascript:es5,es6,es7,js;php:php5\n\n    jscpd --config test/.cpd.yaml\n\nor\n\nIf you have file `.cpd.yaml` in your directory\n```yaml\n#.cpd.yaml\nlanguages:\n  - javascript\n  - coffeescript\n  - typescript\n  - php\n  - python\n  - jsx\n  - haxe\n  - yaml\n  - css\n  - ruby\n  - go\n  - swift\n  - twig\n  - java\n  - clike    # c++, c, objective-c source\n  - csharp      # c# source\n  - htmlmixed   # html mixed source like knockout.js templates\nfiles:\n  - \"test/**/*\"\nexclude:\n  - \"**/*.min.js\"\n  - \"**/*.mm.js\"\nreporter: json\n\nlanguages-exts:\n    coffeescript:\n        - coffeee\n    javascript:\n        - es\n        - es5\n        - es6\n        - es7\n```\nand run `jscpd` command, you will check code for duplicates according config from .cpd.yaml\n\nor\n\n```coffeescript\n# coffeescript\njscpd = require('jscpd')\nresult = jscpd::run\n  path: 'my/project/folder'\n  files: '**/*.js'\n  exclude: ['**/*.min.js', '**/node_modules/**']\n  reporter: json\n```\n\nPlease see the [minimatch documentation](https://github.com/isaacs/minimatch) for more details.\n\n\n## Options:\n\n| Option             | Type      | Default       | Description\n|--------------------|-----------|---------------|-------------------------------------------------------------\n| -l, --min-lines    | [NUMBER]  | 5             | min size of duplication in code lines\n| -t, --min-tokens   | [NUMBER]  | 70            | min size of duplication in code tokens\n| -f, --files        | [STRING]  | *             | glob pattern for find code\n| -r, --reporter     | [STRING]  | xml           | reporter name or path\n| -x, --xsl-href     | [STRING]  | -             | path to xsl file for include to xml report\n| -e, --exclude      | [STRING]  | -             | directory to ignore\n|    --languages-exts| [STRING]  | -             | list of languages with file extensions (e.g. language:ext1,ext2;language:ext3)\n| -g, --languages    | [STRING]  | All supported | list of languages which scan for duplicates, separated with comma\n| -o, --output       | [PATH]    | -             | path to report file\n| -c, --config       | [PATH]    | -             | path to config yml file  (e.g. .cpd.yml)\n|     --verbose      |           | -             | show full info about copies\n|     --skip-comments| false     | -             | skip comments in code when duplications finding\n| -b, --blame        | false     | -             | blame authors of duplications (get information about authors from git)\n| -p, --path         | [PATH]    | Current dir   | path to code\n|     --limit        | [NUMBER]  | 50            | limit of allowed duplications, if real duplications percent more then limit jscpd exit with error\n| -d, --debug        |           | -             | show debug information (options list and selected files)\n| -v, --version      |           | -             | Display the current version\n| -h, --help         |           | -             | Display help and usage details\n\nVerbose output:\n\n![verbose duplication](https://raw.githubusercontent.com/kucherenko/jscpd/develop/images/jscpd_verbose_screenshot.png)\n\nBlame mode use information from git blame and concat it with duplications report:\n\n![blame duplication](https://raw.githubusercontent.com/kucherenko/jscpd/develop/images/jscpd_blame_screenshot.png)\n\n## Reporters\n\n`jscpd` shipped with two standard reporters `xml` and [`json`](test/reporters/json-report.schema.json). It is possible to write custom reporter script too. For hooking reporter up wrap it into node module and provide path to it as `reporter` parameter e.g. `./scripts/jscpd-custom-reporter.coffee` (works with javascript too).\n\nCustom reporter is a function which is executed into context of `Report` (`report.coffee`) class and thus has access to the report object and options. Expected output is array with following elements:\n\n`[raw, dump, log]`\n\n- `raw` is raw report object which will be passed through.\n- `dump` is report which will be written into output file if any provided.\n- `log` custom log output for cli.\n\nAt least one of `raw` or `dump` needs to be provided, `log` is fully optional.\n\n\n## XSLT reports support\n\nYou can point xsl file for add it to xml report\n\n```\njscpd -x reporters-xslt/simple.xsl -p test/fixtures/ -r xml -o report.xml\n```\n\nIn this case report.xml will include following lines:\n\n```\n<?xml version='1.0' encoding='UTF-8' ?>\n<?xml-stylesheet type=\"text/xsl\" href=\"reporters-xslt/simple.xsl\"?>\n<pmd-cpd>\n    <!-- ... -->\n</pmd-cpd>\n```\nIf you open xml file in browser template from `reporters-xslt/simple.xsl` will apply to your xml and show pretty html report.\nYou can find example of xsl template in reporters-xslt folder.\n\n## Errors\n\n - **JSCPD Error 01**: {language} in not supported  -  error will show if you try to find duplication in not supported language\n - **JSCPD Err",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/markdown/file1.md",
@@ -2711,11 +3276,13 @@
         "end": 178,
         "startLoc": {
           "line": 4,
-          "column": 1
+          "column": 1,
+          "position": 3
         },
         "endLoc": {
           "line": 178,
-          "column": 73
+          "column": 73,
+          "position": 1614
         }
       },
       "secondFile": {
@@ -2724,11 +3291,13 @@
         "end": 183,
         "startLoc": {
           "line": 9,
-          "column": 1
+          "column": 1,
+          "position": 5
         },
         "endLoc": {
           "line": 183,
-          "column": 4
+          "column": 4,
+          "position": 1616
         }
       }
     },
@@ -2743,11 +3312,13 @@
         "end": 37,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 37,
-          "column": 11
+          "column": 11,
+          "position": 243
         }
       },
       "secondFile": {
@@ -2756,11 +3327,13 @@
         "end": 37,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 37,
-          "column": 7
+          "column": 7,
+          "position": 243
         }
       }
     },
@@ -2775,11 +3348,13 @@
         "end": 23,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 23,
-          "column": 15
+          "column": 7,
+          "position": 172
         }
       },
       "secondFile": {
@@ -2788,11 +3363,13 @@
         "end": 23,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 23,
-          "column": 11
+          "column": 3,
+          "position": 172
         }
       }
     },
@@ -2807,11 +3384,13 @@
         "end": 83,
         "startLoc": {
           "line": 56,
-          "column": 74
+          "column": 7,
+          "position": 403
         },
         "endLoc": {
           "line": 83,
-          "column": 43
+          "column": 2,
+          "position": 576
         }
       },
       "secondFile": {
@@ -2820,11 +3399,13 @@
         "end": 42,
         "startLoc": {
           "line": 15,
-          "column": 2
+          "column": 2,
+          "position": 102
         },
         "endLoc": {
           "line": 42,
-          "column": 43
+          "column": 2,
+          "position": 275
         }
       }
     },
@@ -2834,16 +3415,18 @@
       "fragment": "module.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};",
       "tokens": 0,
       "firstFile": {
-        "name": "fixtures/javascript/file_2.js",
+        "name": "fixtures/javascript/file_2.mjs",
         "start": 1,
         "end": 28,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 28,
-          "column": 3
+          "column": 2,
+          "position": 278
         }
       },
       "secondFile": {
@@ -2852,11 +3435,13 @@
         "end": 52,
         "startLoc": {
           "line": 25,
-          "column": 1
+          "column": 1,
+          "position": 288
         },
         "endLoc": {
           "line": 52,
-          "column": 3
+          "column": 2,
+          "position": 566
         }
       }
     },
@@ -2866,16 +3451,18 @@
       "fragment": "module.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};",
       "tokens": 0,
       "firstFile": {
-        "name": "fixtures/javascript/file_2.js",
+        "name": "fixtures/javascript/file_2.mjs",
         "start": 29,
         "end": 56,
         "startLoc": {
           "line": 29,
-          "column": 1
+          "column": 1,
+          "position": 280
         },
         "endLoc": {
           "line": 56,
-          "column": 3
+          "column": 2,
+          "position": 558
         }
       },
       "secondFile": {
@@ -2884,11 +3471,85 @@
         "end": 52,
         "startLoc": {
           "line": 25,
-          "column": 1
+          "column": 1,
+          "position": 288
         },
         "endLoc": {
           "line": 52,
-          "column": 3
+          "column": 2,
+          "position": 566
+        }
+      }
+    },
+    {
+      "format": "javascript",
+      "lines": 56,
+      "fragment": "module.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};\nmodule.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};",
+      "tokens": 0,
+      "firstFile": {
+        "name": "fixtures/javascript/file_2.js",
+        "start": 1,
+        "end": 56,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 56,
+          "column": 2,
+          "position": 558
+        }
+      },
+      "secondFile": {
+        "name": "fixtures/javascript/file_3.js",
+        "start": 25,
+        "end": 52,
+        "startLoc": {
+          "line": 25,
+          "column": 1,
+          "position": 288
+        },
+        "endLoc": {
+          "line": 52,
+          "column": 2,
+          "position": 566
+        }
+      }
+    },
+    {
+      "format": "javascript",
+      "lines": 56,
+      "fragment": "module.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};\nmodule.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};",
+      "tokens": 0,
+      "firstFile": {
+        "name": "fixtures/javascript/file_2.cjs",
+        "start": 1,
+        "end": 56,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 56,
+          "column": 2,
+          "position": 558
+        }
+      },
+      "secondFile": {
+        "name": "fixtures/javascript/file_3.js",
+        "start": 25,
+        "end": 52,
+        "startLoc": {
+          "line": 25,
+          "column": 1,
+          "position": 288
+        },
+        "endLoc": {
+          "line": 52,
+          "column": 2,
+          "position": 566
         }
       }
     },
@@ -2898,16 +3559,18 @@
       "fragment": "function utf8_encode ( str_data ) {\n    // Encodes an ISO-8859-1 string to UTF-8\n    //\n    // +   original by: Webtoolkit.info (http://www.webtoolkit.info/)\n    str_data = str_data.replace(/\\r\\n/g,\"\\n\");\n    var utftext = \"\";\n\n    for (var n = 0; n < str_data.length; n++) {\n        var c = str_data.charCodeAt(n);\n        if (c < 128) {\n            utftext += String.fromCharCode(c);\n        } else if((c > 127) && (c < 2048)) {\n            utftext += String.fromCharCode((c >> 6) | 192);\n            utftext += String.fromCharCode((c & 63) | 128);\n        } else {\n            utftext += String.fromCharCode((c >> 12) | 224);\n            utftext += String.fromCharCode(((c >> 6) & 63) | 128);\n            utftext += String.fromCharCode((c & 63) | 128);\n        }\n    }\n\n    return utftext;\n}\n\nmodule.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};",
       "tokens": 0,
       "firstFile": {
-        "name": "fixtures/javascript/file_1.js",
+        "name": "fixtures/javascript/file_1.mjs",
         "start": 4,
         "end": 55,
         "startLoc": {
           "line": 4,
-          "column": 1
+          "column": 1,
+          "position": 2
         },
         "endLoc": {
           "line": 55,
-          "column": 3
+          "column": 2,
+          "position": 568
         }
       },
       "secondFile": {
@@ -2916,11 +3579,157 @@
         "end": 52,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 52,
-          "column": 3
+          "column": 2,
+          "position": 566
+        }
+      }
+    },
+    {
+      "format": "javascript",
+      "lines": 55,
+      "fragment": "/**\n*12312\n*/\nfunction utf8_encode ( str_data ) {\n    // Encodes an ISO-8859-1 string to UTF-8\n    //\n    // +   original by: Webtoolkit.info (http://www.webtoolkit.info/)\n    str_data = str_data.replace(/\\r\\n/g,\"\\n\");\n    var utftext = \"\";\n\n    for (var n = 0; n < str_data.length; n++) {\n        var c = str_data.charCodeAt(n);\n        if (c < 128) {\n            utftext += String.fromCharCode(c);\n        } else if((c > 127) && (c < 2048)) {\n            utftext += String.fromCharCode((c >> 6) | 192);\n            utftext += String.fromCharCode((c & 63) | 128);\n        } else {\n            utftext += String.fromCharCode((c >> 12) | 224);\n            utftext += String.fromCharCode(((c >> 6) & 63) | 128);\n            utftext += String.fromCharCode((c & 63) | 128);\n        }\n    }\n\n    return utftext;\n}\n\nmodule.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};",
+      "tokens": 0,
+      "firstFile": {
+        "name": "fixtures/javascript/file_1.js",
+        "start": 1,
+        "end": 55,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 55,
+          "column": 2,
+          "position": 568
+        }
+      },
+      "secondFile": {
+        "name": "fixtures/javascript/file_1.mjs",
+        "start": 1,
+        "end": 52,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 52,
+          "column": 2,
+          "position": 566
+        }
+      }
+    },
+    {
+      "format": "javascript",
+      "lines": 55,
+      "fragment": "/**\n*12312\n*/\nfunction utf8_encode ( str_data ) {\n    // Encodes an ISO-8859-1 string to UTF-8\n    //\n    // +   original by: Webtoolkit.info (http://www.webtoolkit.info/)\n    str_data = str_data.replace(/\\r\\n/g,\"\\n\");\n    var utftext = \"\";\n\n    for (var n = 0; n < str_data.length; n++) {\n        var c = str_data.charCodeAt(n);\n        if (c < 128) {\n            utftext += String.fromCharCode(c);\n        } else if((c > 127) && (c < 2048)) {\n            utftext += String.fromCharCode((c >> 6) | 192);\n            utftext += String.fromCharCode((c & 63) | 128);\n        } else {\n            utftext += String.fromCharCode((c >> 12) | 224);\n            utftext += String.fromCharCode(((c >> 6) & 63) | 128);\n            utftext += String.fromCharCode((c & 63) | 128);\n        }\n    }\n\n    return utftext;\n}\n\nmodule.exports = function (store) {\n    function getset (name, value) {\n        var node = vars.store;\n        var keys = name.split('.');\n        keys.slice(0,-1).forEach(function (k) {\n            if (node[k] === undefined) node[k] = {};\n            node = node[k]\n        });\n        var key = keys[keys.length - 1];\n        if (arguments.length == 1) {\n            return node[key];\n        }\n        else {\n            return node[key] = value;\n        }\n    }\n\n    var vars = {\n        get : function (name) {\n            return getset(name);\n        },\n        set : function (name, value) {\n            return getset(name, value);\n        },\n        store : store || {},\n    };\n    return vars;\n};",
+      "tokens": 0,
+      "firstFile": {
+        "name": "fixtures/javascript/file_1.cjs",
+        "start": 1,
+        "end": 55,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 55,
+          "column": 2,
+          "position": 568
+        }
+      },
+      "secondFile": {
+        "name": "fixtures/javascript/file_1.mjs",
+        "start": 1,
+        "end": 52,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 52,
+          "column": 2,
+          "position": 566
+        }
+      }
+    },
+    {
+      "format": "typescript",
+      "lines": 376,
+      "fragment": "/* ---------------------------------------------------------------------------------------\n Todos.ts\n Microsoft grants you the right to use these script files under the Apache 2.0 license.\n Microsoft reserves total other rights to the files not expressly granted by Microsoft,\n whether by implication, estoppel or otherwise. The copyright notices and MIT licenses\n below are for informational purposes only.\n\n Portions Copyright © Microsoft Corporation\n Apache 2.0 License\n\n Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this\n file except in compliance with the License. You may obtain a copy of the License at\n http://www.apache.org/licenses/LICENSE-2.0\n\n Unless required by applicable law or agreed to in writing, software distributed under\n the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF\n ANY KIND, either express or implied.\n\n See the License for the specific language governing permissions and limitations\n under the License.\n ------------------------------------------------------------------------------------------\n Provided for Informational Purposes Only\n MIT License\n Permission is hereby granted, free of charge, to any person obtaining a copy of this\n software and associated documentation files (the \"Software\"), to deal in the Software\n without restriction, including without limitation the rights to use, copy, modify, merge,\n publish, distribute, sublicense, and/or sell copies of the Software, and to permit\n persons to whom the Software is furnished to do so, subject to the following conditions:\n\n The above copyright notice and this permission notice shall be included in total copies\n or substantial portions of the Software.\n\n THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,\n INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR\n PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE\n FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\n OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n DEALINGS IN THE SOFTWARE.\n --------------------------------------------------------------------------------------- */\n// Todos.js\n// https://github.com/documentcloud/backbone/blob/master/examples/todos/todos.js\n\n// An example Backbone application contributed by\n// [Jérôme Gravel-Niquet](http://jgn.me/). This demo uses a simple\n// [LocalStorage adapter](backbone-localstorage.js)\n// to persist Backbone models within your browser.\n\ndeclare module Backbone {\n    export class Model {\n        constructor (attr? , opts? );\n        get(name: string): any;\n        set(name: string, val: any): void;\n        set(obj: any): void;\n        save(attr? , opts? ): void;\n        destroy(): void;\n        bind(ev: string, f: Function, ctx?: any): void;\n        toJSON(): any;\n    }\n    export class Collection<T> {\n        constructor (models? , opts? );\n        bind(ev: string, f: Function, ctx?: any): void;\n        length: number;\n        create(attrs, opts? ): any;\n        each(f: (elem: T) => void ): void;\n        fetch(opts?: any): void;\n        last(): T;\n        last(n: number): T[];\n        filter(f: (elem: T) => boolean): T[];\n        without(...values: T[]): T[];\n    }\n    export class View {\n        constructor (options? );\n        $(selector: string): JQuery;\n        el: HTMLElement;\n        $el: JQuery;\n        model: Model;\n        remove(): void;\n        delegateEvents: any;\n        make(tagName: string, attrs? , opts? ): View;\n        setElement(element: HTMLElement, delegate?: boolean): void;\n        setElement(element: JQuery, delegate?: boolean): void;\n        tagName: string;\n        events: any;\n\n        static extend: any;\n    }\n}\ninterface JQuery {\n    fadeIn(): JQuery;\n    fadeOut(): JQuery;\n    focus(): JQuery;\n    html(): string;\n    html(val: string): JQuery;\n    show(): JQuery;\n    addClass(className: string): JQuery;\n    removeClass(className: string): JQuery;\n    append(el: HTMLElement): JQuery;\n    val(): string;\n    val(value: string): JQuery;\n    attr(attrName: string): string;\n}\ndeclare var $: {\n    (el: HTMLElement): JQuery;\n    (selector: string): JQuery;\n    (readyCallback: () => void ): JQuery;\n};\ndeclare var _: {\n    each<T, U>(arr: T[], f: (elem: T) => U): U[];\n    delay(f: Function, wait: number, ...arguments: any[]): number;\n    template(template: string): (model: any) => string;\n    bindAll(object: any, ...methodNames: string[]): void;\n};\ndeclare var Store: any;\n\n\n// Todo Model\n// ----------\n\n// Our basic **Todo** model has `content`, `order`, and `done` attributes.\nclass Todo extends Backbone.Model {\n\n    // Default attributes for the todo.\n    defaults() {\n        return {\n            content: \"empty todo...\",\n            done: false\n        }\n    }\n\n    // Ensure that each todo created has `content`.\n    initialize() {\n        if (!this.get(\"content\")) {\n            this.set({ \"content\": this.defaults().content });\n        }\n    }\n\n    // Toggle the `done` state of this todo item.\n    toggle() {\n        this.save({ done: !this.get(\"done\") });\n    }\n\n    // Remove this Todo from *localStorage* and delete its view.\n    clear() {\n        this.destroy();\n    }\n\n}\n\n// Todo Collection\n// ---------------\n\n// The collection of todos is backed by *localStorage* instead of a remote\n// server.\nclass TodoList extends Backbone.Collection<Todo> {\n\n    // Reference to this collection's model.\n    model = Todo;\n\n    // Save total of the todo items under the `\"todos\"` namespace.\n    localStorage = new Store(\"todos-backbone\");\n\n    // Filter down the list of total todo items that are finished.\n    done() {\n        return this.filter(todo => todo.get('done'));\n    }\n\n    // Filter down the list to only todo items that are still not finished.\n    remaining() {\n        return this.without.apply(this, this.done());\n    }\n\n    // We keep the Todos in sequential order, despite being saved by unordered\n    // GUID in the database. This generates the next order number for new items.\n    nextOrder() {\n        if (!this.length) return 1;\n        return this.last().get('order') + 1;\n    }\n\n    // Todos are sorted by their original insertion order.\n    comparator(todo: Todo) {\n        return todo.get('order');\n    }\n\n}\n\n// Create our global collection of **Todos**.\nvar Todos = new TodoList();\n\n// Todo Item View\n// --------------\n\n// The DOM element for a todo item...\nclass TodoView extends Backbone.View {\n\n    // The TodoView listens for changes to its model, re-rendering. Since there's\n    // a one-to-one correspondence between a **Todo** and a **TodoView** in this\n    // app, we set a direct reference on the model for convenience.\n    template: (data: any) => string;\n\n    // A TodoView model must be a Todo, redeclare with specific type\n    model: Todo;\n    input: JQuery;\n\n    constructor (options? ) {\n        //... is a list tag.\n        this.tagName = \"li\";\n\n        // The DOM events specific to an item.\n        this.events = {\n            \"click .check\": \"toggleDone\",\n            \"dblclick label.todo-content\": \"edit\",\n            \"click span.todo-destroy\": \"clear\",\n            \"keypress .todo-input\": \"updateOnEnter\",\n            \"blur .todo-input\": \"close\"\n        };\n\n        super(options);\n\n        // Cache the template function for a single item.\n        this.template = _.template($('#item-template').html());\n\n        _.bindAll(this, 'render', 'close', 'remove');\n        this.model.bind('change', this.render);\n        this.model.bind('destroy', this.remove);\n    }\n\n    // Re-render the contents of the todo item.\n    render() {\n        this.$el.html(this.template(this.model.toJSON()));\n        this.input = this.$('.todo-input');\n        return this;\n    }\n\n    // Toggle the `\"done\"` state of the model.\n    toggleDone() {\n        this.model.toggle();\n    }\n\n    // Switch this view into `\"editing\"` mode, displaying the input field.\n    edit() {\n        this.$el.addClass(\"editing\");\n        this.input.focus();\n    }\n\n    // Close the `\"editing\"` mode, saving changes to the todo.\n    close() {\n        this.model.save({ content: this.input.val() });\n        this.$el.removeClass(\"editing\");\n    }\n\n    // If you hit `enter`, we're through editing the item.\n    updateOnEnter(e) {\n        if (e.keyCode == 13) close();\n    }\n\n    // Remove the item, destroy the model.\n    clear() {\n        this.model.clear();\n    }\n\n}\n\n// The Application\n// ---------------\n\n// Our overall **AppView** is the top-level piece of UI.\nclass AppView extends Backbone.View {\n\n    // Delegated events for creating new items, and clearing completed ones.\n    events = {\n        \"keypress #new-todo\": \"createOnEnter\",\n        \"keyup #new-todo\": \"showTooltip\",\n        \"click .todo-clear a\": \"clearCompleted\",\n        \"click .mark-all-done\": \"toggleAllComplete\"\n    };\n\n    input: JQuery;\n    allCheckbox: HTMLInputElement;\n    statsTemplate: (params: any) => string;\n\n    constructor () {\n        super();\n        // Instead of generating a new element, bind to the existing skeleton of\n        // the App already present in the HTML.\n        this.setElement($(\"#todoapp\"), true);\n\n        // At initialization we bind to the relevant events on the `Todos`\n        // collection, when items are added or changed. Kick things off by\n        // loading any preexisting todos that might be saved in *localStorage*.\n        _.bindAll(this, 'addOne', 'addAll', 'render', 'toggleAllComplete');\n\n        this.input = this.$(\"#new-todo\");\n        this.allCheckbox = this.$(\".mark-total-done\")[0];\n        this.statsTemplate = _.template($('#stats-template').html());\n\n        Todos.bind('add', this.addOne);\n        Todos.bind('reset', this.addAll);\n        Todos.bind('all', this.render);\n\n        Todos.fetch();\n    }\n\n    // Re-rendering the App just means refreshing the statistics -- the rest\n    // of the app doesn't change.\n    render() {\n        var done = Todos.done().length;\n        var remaining = Todos.remaining().length;\n\n        this.$('#todo-stats').html(this.statsTemplate({\n            total: Todos.length,\n            done: done,\n            remaining: remaining\n        }));\n\n        this.allCheckbox.checked = !remaining;\n    }\n\n    // Add a single todo item to the list by creating a view for it, and\n    // appending its element to the `<ul>`.\n    addOne(todo) {\n        var view = new TodoView({ model: todo });\n        this.$(\"#todo-list\").append(view.render().el);\n    }\n\n    // Add total items in the **Todos** collection at once.\n    addAll() {\n        Todos.each(this.addOne);\n    }\n\n    // Generate the attributes for a new Todo item.\n    newAttributes() {\n        return {\n            content: this.input.val(),\n            order: Todos.nextOrder(),\n            done: false\n        };\n    }\n\n    // If you hit return in the main input field, create new **Todo** model,\n    // persisting it to *localStorage*.\n    createOnEnter(e) {\n        if (e.keyCode != 13) return;\n        Todos.create(this.newAttributes());\n        this.input.val('');\n    }\n\n    // Clear total done todo items, destroying their models.\n    clearCompleted() {\n        _.each(Todos.done(), todo => todo.clear());\n        return false;\n    }\n\n    tooltipTimeout: number = null;\n    // Lazily show the tooltip that tells you to press `enter` to save\n    // a new todo item, after one second.\n    showTooltip(e) {\n        var tooltip = $(\".ui-tooltip-top\");\n        var val = this.input.val();\n        tooltip.fadeOut();\n        if (this.tooltipTimeout) clearTimeout(this.tooltipTimeout);\n        if (val == '' || val == this.input.attr('placeholder')) return;\n        this.tooltipTimeout = _.delay(() => tooltip.show().fadeIn(), 1000);\n    }\n\n    toggleAllComplete() {\n        var done = this.allCheckbox.checked;\n        Todos.each(todo => todo.save({ 'done': done }));\n    }\n\n}\n\n// Load the application once the DOM is ready, using `jQuery.ready`:\n$(() => {\n    // Finally, we kick things off by creating the **App**.\n    new AppView();\n});",
+      "tokens": 0,
+      "firstFile": {
+        "name": "fixtures/javascript/file2.mts",
+        "start": 1,
+        "end": 376,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 376,
+          "column": 2,
+          "position": 2510
+        }
+      },
+      "secondFile": {
+        "name": "fixtures/javascript/file2.ts",
+        "start": 1,
+        "end": 376,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 376,
+          "column": 2,
+          "position": 2510
+        }
+      }
+    },
+    {
+      "format": "typescript",
+      "lines": 376,
+      "fragment": "/* ---------------------------------------------------------------------------------------\n Todos.ts\n Microsoft grants you the right to use these script files under the Apache 2.0 license.\n Microsoft reserves total other rights to the files not expressly granted by Microsoft,\n whether by implication, estoppel or otherwise. The copyright notices and MIT licenses\n below are for informational purposes only.\n\n Portions Copyright © Microsoft Corporation\n Apache 2.0 License\n\n Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this\n file except in compliance with the License. You may obtain a copy of the License at\n http://www.apache.org/licenses/LICENSE-2.0\n\n Unless required by applicable law or agreed to in writing, software distributed under\n the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF\n ANY KIND, either express or implied.\n\n See the License for the specific language governing permissions and limitations\n under the License.\n ------------------------------------------------------------------------------------------\n Provided for Informational Purposes Only\n MIT License\n Permission is hereby granted, free of charge, to any person obtaining a copy of this\n software and associated documentation files (the \"Software\"), to deal in the Software\n without restriction, including without limitation the rights to use, copy, modify, merge,\n publish, distribute, sublicense, and/or sell copies of the Software, and to permit\n persons to whom the Software is furnished to do so, subject to the following conditions:\n\n The above copyright notice and this permission notice shall be included in total copies\n or substantial portions of the Software.\n\n THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,\n INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR\n PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE\n FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\n OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n DEALINGS IN THE SOFTWARE.\n --------------------------------------------------------------------------------------- */\n// Todos.js\n// https://github.com/documentcloud/backbone/blob/master/examples/todos/todos.js\n\n// An example Backbone application contributed by\n// [Jérôme Gravel-Niquet](http://jgn.me/). This demo uses a simple\n// [LocalStorage adapter](backbone-localstorage.js)\n// to persist Backbone models within your browser.\n\ndeclare module Backbone {\n    export class Model {\n        constructor (attr? , opts? );\n        get(name: string): any;\n        set(name: string, val: any): void;\n        set(obj: any): void;\n        save(attr? , opts? ): void;\n        destroy(): void;\n        bind(ev: string, f: Function, ctx?: any): void;\n        toJSON(): any;\n    }\n    export class Collection<T> {\n        constructor (models? , opts? );\n        bind(ev: string, f: Function, ctx?: any): void;\n        length: number;\n        create(attrs, opts? ): any;\n        each(f: (elem: T) => void ): void;\n        fetch(opts?: any): void;\n        last(): T;\n        last(n: number): T[];\n        filter(f: (elem: T) => boolean): T[];\n        without(...values: T[]): T[];\n    }\n    export class View {\n        constructor (options? );\n        $(selector: string): JQuery;\n        el: HTMLElement;\n        $el: JQuery;\n        model: Model;\n        remove(): void;\n        delegateEvents: any;\n        make(tagName: string, attrs? , opts? ): View;\n        setElement(element: HTMLElement, delegate?: boolean): void;\n        setElement(element: JQuery, delegate?: boolean): void;\n        tagName: string;\n        events: any;\n\n        static extend: any;\n    }\n}\ninterface JQuery {\n    fadeIn(): JQuery;\n    fadeOut(): JQuery;\n    focus(): JQuery;\n    html(): string;\n    html(val: string): JQuery;\n    show(): JQuery;\n    addClass(className: string): JQuery;\n    removeClass(className: string): JQuery;\n    append(el: HTMLElement): JQuery;\n    val(): string;\n    val(value: string): JQuery;\n    attr(attrName: string): string;\n}\ndeclare var $: {\n    (el: HTMLElement): JQuery;\n    (selector: string): JQuery;\n    (readyCallback: () => void ): JQuery;\n};\ndeclare var _: {\n    each<T, U>(arr: T[], f: (elem: T) => U): U[];\n    delay(f: Function, wait: number, ...arguments: any[]): number;\n    template(template: string): (model: any) => string;\n    bindAll(object: any, ...methodNames: string[]): void;\n};\ndeclare var Store: any;\n\n\n// Todo Model\n// ----------\n\n// Our basic **Todo** model has `content`, `order`, and `done` attributes.\nclass Todo extends Backbone.Model {\n\n    // Default attributes for the todo.\n    defaults() {\n        return {\n            content: \"empty todo...\",\n            done: false\n        }\n    }\n\n    // Ensure that each todo created has `content`.\n    initialize() {\n        if (!this.get(\"content\")) {\n            this.set({ \"content\": this.defaults().content });\n        }\n    }\n\n    // Toggle the `done` state of this todo item.\n    toggle() {\n        this.save({ done: !this.get(\"done\") });\n    }\n\n    // Remove this Todo from *localStorage* and delete its view.\n    clear() {\n        this.destroy();\n    }\n\n}\n\n// Todo Collection\n// ---------------\n\n// The collection of todos is backed by *localStorage* instead of a remote\n// server.\nclass TodoList extends Backbone.Collection<Todo> {\n\n    // Reference to this collection's model.\n    model = Todo;\n\n    // Save total of the todo items under the `\"todos\"` namespace.\n    localStorage = new Store(\"todos-backbone\");\n\n    // Filter down the list of total todo items that are finished.\n    done() {\n        return this.filter(todo => todo.get('done'));\n    }\n\n    // Filter down the list to only todo items that are still not finished.\n    remaining() {\n        return this.without.apply(this, this.done());\n    }\n\n    // We keep the Todos in sequential order, despite being saved by unordered\n    // GUID in the database. This generates the next order number for new items.\n    nextOrder() {\n        if (!this.length) return 1;\n        return this.last().get('order') + 1;\n    }\n\n    // Todos are sorted by their original insertion order.\n    comparator(todo: Todo) {\n        return todo.get('order');\n    }\n\n}\n\n// Create our global collection of **Todos**.\nvar Todos = new TodoList();\n\n// Todo Item View\n// --------------\n\n// The DOM element for a todo item...\nclass TodoView extends Backbone.View {\n\n    // The TodoView listens for changes to its model, re-rendering. Since there's\n    // a one-to-one correspondence between a **Todo** and a **TodoView** in this\n    // app, we set a direct reference on the model for convenience.\n    template: (data: any) => string;\n\n    // A TodoView model must be a Todo, redeclare with specific type\n    model: Todo;\n    input: JQuery;\n\n    constructor (options? ) {\n        //... is a list tag.\n        this.tagName = \"li\";\n\n        // The DOM events specific to an item.\n        this.events = {\n            \"click .check\": \"toggleDone\",\n            \"dblclick label.todo-content\": \"edit\",\n            \"click span.todo-destroy\": \"clear\",\n            \"keypress .todo-input\": \"updateOnEnter\",\n            \"blur .todo-input\": \"close\"\n        };\n\n        super(options);\n\n        // Cache the template function for a single item.\n        this.template = _.template($('#item-template').html());\n\n        _.bindAll(this, 'render', 'close', 'remove');\n        this.model.bind('change', this.render);\n        this.model.bind('destroy', this.remove);\n    }\n\n    // Re-render the contents of the todo item.\n    render() {\n        this.$el.html(this.template(this.model.toJSON()));\n        this.input = this.$('.todo-input');\n        return this;\n    }\n\n    // Toggle the `\"done\"` state of the model.\n    toggleDone() {\n        this.model.toggle();\n    }\n\n    // Switch this view into `\"editing\"` mode, displaying the input field.\n    edit() {\n        this.$el.addClass(\"editing\");\n        this.input.focus();\n    }\n\n    // Close the `\"editing\"` mode, saving changes to the todo.\n    close() {\n        this.model.save({ content: this.input.val() });\n        this.$el.removeClass(\"editing\");\n    }\n\n    // If you hit `enter`, we're through editing the item.\n    updateOnEnter(e) {\n        if (e.keyCode == 13) close();\n    }\n\n    // Remove the item, destroy the model.\n    clear() {\n        this.model.clear();\n    }\n\n}\n\n// The Application\n// ---------------\n\n// Our overall **AppView** is the top-level piece of UI.\nclass AppView extends Backbone.View {\n\n    // Delegated events for creating new items, and clearing completed ones.\n    events = {\n        \"keypress #new-todo\": \"createOnEnter\",\n        \"keyup #new-todo\": \"showTooltip\",\n        \"click .todo-clear a\": \"clearCompleted\",\n        \"click .mark-all-done\": \"toggleAllComplete\"\n    };\n\n    input: JQuery;\n    allCheckbox: HTMLInputElement;\n    statsTemplate: (params: any) => string;\n\n    constructor () {\n        super();\n        // Instead of generating a new element, bind to the existing skeleton of\n        // the App already present in the HTML.\n        this.setElement($(\"#todoapp\"), true);\n\n        // At initialization we bind to the relevant events on the `Todos`\n        // collection, when items are added or changed. Kick things off by\n        // loading any preexisting todos that might be saved in *localStorage*.\n        _.bindAll(this, 'addOne', 'addAll', 'render', 'toggleAllComplete');\n\n        this.input = this.$(\"#new-todo\");\n        this.allCheckbox = this.$(\".mark-total-done\")[0];\n        this.statsTemplate = _.template($('#stats-template').html());\n\n        Todos.bind('add', this.addOne);\n        Todos.bind('reset', this.addAll);\n        Todos.bind('all', this.render);\n\n        Todos.fetch();\n    }\n\n    // Re-rendering the App just means refreshing the statistics -- the rest\n    // of the app doesn't change.\n    render() {\n        var done = Todos.done().length;\n        var remaining = Todos.remaining().length;\n\n        this.$('#todo-stats').html(this.statsTemplate({\n            total: Todos.length,\n            done: done,\n            remaining: remaining\n        }));\n\n        this.allCheckbox.checked = !remaining;\n    }\n\n    // Add a single todo item to the list by creating a view for it, and\n    // appending its element to the `<ul>`.\n    addOne(todo) {\n        var view = new TodoView({ model: todo });\n        this.$(\"#todo-list\").append(view.render().el);\n    }\n\n    // Add total items in the **Todos** collection at once.\n    addAll() {\n        Todos.each(this.addOne);\n    }\n\n    // Generate the attributes for a new Todo item.\n    newAttributes() {\n        return {\n            content: this.input.val(),\n            order: Todos.nextOrder(),\n            done: false\n        };\n    }\n\n    // If you hit return in the main input field, create new **Todo** model,\n    // persisting it to *localStorage*.\n    createOnEnter(e) {\n        if (e.keyCode != 13) return;\n        Todos.create(this.newAttributes());\n        this.input.val('');\n    }\n\n    // Clear total done todo items, destroying their models.\n    clearCompleted() {\n        _.each(Todos.done(), todo => todo.clear());\n        return false;\n    }\n\n    tooltipTimeout: number = null;\n    // Lazily show the tooltip that tells you to press `enter` to save\n    // a new todo item, after one second.\n    showTooltip(e) {\n        var tooltip = $(\".ui-tooltip-top\");\n        var val = this.input.val();\n        tooltip.fadeOut();\n        if (this.tooltipTimeout) clearTimeout(this.tooltipTimeout);\n        if (val == '' || val == this.input.attr('placeholder')) return;\n        this.tooltipTimeout = _.delay(() => tooltip.show().fadeIn(), 1000);\n    }\n\n    toggleAllComplete() {\n        var done = this.allCheckbox.checked;\n        Todos.each(todo => todo.save({ 'done': done }));\n    }\n\n}\n\n// Load the application once the DOM is ready, using `jQuery.ready`:\n$(() => {\n    // Finally, we kick things off by creating the **App**.\n    new AppView();\n});",
+      "tokens": 0,
+      "firstFile": {
+        "name": "fixtures/javascript/file2.cts",
+        "start": 1,
+        "end": 376,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 376,
+          "column": 2,
+          "position": 2510
+        }
+      },
+      "secondFile": {
+        "name": "fixtures/javascript/file2.ts",
+        "start": 1,
+        "end": 376,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 376,
+          "column": 2,
+          "position": 2510
         }
       }
     },
@@ -2935,11 +3744,13 @@
         "end": 73,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 73,
-          "column": 46
+          "column": 46,
+          "position": 817
         }
       },
       "secondFile": {
@@ -2948,11 +3759,13 @@
         "end": 119,
         "startLoc": {
           "line": 48,
-          "column": 1
+          "column": 1,
+          "position": 16
         },
         "endLoc": {
           "line": 119,
-          "column": 75
+          "column": 75,
+          "position": 832
         }
       }
     },
@@ -2967,11 +3780,13 @@
         "end": 263,
         "startLoc": {
           "line": 73,
-          "column": 1
+          "column": 1,
+          "position": 817
         },
         "endLoc": {
           "line": 263,
-          "column": 4
+          "column": 2,
+          "position": 2125
         }
       },
       "secondFile": {
@@ -2980,11 +3795,49 @@
         "end": 376,
         "startLoc": {
           "line": 186,
-          "column": 1
+          "column": 1,
+          "position": 1202
         },
         "endLoc": {
           "line": 376,
-          "column": 4
+          "column": 2,
+          "position": 2510
+        }
+      }
+    },
+    {
+      "format": "typescript",
+      "lines": 263,
+      "fragment": "declare module Backbone {\n    export class Model {\n        constructor (attr? , opts? );\n        get(name: string): any;\n        set(name: string, val: any): void;\n        set(obj: any): void;\n        save(attr? , opts? ): void;\n        destroy(): void;\n        bind(ev: string, f: Function, ctx?: any): void;\n        toJSON(): any;\n    }\n    export class Collection<T> {\n        constructor (models? , opts? );\n        bind(ev: string, f: Function, ctx?: any): void;\n        length: number;\n        create(attrs, opts? ): any;\n        each(f: (elem: T) => void ): void;\n        fetch(opts?: any): void;\n        last(): T;\n        last(n: number): T[];\n        filter(f: (elem: T) => boolean): T[];\n        without(...values: T[]): T[];\n    }\n    export class View {\n        constructor (options? );\n        $(selector: string): JQuery;\n        el: HTMLElement;\n        $el: JQuery;\n        model: Model;\n        remove(): void;\n        delegateEvents: any;\n        make(tagName: string, attrs? , opts? ): View;\n        setElement(element: HTMLElement, delegate?: boolean): void;\n        setElement(element: JQuery, delegate?: boolean): void;\n        tagName: string;\n        events: any;\n\n        static extend: any;\n    }\n}\ninterface JQuery {\n    fadeIn(): JQuery;\n    fadeOut(): JQuery;\n    focus(): JQuery;\n    html(): string;\n    html(val: string): JQuery;\n    show(): JQuery;\n    addClass(className: string): JQuery;\n    removeClass(className: string): JQuery;\n    append(el: HTMLElement): JQuery;\n    val(): string;\n    val(value: string): JQuery;\n    attr(attrName: string): string;\n}\ndeclare var $: {\n    (el: HTMLElement): JQuery;\n    (selector: string): JQuery;\n    (readyCallback: () => void ): JQuery;\n};\ndeclare var _: {\n    each<T, U>(arr: T[], f: (elem: T) => U): U[];\n    delay(f: Function, wait: number, ...arguments: any[]): number;\n    template(template: string): (model: any) => string;\n    bindAll(object: any, ...methodNames: string[]): void;\n};\ndeclare var Store: any;\n\n\n// Todo Model\n// ----------\n\n\n// Create our global collection of **Todos**.\nvar Todos = new TodoList();\n\n// Todo Item View\n// --------------\n\n// The DOM element for a todo item...\nclass TodoView extends Backbone.View {\n\n    // The TodoView listens for changes to its model, re-rendering. Since there's\n    // a one-to-one correspondence between a **Todo** and a **TodoView** in this\n    // app, we set a direct reference on the model for convenience.\n    template: (data: any) => string;\n\n    // A TodoView model must be a Todo, redeclare with specific type\n    model: Todo;\n    input: JQuery;\n\n    constructor (options? ) {\n        //... is a list tag.\n        this.tagName = \"li\";\n\n        // The DOM events specific to an item.\n        this.events = {\n            \"click .check\": \"toggleDone\",\n            \"dblclick label.todo-content\": \"edit\",\n            \"click span.todo-destroy\": \"clear\",\n            \"keypress .todo-input\": \"updateOnEnter\",\n            \"blur .todo-input\": \"close\"\n        };\n\n        super(options);\n\n        // Cache the template function for a single item.\n        this.template = _.template($('#item-template').html());\n\n        _.bindAll(this, 'render', 'close', 'remove');\n        this.model.bind('change', this.render);\n        this.model.bind('destroy', this.remove);\n    }\n\n    // Re-render the contents of the todo item.\n    render() {\n        this.$el.html(this.template(this.model.toJSON()));\n        this.input = this.$('.todo-input');\n        return this;\n    }\n\n    // Toggle the `\"done\"` state of the model.\n    toggleDone() {\n        this.model.toggle();\n    }\n\n    // Switch this view into `\"editing\"` mode, displaying the input field.\n    edit() {\n        this.$el.addClass(\"editing\");\n        this.input.focus();\n    }\n\n    // Close the `\"editing\"` mode, saving changes to the todo.\n    close() {\n        this.model.save({ content: this.input.val() });\n        this.$el.removeClass(\"editing\");\n    }\n\n    // If you hit `enter`, we're through editing the item.\n    updateOnEnter(e) {\n        if (e.keyCode == 13) close();\n    }\n\n    // Remove the item, destroy the model.\n    clear() {\n        this.model.clear();\n    }\n\n}\n\n// The Application\n// ---------------\n\n// Our overall **AppView** is the top-level piece of UI.\nclass AppView extends Backbone.View {\n\n    // Delegated events for creating new items, and clearing completed ones.\n    events = {\n        \"keypress #new-todo\": \"createOnEnter\",\n        \"keyup #new-todo\": \"showTooltip\",\n        \"click .todo-clear a\": \"clearCompleted\",\n        \"click .mark-all-done\": \"toggleAllComplete\"\n    };\n\n    input: JQuery;\n    allCheckbox: HTMLInputElement;\n    statsTemplate: (params: any) => string;\n\n    constructor () {\n        super();\n        // Instead of generating a new element, bind to the existing skeleton of\n        // the App already present in the HTML.\n        this.setElement($(\"#todoapp\"), true);\n\n        // At initialization we bind to the relevant events on the `Todos`\n        // collection, when items are added or changed. Kick things off by\n        // loading any preexisting todos that might be saved in *localStorage*.\n        _.bindAll(this, 'addOne', 'addAll', 'render', 'toggleAllComplete');\n\n        this.input = this.$(\"#new-todo\");\n        this.allCheckbox = this.$(\".mark-total-done\")[0];\n        this.statsTemplate = _.template($('#stats-template').html());\n\n        Todos.bind('add', this.addOne);\n        Todos.bind('reset', this.addAll);\n        Todos.bind('all', this.render);\n\n        Todos.fetch();\n    }\n\n    // Re-rendering the App just means refreshing the statistics -- the rest\n    // of the app doesn't change.\n    render() {\n        var done = Todos.done().length;\n        var remaining = Todos.remaining().length;\n\n        this.$('#todo-stats').html(this.statsTemplate({\n            total: Todos.length,\n            done: done,\n            remaining: remaining\n        }));\n\n        this.allCheckbox.checked = !remaining;\n    }\n\n    // Add a single todo item to the list by creating a view for it, and\n    // appending its element to the `<ul>`.\n    addOne(todo) {\n        var view = new TodoView({ model: todo });\n        this.$(\"#todo-list\").append(view.render().el);\n    }\n\n    // Add total items in the **Todos** collection at once.\n    addAll() {\n        Todos.each(this.addOne);\n    }\n\n    // Generate the attributes for a new Todo item.\n    newAttributes() {\n        return {\n            content: this.input.val(),\n            order: Todos.nextOrder(),\n            done: false\n        };\n    }\n\n    // If you hit return in the main input field, create new **Todo** model,\n    // persisting it to *localStorage*.\n    createOnEnter(e) {\n        if (e.keyCode != 13) return;\n        Todos.create(this.newAttributes());\n        this.input.val('');\n    }\n\n    // Clear total done todo items, destroying their models.\n    clearCompleted() {\n        _.each(Todos.done(), todo => todo.clear());\n        return false;\n    }\n\n    tooltipTimeout: number = null;\n    // Lazily show the tooltip that tells you to press `enter` to save\n    // a new todo item, after one second.\n    showTooltip(e) {\n        var tooltip = $(\".ui-tooltip-top\");\n        var val = this.input.val();\n        tooltip.fadeOut();\n        if (this.tooltipTimeout) clearTimeout(this.tooltipTimeout);\n        if (val == '' || val == this.input.attr('placeholder')) return;\n        this.tooltipTimeout = _.delay(() => tooltip.show().fadeIn(), 1000);\n    }\n\n    toggleAllComplete() {\n        var done = this.allCheckbox.checked;\n        Todos.each(todo => todo.save({ 'done': done }));\n    }\n\n}\n\n// Load the application once the DOM is ready, using `jQuery.ready`:\n$(() => {\n    // Finally, we kick things off by creating the **App**.\n    new AppView();\n});",
+      "tokens": 0,
+      "firstFile": {
+        "name": "fixtures/javascript/file1.mts",
+        "start": 1,
+        "end": 263,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 263,
+          "column": 2,
+          "position": 2125
+        }
+      },
+      "secondFile": {
+        "name": "fixtures/javascript/file2.ts",
+        "start": 48,
+        "end": 376,
+        "startLoc": {
+          "line": 48,
+          "column": 1,
+          "position": 16
+        },
+        "endLoc": {
+          "line": 376,
+          "column": 2,
+          "position": 2510
         }
       }
     },
@@ -2999,11 +3852,13 @@
         "end": 24,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 24,
-          "column": 2
+          "column": 2,
+          "position": 154
         }
       },
       "secondFile": {
@@ -3012,11 +3867,49 @@
         "end": 27,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 27,
-          "column": 2
+          "column": 2,
+          "position": 157
+        }
+      }
+    },
+    {
+      "format": "typescript",
+      "lines": 263,
+      "fragment": "declare module Backbone {\n    export class Model {\n        constructor (attr? , opts? );\n        get(name: string): any;\n        set(name: string, val: any): void;\n        set(obj: any): void;\n        save(attr? , opts? ): void;\n        destroy(): void;\n        bind(ev: string, f: Function, ctx?: any): void;\n        toJSON(): any;\n    }\n    export class Collection<T> {\n        constructor (models? , opts? );\n        bind(ev: string, f: Function, ctx?: any): void;\n        length: number;\n        create(attrs, opts? ): any;\n        each(f: (elem: T) => void ): void;\n        fetch(opts?: any): void;\n        last(): T;\n        last(n: number): T[];\n        filter(f: (elem: T) => boolean): T[];\n        without(...values: T[]): T[];\n    }\n    export class View {\n        constructor (options? );\n        $(selector: string): JQuery;\n        el: HTMLElement;\n        $el: JQuery;\n        model: Model;\n        remove(): void;\n        delegateEvents: any;\n        make(tagName: string, attrs? , opts? ): View;\n        setElement(element: HTMLElement, delegate?: boolean): void;\n        setElement(element: JQuery, delegate?: boolean): void;\n        tagName: string;\n        events: any;\n\n        static extend: any;\n    }\n}\ninterface JQuery {\n    fadeIn(): JQuery;\n    fadeOut(): JQuery;\n    focus(): JQuery;\n    html(): string;\n    html(val: string): JQuery;\n    show(): JQuery;\n    addClass(className: string): JQuery;\n    removeClass(className: string): JQuery;\n    append(el: HTMLElement): JQuery;\n    val(): string;\n    val(value: string): JQuery;\n    attr(attrName: string): string;\n}\ndeclare var $: {\n    (el: HTMLElement): JQuery;\n    (selector: string): JQuery;\n    (readyCallback: () => void ): JQuery;\n};\ndeclare var _: {\n    each<T, U>(arr: T[], f: (elem: T) => U): U[];\n    delay(f: Function, wait: number, ...arguments: any[]): number;\n    template(template: string): (model: any) => string;\n    bindAll(object: any, ...methodNames: string[]): void;\n};\ndeclare var Store: any;\n\n\n// Todo Model\n// ----------\n\n\n// Create our global collection of **Todos**.\nvar Todos = new TodoList();\n\n// Todo Item View\n// --------------\n\n// The DOM element for a todo item...\nclass TodoView extends Backbone.View {\n\n    // The TodoView listens for changes to its model, re-rendering. Since there's\n    // a one-to-one correspondence between a **Todo** and a **TodoView** in this\n    // app, we set a direct reference on the model for convenience.\n    template: (data: any) => string;\n\n    // A TodoView model must be a Todo, redeclare with specific type\n    model: Todo;\n    input: JQuery;\n\n    constructor (options? ) {\n        //... is a list tag.\n        this.tagName = \"li\";\n\n        // The DOM events specific to an item.\n        this.events = {\n            \"click .check\": \"toggleDone\",\n            \"dblclick label.todo-content\": \"edit\",\n            \"click span.todo-destroy\": \"clear\",\n            \"keypress .todo-input\": \"updateOnEnter\",\n            \"blur .todo-input\": \"close\"\n        };\n\n        super(options);\n\n        // Cache the template function for a single item.\n        this.template = _.template($('#item-template').html());\n\n        _.bindAll(this, 'render', 'close', 'remove');\n        this.model.bind('change', this.render);\n        this.model.bind('destroy', this.remove);\n    }\n\n    // Re-render the contents of the todo item.\n    render() {\n        this.$el.html(this.template(this.model.toJSON()));\n        this.input = this.$('.todo-input');\n        return this;\n    }\n\n    // Toggle the `\"done\"` state of the model.\n    toggleDone() {\n        this.model.toggle();\n    }\n\n    // Switch this view into `\"editing\"` mode, displaying the input field.\n    edit() {\n        this.$el.addClass(\"editing\");\n        this.input.focus();\n    }\n\n    // Close the `\"editing\"` mode, saving changes to the todo.\n    close() {\n        this.model.save({ content: this.input.val() });\n        this.$el.removeClass(\"editing\");\n    }\n\n    // If you hit `enter`, we're through editing the item.\n    updateOnEnter(e) {\n        if (e.keyCode == 13) close();\n    }\n\n    // Remove the item, destroy the model.\n    clear() {\n        this.model.clear();\n    }\n\n}\n\n// The Application\n// ---------------\n\n// Our overall **AppView** is the top-level piece of UI.\nclass AppView extends Backbone.View {\n\n    // Delegated events for creating new items, and clearing completed ones.\n    events = {\n        \"keypress #new-todo\": \"createOnEnter\",\n        \"keyup #new-todo\": \"showTooltip\",\n        \"click .todo-clear a\": \"clearCompleted\",\n        \"click .mark-all-done\": \"toggleAllComplete\"\n    };\n\n    input: JQuery;\n    allCheckbox: HTMLInputElement;\n    statsTemplate: (params: any) => string;\n\n    constructor () {\n        super();\n        // Instead of generating a new element, bind to the existing skeleton of\n        // the App already present in the HTML.\n        this.setElement($(\"#todoapp\"), true);\n\n        // At initialization we bind to the relevant events on the `Todos`\n        // collection, when items are added or changed. Kick things off by\n        // loading any preexisting todos that might be saved in *localStorage*.\n        _.bindAll(this, 'addOne', 'addAll', 'render', 'toggleAllComplete');\n\n        this.input = this.$(\"#new-todo\");\n        this.allCheckbox = this.$(\".mark-total-done\")[0];\n        this.statsTemplate = _.template($('#stats-template').html());\n\n        Todos.bind('add', this.addOne);\n        Todos.bind('reset', this.addAll);\n        Todos.bind('all', this.render);\n\n        Todos.fetch();\n    }\n\n    // Re-rendering the App just means refreshing the statistics -- the rest\n    // of the app doesn't change.\n    render() {\n        var done = Todos.done().length;\n        var remaining = Todos.remaining().length;\n\n        this.$('#todo-stats').html(this.statsTemplate({\n            total: Todos.length,\n            done: done,\n            remaining: remaining\n        }));\n\n        this.allCheckbox.checked = !remaining;\n    }\n\n    // Add a single todo item to the list by creating a view for it, and\n    // appending its element to the `<ul>`.\n    addOne(todo) {\n        var view = new TodoView({ model: todo });\n        this.$(\"#todo-list\").append(view.render().el);\n    }\n\n    // Add total items in the **Todos** collection at once.\n    addAll() {\n        Todos.each(this.addOne);\n    }\n\n    // Generate the attributes for a new Todo item.\n    newAttributes() {\n        return {\n            content: this.input.val(),\n            order: Todos.nextOrder(),\n            done: false\n        };\n    }\n\n    // If you hit return in the main input field, create new **Todo** model,\n    // persisting it to *localStorage*.\n    createOnEnter(e) {\n        if (e.keyCode != 13) return;\n        Todos.create(this.newAttributes());\n        this.input.val('');\n    }\n\n    // Clear total done todo items, destroying their models.\n    clearCompleted() {\n        _.each(Todos.done(), todo => todo.clear());\n        return false;\n    }\n\n    tooltipTimeout: number = null;\n    // Lazily show the tooltip that tells you to press `enter` to save\n    // a new todo item, after one second.\n    showTooltip(e) {\n        var tooltip = $(\".ui-tooltip-top\");\n        var val = this.input.val();\n        tooltip.fadeOut();\n        if (this.tooltipTimeout) clearTimeout(this.tooltipTimeout);\n        if (val == '' || val == this.input.attr('placeholder')) return;\n        this.tooltipTimeout = _.delay(() => tooltip.show().fadeIn(), 1000);\n    }\n\n    toggleAllComplete() {\n        var done = this.allCheckbox.checked;\n        Todos.each(todo => todo.save({ 'done': done }));\n    }\n\n}\n\n// Load the application once the DOM is ready, using `jQuery.ready`:\n$(() => {\n    // Finally, we kick things off by creating the **App**.\n    new AppView();\n});",
+      "tokens": 0,
+      "firstFile": {
+        "name": "fixtures/javascript/file1.cts",
+        "start": 1,
+        "end": 263,
+        "startLoc": {
+          "line": 1,
+          "column": 1,
+          "position": 0
+        },
+        "endLoc": {
+          "line": 263,
+          "column": 2,
+          "position": 2125
+        }
+      },
+      "secondFile": {
+        "name": "fixtures/javascript/file2.ts",
+        "start": 48,
+        "end": 376,
+        "startLoc": {
+          "line": 48,
+          "column": 1,
+          "position": 16
+        },
+        "endLoc": {
+          "line": 376,
+          "column": 2,
+          "position": 2510
         }
       }
     },
@@ -3031,11 +3924,13 @@
         "end": 61,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 61,
-          "column": 35
+          "column": 8,
+          "position": 553
         }
       },
       "secondFile": {
@@ -3044,11 +3939,13 @@
         "end": 61,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 61,
-          "column": 35
+          "column": 8,
+          "position": 553
         }
       }
     },
@@ -3063,11 +3960,13 @@
         "end": 24,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 24,
-          "column": 7
+          "column": 2,
+          "position": 172
         }
       },
       "secondFile": {
@@ -3076,43 +3975,49 @@
         "end": 24,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 24,
-          "column": 7
+          "column": 2,
+          "position": 172
         }
       }
     },
     {
       "format": "markup",
-      "lines": 15,
-      "fragment": "<!doctype html>\n<html lang=\"en\">\n<head>\n    <meta charset=\"UTF-8\">\n    <meta name=\"viewport\"\n          content=\"width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0\">\n    <meta http-equiv=\"X-UA-Compatible\" content=\"ie=edge\">\n    <title>Document</title>\n</head>\n<body>\n<div>\n    <h1>Test File</h1>\n    <p>Ololo</p>\n</div>\n</",
+      "lines": 16,
+      "fragment": "<!doctype html>\n<html lang=\"en\">\n<head>\n    <meta charset=\"UTF-8\">\n    <meta name=\"viewport\"\n          content=\"width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0\">\n    <meta http-equiv=\"X-UA-Compatible\" content=\"ie=edge\">\n    <title>Document</title>\n</head>\n<body>\n<div>\n    <script>alert('test')</script>\n    <h1>Test File</h1>\n    <p>Ololo</p>\n</div>\n</",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/htmlmixed/file1.html",
         "start": 1,
-        "end": 15,
+        "end": 16,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
-          "line": 15,
-          "column": 3
+          "line": 16,
+          "column": 3,
+          "position": 115
         }
       },
       "secondFile": {
         "name": "fixtures/htmlmixed/file2.html",
         "start": 1,
-        "end": 15,
+        "end": 16,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
-          "line": 15,
-          "column": 19
+          "line": 16,
+          "column": 19,
+          "position": 115
         }
       }
     },
@@ -3127,11 +4032,13 @@
         "end": 24,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 24,
-          "column": 7
+          "column": 2,
+          "position": 172
         }
       },
       "secondFile": {
@@ -3140,11 +4047,13 @@
         "end": 24,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 24,
-          "column": 7
+          "column": 2,
+          "position": 172
         }
       }
     },
@@ -3159,11 +4068,13 @@
         "end": 14,
         "startLoc": {
           "line": 3,
-          "column": 1
+          "column": 1,
+          "position": 16
         },
         "endLoc": {
           "line": 14,
-          "column": 10
+          "column": 5,
+          "position": 90
         }
       },
       "secondFile": {
@@ -3172,11 +4083,13 @@
         "end": 12,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 12,
-          "column": 10
+          "column": 5,
+          "position": 74
         }
       }
     },
@@ -3191,11 +4104,13 @@
         "end": 47,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 47,
-          "column": 18
+          "column": 9,
+          "position": 357
         }
       },
       "secondFile": {
@@ -3204,11 +4119,13 @@
         "end": 47,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 47,
-          "column": 13
+          "column": 4,
+          "position": 357
         }
       }
     },
@@ -3223,11 +4140,13 @@
         "end": 103,
         "startLoc": {
           "line": 47,
-          "column": 3
+          "column": 3,
+          "position": 355
         },
         "endLoc": {
           "line": 103,
-          "column": 2
+          "column": 2,
+          "position": 792
         }
       },
       "secondFile": {
@@ -3236,11 +4155,13 @@
         "end": 62,
         "startLoc": {
           "line": 6,
-          "column": 3
+          "column": 3,
+          "position": 29
         },
         "endLoc": {
           "line": 62,
-          "column": 2
+          "column": 2,
+          "position": 466
         }
       }
     },
@@ -3255,11 +4176,13 @@
         "end": 175,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 175,
-          "column": 32
+          "column": 32,
+          "position": 1354
         }
       },
       "secondFile": {
@@ -3268,11 +4191,13 @@
         "end": 175,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 175,
-          "column": 60
+          "column": 60,
+          "position": 1354
         }
       }
     },
@@ -3287,11 +4212,13 @@
         "end": 204,
         "startLoc": {
           "line": 190,
-          "column": 1
+          "column": 1,
+          "position": 1504
         },
         "endLoc": {
           "line": 204,
-          "column": 33
+          "column": 16,
+          "position": 1675
         }
       },
       "secondFile": {
@@ -3300,11 +4227,13 @@
         "end": 189,
         "startLoc": {
           "line": 175,
-          "column": 1
+          "column": 1,
+          "position": 1354
         },
         "endLoc": {
           "line": 189,
-          "column": 33
+          "column": 16,
+          "position": 1525
         }
       }
     },
@@ -3319,11 +4248,13 @@
         "end": 30,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 30,
-          "column": 13
+          "column": 8,
+          "position": 212
         }
       },
       "secondFile": {
@@ -3332,11 +4263,13 @@
         "end": 31,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 31,
-          "column": 10
+          "column": 5,
+          "position": 213
         }
       }
     },
@@ -3351,11 +4284,13 @@
         "end": 56,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 56,
-          "column": 3
+          "column": 2,
+          "position": 558
         }
       },
       "secondFile": {
@@ -3364,11 +4299,13 @@
         "end": 52,
         "startLoc": {
           "line": 25,
-          "column": 1
+          "column": 1,
+          "position": 288
         },
         "endLoc": {
           "line": 52,
-          "column": 3
+          "column": 2,
+          "position": 566
         }
       }
     },
@@ -3383,24 +4320,28 @@
         "end": 55,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 55,
-          "column": 3
+          "column": 2,
+          "position": 568
         }
       },
       "secondFile": {
-        "name": "fixtures/javascript/file_1.js",
+        "name": "fixtures/javascript/file_1.mjs",
         "start": 1,
         "end": 52,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 52,
-          "column": 3
+          "column": 2,
+          "position": 566
         }
       }
     },
@@ -3415,11 +4356,13 @@
         "end": 28,
         "startLoc": {
           "line": 18,
-          "column": 3
+          "column": 3,
+          "position": 131
         },
         "endLoc": {
           "line": 28,
-          "column": 9
+          "column": 7,
+          "position": 238
         }
       },
       "secondFile": {
@@ -3428,11 +4371,13 @@
         "end": 18,
         "startLoc": {
           "line": 8,
-          "column": 3
+          "column": 3,
+          "position": 24
         },
         "endLoc": {
           "line": 18,
-          "column": 8
+          "column": 6,
+          "position": 131
         }
       }
     },
@@ -3447,11 +4392,13 @@
         "end": 121,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 121,
-          "column": 7
+          "column": 2,
+          "position": 919
         }
       },
       "secondFile": {
@@ -3460,11 +4407,13 @@
         "end": 121,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 121,
-          "column": 7
+          "column": 2,
+          "position": 919
         }
       }
     },
@@ -3479,11 +4428,13 @@
         "end": 91,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 91,
-          "column": 21
+          "column": 19,
+          "position": 658
         }
       },
       "secondFile": {
@@ -3492,11 +4443,13 @@
         "end": 91,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 91,
-          "column": 13
+          "column": 11,
+          "position": 658
         }
       }
     },
@@ -3511,11 +4464,13 @@
         "end": 148,
         "startLoc": {
           "line": 118,
-          "column": 15
+          "column": 2,
+          "position": 878
         },
         "endLoc": {
           "line": 148,
-          "column": 2
+          "column": 2,
+          "position": 1082
         }
       },
       "secondFile": {
@@ -3524,11 +4479,13 @@
         "end": 118,
         "startLoc": {
           "line": 88,
-          "column": 6
+          "column": 2,
+          "position": 650
         },
         "endLoc": {
           "line": 118,
-          "column": 2
+          "column": 2,
+          "position": 854
         }
       }
     },
@@ -3543,11 +4500,13 @@
         "end": 169,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 169,
-          "column": 6
+          "column": 2,
+          "position": 1448
         }
       },
       "secondFile": {
@@ -3556,11 +4515,13 @@
         "end": 169,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 169,
-          "column": 6
+          "column": 2,
+          "position": 1448
         }
       }
     },
@@ -3575,11 +4536,13 @@
         "end": 20,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 20,
-          "column": 10
+          "column": 6,
+          "position": 180
         }
       },
       "secondFile": {
@@ -3588,11 +4551,13 @@
         "end": 20,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 20,
-          "column": 2
+          "column": 2,
+          "position": 179
         }
       }
     },
@@ -3607,11 +4572,13 @@
         "end": 20,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 20,
-          "column": 10
+          "column": 6,
+          "position": 181
         }
       },
       "secondFile": {
@@ -3620,11 +4587,13 @@
         "end": 20,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 20,
-          "column": 2
+          "column": 2,
+          "position": 180
         }
       }
     },
@@ -3639,11 +4608,13 @@
         "end": 36,
         "startLoc": {
           "line": 24,
-          "column": 5
+          "column": 5,
+          "position": 231
         },
         "endLoc": {
           "line": 36,
-          "column": 2
+          "column": 2,
+          "position": 338
         }
       },
       "secondFile": {
@@ -3652,11 +4623,13 @@
         "end": 25,
         "startLoc": {
           "line": 14,
-          "column": 35
+          "column": 2,
+          "position": 127
         },
         "endLoc": {
           "line": 25,
-          "column": 2
+          "column": 2,
+          "position": 233
         }
       }
     },
@@ -3671,11 +4644,13 @@
         "end": 25,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 25,
-          "column": 2
+          "column": 2,
+          "position": 228
         }
       },
       "secondFile": {
@@ -3684,11 +4659,13 @@
         "end": 25,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 25,
-          "column": 2
+          "column": 2,
+          "position": 228
         }
       }
     },
@@ -3703,11 +4680,13 @@
         "end": 13,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 13,
-          "column": 22
+          "column": 6,
+          "position": 108
         }
       },
       "secondFile": {
@@ -3716,11 +4695,13 @@
         "end": 15,
         "startLoc": {
           "line": 3,
-          "column": 1
+          "column": 1,
+          "position": 7
         },
         "endLoc": {
           "line": 15,
-          "column": 22
+          "column": 6,
+          "position": 115
         }
       }
     },
@@ -3735,11 +4716,13 @@
         "end": 77,
         "startLoc": {
           "line": 46,
-          "column": 1
+          "column": 1,
+          "position": 332
         },
         "endLoc": {
           "line": 77,
-          "column": 8
+          "column": 8,
+          "position": 553
         }
       },
       "secondFile": {
@@ -3748,18 +4731,20 @@
         "end": 46,
         "startLoc": {
           "line": 16,
-          "column": 1
+          "column": 1,
+          "position": 112
         },
         "endLoc": {
           "line": 46,
-          "column": 6
+          "column": 6,
+          "position": 332
         }
       }
     },
     {
       "format": "cpp-header",
       "lines": 22,
-      "fragment": "StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\nprivate",
+      "fragment": "(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(si",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/clike/file2.hpp",
@@ -3767,11 +4752,13 @@
         "end": 66,
         "startLoc": {
           "line": 45,
-          "column": 5
+          "column": 5,
+          "position": 455
         },
         "endLoc": {
           "line": 66,
-          "column": 8
+          "column": 8,
+          "position": 757
         }
       },
       "secondFile": {
@@ -3780,11 +4767,13 @@
         "end": 45,
         "startLoc": {
           "line": 24,
-          "column": 5
+          "column": 5,
+          "position": 152
         },
         "endLoc": {
           "line": 45,
-          "column": 11
+          "column": 7,
+          "position": 455
         }
       }
     },
@@ -3799,11 +4788,13 @@
         "end": 28,
         "startLoc": {
           "line": 18,
-          "column": 3
+          "column": 3,
+          "position": 131
         },
         "endLoc": {
           "line": 28,
-          "column": 9
+          "column": 7,
+          "position": 238
         }
       },
       "secondFile": {
@@ -3812,18 +4803,20 @@
         "end": 18,
         "startLoc": {
           "line": 8,
-          "column": 3
+          "column": 3,
+          "position": 24
         },
         "endLoc": {
           "line": 18,
-          "column": 8
+          "column": 6,
+          "position": 131
         }
       }
     },
     {
       "format": "cpp",
       "lines": 22,
-      "fragment": "StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\nprivate",
+      "fragment": "(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(si",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/clike/file2.cpp",
@@ -3831,11 +4824,13 @@
         "end": 66,
         "startLoc": {
           "line": 45,
-          "column": 5
+          "column": 5,
+          "position": 455
         },
         "endLoc": {
           "line": 66,
-          "column": 8
+          "column": 8,
+          "position": 757
         }
       },
       "secondFile": {
@@ -3844,11 +4839,13 @@
         "end": 45,
         "startLoc": {
           "line": 24,
-          "column": 5
+          "column": 5,
+          "position": 152
         },
         "endLoc": {
           "line": 45,
-          "column": 11
+          "column": 7,
+          "position": 455
         }
       }
     },
@@ -3863,11 +4860,13 @@
         "end": 29,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 29,
-          "column": 2
+          "column": 2,
+          "position": 243
         }
       },
       "secondFile": {
@@ -3876,11 +4875,13 @@
         "end": 29,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 29,
-          "column": 2
+          "column": 2,
+          "position": 243
         }
       }
     },
@@ -3895,11 +4896,13 @@
         "end": 29,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 29,
-          "column": 2
+          "column": 2,
+          "position": 97
         }
       },
       "secondFile": {
@@ -3908,11 +4911,13 @@
         "end": 29,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 29,
-          "column": 2
+          "column": 2,
+          "position": 97
         }
       }
     },
@@ -3927,11 +4932,13 @@
         "end": 191,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 191,
-          "column": 6
+          "column": 6,
+          "position": 635
         }
       },
       "secondFile": {
@@ -3940,11 +4947,13 @@
         "end": 191,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 191,
-          "column": 6
+          "column": 6,
+          "position": 635
         }
       }
     },
@@ -3959,11 +4968,13 @@
         "end": 221,
         "startLoc": {
           "line": 182,
-          "column": 51
+          "column": 15,
+          "position": 626
         },
         "endLoc": {
           "line": 221,
-          "column": 2
+          "column": 2,
+          "position": 795
         }
       },
       "secondFile": {
@@ -3972,18 +4983,20 @@
         "end": 233,
         "startLoc": {
           "line": 194,
-          "column": 52
+          "column": 16,
+          "position": 682
         },
         "endLoc": {
           "line": 233,
-          "column": 2
+          "column": 2,
+          "position": 851
         }
       }
     },
     {
       "format": "cpp-header",
       "lines": 73,
-      "fragment": "class StrVec\n{\n    friend bool operator==(const StrVec&, const StrVec&);\n    friend bool operator!=(const StrVec&, const StrVec&);\n    friend bool operator< (const StrVec&, const StrVec&);\n    friend bool operator> (const StrVec&, const StrVec&);\n    friend bool operator<=(const StrVec&, const StrVec&);\n    friend bool operator>=(const StrVec&, const StrVec&);\n\npublic:\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\nprivate:\n    std::pair<std::string*, std::string*> alloc_n_copy(const std::string*, const std::string*);\n    void free();\n    void chk_n_alloc() { if (size() == capacity()) reallocate(); }\n    void reallocate();\n    void alloc_n_move(size_t new_cap);\n    void range_initialize(const std::string*, const std::string*);\n\nprivate:\n    std::string *elements;\n    std::string *first_free;\n    std::string *cap;\n    std::allocator<std::string> alloc;\n};\n\nbool operator==(const StrVec&, const StrVec&);\nbool operator!=(const StrVec&, const StrVec&);\nbool operator< (const StrVec&, const StrVec&);\nbool operator> (const StrVec&, const StrVec&);\nbool operator<=(const StrVec&, const StrVec&);\nbool operator>=(const StrVec&, const StrVec&);",
+      "fragment": "TRVEC_H_\n#define CP5_STRVEC_H_\n\n#include <memory>\n#include <string>\n#include <initializer_list>\n\n#ifndef _MSC_VER\n#define NOEXCEPT noexcept\n#else\n#define NOEXCEPT\n#endif\n\nclass StrVec\n{\n    friend bool operator==(const StrVec&, const StrVec&);\n    friend bool operator!=(const StrVec&, const StrVec&);\n    friend bool operator< (const StrVec&, const StrVec&);\n    friend bool operator> (const StrVec&, const StrVec&);\n    friend bool operator<=(const StrVec&, const StrVec&);\n    friend bool operator>=(const StrVec&, const StrVec&);\n\npublic:\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\nprivate:\n    std::pair<std::string*, std::string*> alloc_n_copy(const std::string*, const std::string*);\n    void free();\n    void chk_n_alloc() { if (size() == capacity()) reallocate(); }\n    void reallocate();\n    void alloc_n_move(size_t new_cap);\n    void range_initialize(const std::string*, const std::string*);\n\nprivate:\n    std::string *elements;\n    std::string *first_free;\n    std::string *cap;\n    std::allocator<std::string> alloc;\n};\n\nbool operator==(const StrVec&, const StrVec&);\nbool operator!=(const StrVec&, const StrVec&);\nbool operator< (",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/clike/file1.hpp",
@@ -3991,11 +5004,13 @@
         "end": 86,
         "startLoc": {
           "line": 14,
-          "column": 1
+          "column": 1,
+          "position": 13
         },
         "endLoc": {
           "line": 86,
-          "column": 47
+          "column": 2,
+          "position": 1031
         }
       },
       "secondFile": {
@@ -4004,11 +5019,13 @@
         "end": 86,
         "startLoc": {
           "line": 14,
-          "column": 1
+          "column": 1,
+          "position": 13
         },
         "endLoc": {
           "line": 86,
-          "column": 47
+          "column": 2,
+          "position": 1031
         }
       }
     },
@@ -4023,11 +5040,13 @@
         "end": 19,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 19,
-          "column": 2
+          "column": 2,
+          "position": 136
         }
       },
       "secondFile": {
@@ -4036,18 +5055,20 @@
         "end": 29,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 29,
-          "column": 2
+          "column": 2,
+          "position": 243
         }
       }
     },
     {
       "format": "csharp",
       "lines": 95,
-      "fragment": "// ***********************************************************************\n// Copyright (c) 2008-2013 Charlie Poole\n//\n// Permission is hereby granted, free of charge, to any person obtaining\n// a copy of this software and associated documentation files (the\n// \"Software\"), to deal in the Software without restriction, including\n// without limitation the rights to use, copy, modify, merge, publish,\n// distribute, sublicense, and/or sell copies of the Software, and to\n// permit persons to whom the Software is furnished to do so, subject to\n// the following conditions:\n//\n// The above copyright notice and this permission notice shall be\n// included in all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\n// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\n// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n// ***********************************************************************\n\nusing System;\nusing System.IO;\n\n#if NUNIT_ENGINE\nnamespace NUnit.Engine.Internal\n#elif NUNIT_FRAMEWORK\nnamespace NUnit.Framework.Internal\n#else\nnamespace NUnit.Common\n#endif\n{\n    /// <summary>\n    /// Provides internal logging to the NUnit framework\n    /// </summary>\n    public class Logger : ILogger\n    {\n        private readonly static string TIME_FMT = \"HH:mm:ss.fff\";\n        private readonly static string TRACE_FMT = \"{0} {1,-5} [{2,2}] {3}: {4}\";\n\n        private string name;\n        private string fullname;\n        private InternalTraceLevel maxLevel;\n        private TextWriter writer;\n\n        /// <summary>\n        /// Initializes a new instance of the <see cref=\"Logger\"/> class.\n        /// </summary>\n        /// <param name=\"name\">The name.</param>\n        /// <param name=\"level\">The log level.</param>\n        /// <param name=\"writer\">The writer where logs are sent.</param>\n        public Logger(string name, InternalTraceLevel level, TextWriter writer)\n        {\n            this.maxLevel = level;\n            this.writer = writer;\n            this.fullname = this.name = name;\n            int index = fullname.LastIndexOf('.');\n            if (index >= 0)\n                this.name = fullname.Substring(index + 1);\n        }\n\n        #region Error\n        /// <summary>\n        /// Logs the message at error level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        public void Error(string message)\n        {\n            Log(InternalTraceLevel.Error, message);\n        }\n\n        /// <summary>\n        /// Logs the message at error level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        /// <param name=\"args\">The message arguments.</param>\n        public void Error(string message, params object[] args)\n        {\n            Log(InternalTraceLevel.Error, message, args);\n        }\n\n        //public void Error(string message, Exception ex)\n        //{\n        //    if (service.Level >= InternalTraceLevel.Error)\n        //    {\n        //        service.Log(InternalTraceLevel.Error, message, name, ex);\n        //    }\n        //}\n        #endregion\n\n        #region Warning\n        /// <summary>\n        /// Logs the message at warm level.",
+      "fragment": "// ***********************************************************************\n// Copyright (c) 2008-2013 Charlie Poole\n//\n// Permission is hereby granted, free of charge, to any person obtaining\n// a copy of this software and associated documentation files (the\n// \"Software\"), to deal in the Software without restriction, including\n// without limitation the rights to use, copy, modify, merge, publish,\n// distribute, sublicense, and/or sell copies of the Software, and to\n// permit persons to whom the Software is furnished to do so, subject to\n// the following conditions:\n//\n// The above copyright notice and this permission notice shall be\n// included in all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\n// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\n// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n// ***********************************************************************\n\nusing System;\nusing System.IO;\n\n#if NUNIT_ENGINE\nnamespace NUnit.Engine.Internal\n#elif NUNIT_FRAMEWORK\nnamespace NUnit.Framework.Internal\n#else\nnamespace NUnit.Common\n#endif\n{\n    /// <summary>\n    /// Provides internal logging to the NUnit framework\n    /// </summary>\n    public class Logger : ILogger\n    {\n        private readonly static string TIME_FMT = \"HH:mm:ss.fff\";\n        private readonly static string TRACE_FMT = \"{0} {1,-5} [{2,2}] {3}: {4}\";\n\n        private string name;\n        private string fullname;\n        private InternalTraceLevel maxLevel;\n        private TextWriter writer;\n\n        /// <summary>\n        /// Initializes a new instance of the <see cref=\"Logger\"/> class.\n        /// </summary>\n        /// <param name=\"name\">The name.</param>\n        /// <param name=\"level\">The log level.</param>\n        /// <param name=\"writer\">The writer where logs are sent.</param>\n        public Logger(string name, InternalTraceLevel level, TextWriter writer)\n        {\n            this.maxLevel = level;\n            this.writer = writer;\n            this.fullname = this.name = name;\n            int index = fullname.LastIndexOf('.');\n            if (index >= 0)\n                this.name = fullname.Substring(index + 1);\n        }\n\n        #region Error\n        /// <summary>\n        /// Logs the message at error level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        public void Error(string message)\n        {\n            Log(InternalTraceLevel.Error, message);\n        }\n\n        /// <summary>\n        /// Logs the message at error level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        /// <param name=\"args\">The message arguments.</param>\n        public void Error(string message, params object[] args)\n        {\n            Log(InternalTraceLevel.Error, message, args);\n        }\n\n        //public void Error(string message, Exception ex)\n        //{\n        //    if (service.Level >= InternalTraceLevel.Error)\n        //    {\n        //        service.Log(InternalTraceLevel.Error, message, name, ex);\n        //    }\n        //}\n        #endregion\n\n   ",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/clike/file1.cs",
@@ -4055,11 +5076,13 @@
         "end": 95,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 95,
-          "column": 44
+          "column": 36,
+          "position": 434
         }
       },
       "secondFile": {
@@ -4068,18 +5091,20 @@
         "end": 94,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 94,
-          "column": 47
+          "column": 39,
+          "position": 432
         }
       }
     },
     {
       "format": "csharp",
       "lines": 83,
-      "fragment": "/// <summary>\n        /// Logs the message at warning level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        /// <param name=\"args\">The message arguments.</param>\n        public void Warning(string message, params object[] args)\n        {\n            Log(InternalTraceLevel.Warning, message, args);\n        }\n        #endregion\n\n        #region Info\n        /// <summary>\n        /// Logs the message at info level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        public void Info(string message)\n        {\n            Log(InternalTraceLevel.Info, message);\n        }\n\n        /// <summary>\n        /// Logs the message at info level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        /// <param name=\"args\">The message arguments.</param>\n        public void Info(string message, params object[] args)\n        {\n            Log(InternalTraceLevel.Info, message, args);\n        }\n        #endregion\n\n        #region Debug\n        /// <summary>\n        /// Logs the message at debug level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        public void Debug(string message)\n        {\n            Log(InternalTraceLevel.Verbose, message);\n        }\n\n        /// <summary>\n        /// Logs the message at debug level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        /// <param name=\"args\">The message arguments.</param>\n        public void Debug(string message, params object[] args)\n        {\n            Log(InternalTraceLevel.Verbose, message, args);\n        }\n        #endregion\n\n        #region Helper Methods\n        private void Log(InternalTraceLevel level, string message)\n        {\n            if (writer != null && this.maxLevel >= level)\n                WriteLog(level, message);\n        }\n\n        private void Log(InternalTraceLevel level, string format, params object[] args)\n        {\n            if (this.maxLevel >= level)\n                WriteLog(level, string.Format( format, args ) );\n        }\n\n        private void WriteLog(InternalTraceLevel level, string message)\n        {\n            writer.WriteLine(TRACE_FMT,\n                DateTime.Now.ToString(TIME_FMT),\n                level == InternalTraceLevel.Verbose ? \"Debug\" : level.ToString(),\n#if PORTABLE\n                System.Environment.CurrentManagedThreadId,\n#else\n                System.Threading.Thread.CurrentThread.ManagedThreadId,\n#endif\n                name,\n                message);\n        }\n\n#endregion\n    }\n}",
+      "fragment": "e)\n        {\n            Log(InternalTraceLevel.Warning, message);\n        }\n\n        /// <summary>\n        /// Logs the message at warning level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        /// <param name=\"args\">The message arguments.</param>\n        public void Warning(string message, params object[] args)\n        {\n            Log(InternalTraceLevel.Warning, message, args);\n        }\n        #endregion\n\n        #region Info\n        /// <summary>\n        /// Logs the message at info level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        public void Info(string message)\n        {\n            Log(InternalTraceLevel.Info, message);\n        }\n\n        /// <summary>\n        /// Logs the message at info level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        /// <param name=\"args\">The message arguments.</param>\n        public void Info(string message, params object[] args)\n        {\n            Log(InternalTraceLevel.Info, message, args);\n        }\n        #endregion\n\n        #region Debug\n        /// <summary>\n        /// Logs the message at debug level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        public void Debug(string message)\n        {\n            Log(InternalTraceLevel.Verbose, message);\n        }\n\n        /// <summary>\n        /// Logs the message at debug level.\n        /// </summary>\n        /// <param name=\"message\">The message.</param>\n        /// <param name=\"args\">The message arguments.</param>\n        public void Debug(string message, params object[] args)\n        {\n            Log(InternalTraceLevel.Verbose, message, args);\n        }\n        #endregion\n\n        #region Helper Methods\n        private void Log(InternalTraceLevel level, string message)\n        {\n            if (writer != null && this.maxLevel >= level)\n                WriteLog(level, message);\n        }\n\n        private void Log(InternalTraceLevel level, string format, params object[] args)\n        {\n            if (this.maxLevel >= level)\n                WriteLog(level, string.Format( format, args ) );\n        }\n\n        private void WriteLog(InternalTraceLevel level, string message)\n        {\n            writer.WriteLine(TRACE_FMT,\n                DateTime.Now.ToString(TIME_FMT),\n                level == InternalTraceLevel.Verbose ? \"Debug\" : level.ToString(),\n#if PORTABLE\n                System.E",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/clike/file1.cs",
@@ -4087,11 +5112,13 @@
         "end": 185,
         "startLoc": {
           "line": 103,
-          "column": 9
+          "column": 9,
+          "position": 474
         },
         "endLoc": {
           "line": 185,
-          "column": 2
+          "column": 2,
+          "position": 968
         }
       },
       "secondFile": {
@@ -4100,18 +5127,20 @@
         "end": 175,
         "startLoc": {
           "line": 93,
-          "column": 9
+          "column": 9,
+          "position": 429
         },
         "endLoc": {
           "line": 175,
-          "column": 2
+          "column": 2,
+          "position": 923
         }
       }
     },
     {
       "format": "cpp",
       "lines": 73,
-      "fragment": "class StrVec\n{\n    friend bool operator==(const StrVec&, const StrVec&);\n    friend bool operator!=(const StrVec&, const StrVec&);\n    friend bool operator< (const StrVec&, const StrVec&);\n    friend bool operator> (const StrVec&, const StrVec&);\n    friend bool operator<=(const StrVec&, const StrVec&);\n    friend bool operator>=(const StrVec&, const StrVec&);\n\npublic:\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\nprivate:\n    std::pair<std::string*, std::string*> alloc_n_copy(const std::string*, const std::string*);\n    void free();\n    void chk_n_alloc() { if (size() == capacity()) reallocate(); }\n    void reallocate();\n    void alloc_n_move(size_t new_cap);\n    void range_initialize(const std::string*, const std::string*);\n\nprivate:\n    std::string *elements;\n    std::string *first_free;\n    std::string *cap;\n    std::allocator<std::string> alloc;\n};\n\nbool operator==(const StrVec&, const StrVec&);\nbool operator!=(const StrVec&, const StrVec&);\nbool operator< (const StrVec&, const StrVec&);\nbool operator> (const StrVec&, const StrVec&);\nbool operator<=(const StrVec&, const StrVec&);\nbool operator>=(const StrVec&, const StrVec&);",
+      "fragment": "TRVEC_H_\n#define CP5_STRVEC_H_\n\n#include <memory>\n#include <string>\n#include <initializer_list>\n\n#ifndef _MSC_VER\n#define NOEXCEPT noexcept\n#else\n#define NOEXCEPT\n#endif\n\nclass StrVec\n{\n    friend bool operator==(const StrVec&, const StrVec&);\n    friend bool operator!=(const StrVec&, const StrVec&);\n    friend bool operator< (const StrVec&, const StrVec&);\n    friend bool operator> (const StrVec&, const StrVec&);\n    friend bool operator<=(const StrVec&, const StrVec&);\n    friend bool operator>=(const StrVec&, const StrVec&);\n\npublic:\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\n    StrVec() : elements(nullptr), first_free(nullptr), cap(nullptr) { }\n    StrVec(std::initializer_list<std::string>);\n    StrVec(const StrVec&);\n    StrVec& operator=(const StrVec&);\n    StrVec(StrVec&&) NOEXCEPT;\n    StrVec& operator=(StrVec&&)NOEXCEPT;\n    ~StrVec();\n\n    void push_back(const std::string&);\n    size_t size() const { return first_free - elements; }\n    size_t capacity() const { return cap - elements; }\n    std::string *begin() const { return elements; }\n    std::string *end() const { return first_free; }\n\n    std::string& at(size_t pos) { return *(elements + pos); }\n    const std::string& at(size_t pos) const { return *(elements + pos); }\n\n    void reserve(size_t new_cap);\n    void resize(size_t count);\n    void resize(size_t count, const std::string&);\n\nprivate:\n    std::pair<std::string*, std::string*> alloc_n_copy(const std::string*, const std::string*);\n    void free();\n    void chk_n_alloc() { if (size() == capacity()) reallocate(); }\n    void reallocate();\n    void alloc_n_move(size_t new_cap);\n    void range_initialize(const std::string*, const std::string*);\n\nprivate:\n    std::string *elements;\n    std::string *first_free;\n    std::string *cap;\n    std::allocator<std::string> alloc;\n};\n\nbool operator==(const StrVec&, const StrVec&);\nbool operator!=(const StrVec&, const StrVec&);\nbool operator< (",
       "tokens": 0,
       "firstFile": {
         "name": "fixtures/clike/file1.cpp",
@@ -4119,11 +5148,13 @@
         "end": 86,
         "startLoc": {
           "line": 14,
-          "column": 1
+          "column": 1,
+          "position": 13
         },
         "endLoc": {
           "line": 86,
-          "column": 47
+          "column": 2,
+          "position": 1031
         }
       },
       "secondFile": {
@@ -4132,11 +5163,13 @@
         "end": 86,
         "startLoc": {
           "line": 14,
-          "column": 1
+          "column": 1,
+          "position": 13
         },
         "endLoc": {
           "line": 86,
-          "column": 47
+          "column": 2,
+          "position": 1031
         }
       }
     },
@@ -4151,11 +5184,13 @@
         "end": 19,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 19,
-          "column": 2
+          "column": 2,
+          "position": 136
         }
       },
       "secondFile": {
@@ -4164,11 +5199,13 @@
         "end": 29,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 29,
-          "column": 2
+          "column": 2,
+          "position": 243
         }
       }
     },
@@ -4183,11 +5220,13 @@
         "end": 41,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 41,
-          "column": 59
+          "column": 3,
+          "position": 788
         }
       },
       "secondFile": {
@@ -4196,11 +5235,13 @@
         "end": 41,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 41,
-          "column": 59
+          "column": 3,
+          "position": 788
         }
       }
     },
@@ -4215,11 +5256,13 @@
         "end": 28,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 28,
-          "column": 2
+          "column": 2,
+          "position": 517
         }
       },
       "secondFile": {
@@ -4228,11 +5271,13 @@
         "end": 28,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 28,
-          "column": 4
+          "column": 4,
+          "position": 517
         }
       }
     },
@@ -4247,11 +5292,13 @@
         "end": 36,
         "startLoc": {
           "line": 28,
-          "column": 1
+          "column": 1,
+          "position": 517
         },
         "endLoc": {
           "line": 36,
-          "column": 59
+          "column": 3,
+          "position": 735
         }
       },
       "secondFile": {
@@ -4260,11 +5307,13 @@
         "end": 41,
         "startLoc": {
           "line": 33,
-          "column": 1
+          "column": 1,
+          "position": 570
         },
         "endLoc": {
           "line": 41,
-          "column": 59
+          "column": 3,
+          "position": 788
         }
       }
     },
@@ -4279,11 +5328,13 @@
         "end": 41,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 41,
-          "column": 59
+          "column": 3,
+          "position": 788
         }
       },
       "secondFile": {
@@ -4292,11 +5343,13 @@
         "end": 41,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 41,
-          "column": 59
+          "column": 3,
+          "position": 788
         }
       }
     },
@@ -4311,11 +5364,13 @@
         "end": 21,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 21,
-          "column": 14
+          "column": 14,
+          "position": 259
         }
       },
       "secondFile": {
@@ -4324,11 +5379,13 @@
         "end": 22,
         "startLoc": {
           "line": 1,
-          "column": 1
+          "column": 1,
+          "position": 0
         },
         "endLoc": {
           "line": 22,
-          "column": 14
+          "column": 14,
+          "position": 260
         }
       }
     }

--- a/packages/html-reporter/mockups/src/components/Clone.vue
+++ b/packages/html-reporter/mockups/src/components/Clone.vue
@@ -28,7 +28,7 @@
       </button>
     </div>
     <div v-if="isActive">
-      <pre class="text-left bg-gray-100 p-5 text-sm">{{ clone.fragment }}</pre>
+      <pre class="text-left bg-gray-100 p-5 text-sm overflow-scroll"><code>{{ clone.fragment }}</code></pre>
     </div>
   </div>
 </template>

--- a/packages/html-reporter/src/index.ts
+++ b/packages/html-reporter/src/index.ts
@@ -4,23 +4,6 @@ import {IReporter, JsonReporter} from "@jscpd/finder";
 import {copySync, writeFileSync, readFileSync} from "fs-extra";
 import {green, red} from "colors/safe";
 
-function escapeHtml(value) {
-  if (typeof value !== 'string') {
-    return value;
-  }
-  return value.replace(/[&<>`"'/]/g, function(result) {
-    return {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '`': '&#x60;',
-      '"': '&quot;',
-      "'": '&#x27;',
-      '/': '&#x2f;',
-    }[result];
-  })
-}
-
 export default class HtmlReporter implements IReporter {
   constructor(private options: IOptions) {
   }
@@ -28,9 +11,6 @@ export default class HtmlReporter implements IReporter {
   public report(clones: IClone[], statistic: IStatistic): void {
     const jsonReporter = new JsonReporter(this.options);
     const json = jsonReporter.generateJson(clones, statistic);
-    json.duplicates.forEach(item => {
-      item.fragment = escapeHtml(item.fragment);
-    });
     if (this.options.output) {
       const src = join(__dirname, '../html/');
       const destination = join(this.options.output, 'html/');


### PR DESCRIPTION
Fixes #550, reverts https://github.com/kucherenko/jscpd/pull/533, replaced by the usage of  `<code>`.

I did add a `<script>` HTML tag to verify, but I was not able to reproduce the case of https://github.com/kucherenko/jscpd/issues/476 after the revert and without my fix.

If you have the concrete case to provide, I would be glad to integrate it.