### PR TITLE
doc: remove 404ing code-inspector, add drywall I just found

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ In case of deep customisation of detection process you can build your own tool w
 
 ## Who uses jscpd
  - [GitHub Super Linter](https://github.com/github/super-linter) is combination of multiple linters to install as a GitHub Action
- - [Code-Inspector](https://www.code-inspector.com/) is a code analysis and technical debt management service.
  - [Mega-Linter](https://nvuillam.github.io/mega-linter/) is a 100% open-source linters aggregator for CI (GitHub Action & other CI tools) or to run locally
  - [Codacy](http://docs.codacy.com/getting-started/supported-languages-and-tools/) automatically analyzes your source code and identifies issues as you go, helping you develop software more efficiently with fewer issues down the line.
  - [Natural](https://github.com/NaturalNode/natural) is a general natural language facility for nodejs. It offers a broad range of functionalities for natural language processing.
+ - [drywall](https://github.com/nikhaldi/drywall) claude code plugin for detecting and eliminating code duplication.
 
 
 ## Backers


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/783)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the list of projects and tools that use jscpd.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- brian settings start --><!--{}--><!-- brian settings end -->