### PR TITLE
fix: when importing jscpd as a node, it should not be automatically executed

### DIFF
--- a/apps/jscpd/bin/jscpd
+++ b/apps/jscpd/bin/jscpd
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../dist/jscpd')
+require('../dist/bin/jscpd')

--- a/apps/jscpd/package.json
+++ b/apps/jscpd/package.json
@@ -5,14 +5,14 @@
   "author": "Andrey Kucherenko <kucherenko.andrey@gmail.com>",
   "homepage": "https://github.com/kucherenko/jscpd#readme",
   "license": "MIT",
-  "main": "dist/jscpd.js",
-  "module": "dist/jscpd.mjs",
-  "typings": "dist/jscpd.d.mts",
+  "main": "dist/src/index.js",
+  "module": "dist/src/index.mjs",
+  "typings": "dist/src/index.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/jscpd.d.ts",
-      "import": "./dist/jscpd.mjs",
-      "require": "./dist/jscpd.js"
+      "types": "./dist/src/index.d.mts",
+      "import": "./dist/src/index.mjs",
+      "require": "./dist/src/index.js"
     },
     "./README.md": "./README.md"
   },

--- a/apps/jscpd/tsup.config.ts
+++ b/apps/jscpd/tsup.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'tsup'
+import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ['bin/jscpd.ts'],
+  entry: ["bin/jscpd.ts", "src/index.ts"],
   splitting: true,
   sourcemap: true,
   clean: true,
-  format: ['esm', 'cjs']
-})
+  format: ["esm", "cjs"],
+});


### PR DESCRIPTION
* when importing jscpd as a node, it should not be automatically executed

* https://github.com/kucherenko/jscpd/issues/734

* I split the bin file and src file into two packaging entry points, and pointed the import behavior to the index file in packagejson

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/735)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reorganized internal module resolution and package export paths to align with the new directory structure.
- **Chore**
  - Updated the build configuration to include an additional entry point, streamlining the build process and ensuring consistency across outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->