### PR TITLE
fix: 🐛 replaced $ for $$ for next replacement

### DIFF
--- a/packages/html-reporter/src/index.ts
+++ b/packages/html-reporter/src/index.ts
@@ -17,16 +17,20 @@ export default class HtmlReporter implements IReporter {
       try {
         copySync(src, destination, {overwrite: true});
         const index = join(destination, 'index.html');
+        const initialData = JSON.stringify(json, null, '  ')
+        // replace $ for $$
+        const initialDataForReplace = initialData.replace(/\$/g, '$$$$')
+
         const html = readFileSync(index).toString();
         writeFileSync(index, html.replace(
           '<body>',
           `<body><script>
                        // <!--
-                       window.initialData = ${JSON.stringify(json, null, '  ')};
+                       window.initialData = ${initialDataForReplace};
                        // -->
                        </script>`
         ))
-        writeFileSync(join(destination, 'jscpd-report.json'), JSON.stringify(json, null, '  '));
+        writeFileSync(join(destination, 'jscpd-report.json'), initialData);
         console.log(green(`HTML report saved to ${join(this.options.output, 'html/')}`));
       } catch (e) {
         console.log(red(e))


### PR DESCRIPTION
✅ Closes: #538

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

html reporter fix

* **What is the current behavior?** (You can also link to an open issue here)

if the duplicate code contains $' signs, then an incorrect value is written to window.initialData in html. Because the replace method has patterns (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement)

if it turned out to take duplicate codes from jscpd-report.json, then there is a visual bug, like here https://github.com/kucherenko/jscpd/issues/538

If it didn’t work out, then duplicate code is simply not displayed.

* **What is the new behavior (if this is a feature change)?**

i replaced $ with $$ for the next replacement


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/572)
<!-- Reviewable:end -->
