### PR TITLE
Support multiple CDATA blocks in a single duplicated fragment

### DIFF
--- a/packages/finder/src/reporters/xml.ts
+++ b/packages/finder/src/reporters/xml.ts
@@ -20,12 +20,12 @@ export class XmlReporter implements IReporter {
       xmlDoc = `${xmlDoc}
       <duplication lines="${clone.duplicationA.end.line - clone.duplicationA.start.line}">
             <file path="${escapeXml(getPath(clone.duplicationA.sourceId, this.options))}" line="${clone.duplicationA.start.line}">
-              <codefragment><![CDATA[${clone.duplicationA.fragment.replace(/]]>/i, 'CDATA_END')}]]></codefragment>
+              <codefragment><![CDATA[${clone.duplicationA.fragment.replace(/]]>/g, 'CDATA_END')}]]></codefragment>
             </file>
             <file path="${escapeXml(getPath(clone.duplicationB.sourceId, this.options))}" line="${clone.duplicationB.start.line}">
-              <codefragment><![CDATA[${clone.duplicationB.fragment.replace(/]]>/i, 'CDATA_END')}]]></codefragment>
+              <codefragment><![CDATA[${clone.duplicationB.fragment.replace(/]]>/g, 'CDATA_END')}]]></codefragment>
             </file>
-            <codefragment><![CDATA[${clone.duplicationA.fragment.replace(/]]>/i, 'CDATA_END')}]]></codefragment>
+            <codefragment><![CDATA[${clone.duplicationA.fragment.replace(/]]>/g, 'CDATA_END')}]]></codefragment>
         </duplication>
       `;
 		});


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix the case when a single duplicate code fragment contains several CDATA statements

* **What is the current behavior?** (You can also link to an open issue here)

Only the first ocurrence gets replaced by the CDATA_END placeholder, leading to a malformed xml document

* **What is the new behavior (if this is a feature change)?**

All ocurrences of cdata end sequence (]]>) are replaced

* **Other information**:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/613)
<!-- Reviewable:end -->

<!-- brian settings start --><!--{}--><!-- brian settings end -->