### PR TITLE
ci,chore: add codespell support with configuration and fixes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.gitignore,.gitattributes,*.svg,*-lock.yaml,*.css,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,9 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,.gitignore,.gitattributes,*.svg,*-lock.yaml,*.css,.codespellrc
+skip = .git,.gitignore,.gitattributes,*.svg,*-lock.yaml,*.css,.codespellrc,fixtures
 check-hidden = true
-# ignore-regex = 
-# ignore-words-list =
+# ignore-regex =
+# afterall - JS test framework function (afterAll)
+# inout - SQL keyword (INOUT)
+# acter - part of CHAR(?:ACTER|SET)? regex pattern for SQL keywords
+ignore-words-list = afterall,inout,acter

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/apps/jscpd/README.md
+++ b/apps/jscpd/README.md
@@ -46,7 +46,7 @@ The jscpd tool implements [Rabin-Karp](https://en.wikipedia.org/wiki/Rabin%E2%80
 
 
 ## Features
- - Detect duplications in programming source code, use semantic of programing languages, can skip comments, empty lines etc.
+ - Detect duplications in programming source code, use semantic of programming languages, can skip comments, empty lines etc.
  - Detect duplications in embedded blocks of code, like `<script>` or `<style>` sections in html
  - Blame authors of duplications
  - Generate XML report in pmd-cpd format, JSON report, [HTML report](http://kucherenko.github.io/jscpd-report.html)


### PR DESCRIPTION
Since just 1 minor typo fixed - feel free to ignore or cherrypick etc... just my way to say "thanks" for a nice tool is by making world free of typos ;)

Add codespell configuration and fix existing typo.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to over a hundred of projects already mostly with a positive feedback
(see the ["improveit-dashboard"](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

CI workflow has 'permissions' set only to 'read' so also should be safe.

## Changes

### Configuration & Infrastructure
- Added `.codespellrc` with skip patterns for fixtures, SVGs, CSS, lock files
- Created GitHub Actions workflow to check spelling on push and PRs to master

### Domain-Specific Whitelist
Added legitimate terms that codespell flags as typos:
- `afterall` - JS test framework function (`afterAll`)
- `inout` - SQL keyword (`INOUT`)
- `acter` - part of `CHAR(?:ACTER|SET)?` regex pattern for SQL keywords

### Typo Fixes

**Non-ambiguous typo fixed** (1 fix):
- `programing` -> `programming` (apps/jscpd/README.md)

### Historical Context
This project has had 39 prior commits fixing typos manually, demonstrating the value of automated spell-checking.

## Testing

Codespell passes with zero errors after all fixes.

---

Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/782)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling error in project documentation.

* **Chores**
  * Added automated spell-checking configuration and GitHub Actions workflow to maintain code quality across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->