### PR TITLE
fix: report duplicate token counts in json

### DIFF
--- a/packages/finder/__tests__/reporters.test.ts
+++ b/packages/finder/__tests__/reporters.test.ts
@@ -254,6 +254,19 @@ describe('JsonReporter', () => {
     expect(Array.isArray(result.duplicates)).toBe(true);
   });
 
+  it('generateJson reports duplicate token count from token positions', async () => {
+    const { JsonReporter } = await import('../src/reporters/json');
+    const reporter = new JsonReporter(options);
+    const clone = buildClone({
+      duplicationA: {
+        start: { line: 3, column: 1, position: 25 },
+        end: { line: 12, column: 1, position: 93 },
+      },
+    });
+    const result = reporter.generateJson([clone], buildStatistic());
+    expect(result.duplicates[0].tokens).toBe(68);
+  });
+
   it('calls writeFileSync with path ending in jscpd-report.json', async () => {
     const { JsonReporter } = await import('../src/reporters/json');
     const reporter = new JsonReporter(options);

--- a/packages/finder/src/reporters/json.ts
+++ b/packages/finder/src/reporters/json.ts
@@ -62,7 +62,9 @@ export class JsonReporter implements IReporter {
       format: clone.format,
       lines: endLineA - startLineA + 1,
       fragment: clone.duplicationA.fragment as string,
-      tokens: 0,
+      tokens: clone.duplicationA.end.position && clone.duplicationA.start.position !== undefined
+        ? clone.duplicationA.end.position - clone.duplicationA.start.position
+        : 0,
       firstFile: {
         name: getPath(clone.duplicationA.sourceId, this.options),
         start: startLineA,


### PR DESCRIPTION
## Problem

JSON reports always set each duplicate's `tokens` field to `0`, even when clone locations include token positions. This makes the JSON reporter lose the same token count that the console output can already show.

Fixes #606.

## Solution

I changed the JSON reporter to calculate the duplicate token count from the first duplicate's start and end token positions, matching the existing console reporter behavior. I also added regression coverage so generated JSON keeps a non-zero token count when location positions are present.

## Testing

- `corepack pnpm@10.28.0 install --frozen-lockfile`
- `corepack pnpm@10.28.0 --filter @jscpd/core build`
- `corepack pnpm@10.28.0 --filter @jscpd/tokenizer build`
- `corepack pnpm@10.28.0 --filter @jscpd/finder exec vitest run __tests__/reporters.test.ts`
- `corepack pnpm@10.28.0 --filter @jscpd/finder typecheck`
- `corepack pnpm@10.28.0 --filter @jscpd/finder build`
- `git diff --check`

I also ran the full `@jscpd/finder` test suite. The reporter tests passed, but several existing file-discovery tests fail in this Windows environment because fixture discovery returns no files and symlink creation is denied with `EPERM`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/801)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate token count reporting in JSON output. Token counts are now accurately computed from duplication position data instead of always reporting zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- brian settings start --><!--{}--><!-- brian settings end -->