### PR TITLE
fix: spelling in JSON reporter example

### DIFF
--- a/packages/jscpd/README.md
+++ b/packages/jscpd/README.md
@@ -384,7 +384,7 @@ More info [jscpd-badge-reporter](https://github.com/kucherenko/jscpd-badge-repor
 ### JSON reporters
 ```json
 {
-  "duplications": [{
+  "duplicates": [{
       "format": "javascript",
       "lines": 27,
       "fragment": "...code fragment... ",


### PR DESCRIPTION
This is a small update on the README, since JSON Reporter uses `duplicates` as the key of the array.
https://github.com/kucherenko/jscpd/blob/master/packages/finder/src/reporters/json.ts#L32

But the README shows an example JSON Report with `duplications` as the key

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/601)
<!-- Reviewable:end -->
