### PR TITLE
fix(#813): prevent mmap exhaustion on large repositories

### DIFF
--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -113,12 +113,6 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
         extensions: config.formats.clone(),
         ignore_patterns: config.ignore.clone(),
         max_size: config.max_size,
-        min_lines: if config.min_lines > 0 {
-            Some(config.min_lines)
-        } else {
-            None
-        },
-        max_lines: config.max_lines,
         follow_symlinks: config.follow_symlinks,
         no_gitignore: config.no_gitignore,
         formats_exts: config.formats_exts.clone(),
@@ -136,6 +130,8 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
     use rayon::prelude::*;
     let mode = config.mode;
     let min_tokens = config.min_tokens;
+    let min_lines = config.min_lines;
+    let max_lines = config.max_lines;
     let skip_local = config.skip_local;
     let ignore_case = config.ignore_case;
 
@@ -157,7 +153,33 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
         discovered
             .into_par_iter()
             .filter_map(|file| {
-                let content = str::from_utf8(&file.map).ok()?;
+                // Open and memory-map the file inside the worker.  By NOT
+                // storing the Mmap in DiscoveredFile we cap concurrent
+                // mappings to the rayon thread-pool size, which is always
+                // far below vm.max_map_count (default 131 072 on Linux).
+                // This also avoids the Vec<u8> allocation that a to_vec()
+                // copy would require, matching the allocation profile of the
+                // original mmap approach.
+                let f = std::fs::File::open(&file.path).ok()?;
+                let map = unsafe { memmap2::Mmap::map(&f) }.ok()?;
+
+                // Line-count filter — fast O(n) pass before UTF-8 decode.
+                if min_lines > 0 || max_lines.is_some() {
+                    let newlines = memchr::Memchr::new(b'\n', &map).count();
+                    let lc = if !map.is_empty() && *map.last().unwrap() != b'\n' {
+                        newlines + 1
+                    } else {
+                        newlines
+                    };
+                    if lc < min_lines {
+                        return None;
+                    }
+                    if max_lines.is_some_and(|m| lc > m) {
+                        return None;
+                    }
+                }
+
+                let content = str::from_utf8(&map).ok()?;
                 let id = file.path.to_string_lossy().into_owned();
 
                 // Compute code-level ignore ranges from regex matches against source text.

--- a/rust/crates/cpd-finder/src/walker.rs
+++ b/rust/crates/cpd-finder/src/walker.rs
@@ -1,6 +1,6 @@
 // walker.rs
 
-use std::{collections::HashMap, fs::File, io::BufRead};
+use std::{collections::HashMap, io::BufRead};
 
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
@@ -15,8 +15,6 @@ pub struct WalkConfig {
     pub extensions: Vec<String>, // empty = all supported formats
     pub ignore_patterns: Vec<String>,
     pub max_size: Option<u64>,
-    pub min_lines: Option<usize>,
-    pub max_lines: Option<usize>,
     pub follow_symlinks: bool,
     pub no_gitignore: bool,
     pub formats_exts: HashMap<String, Vec<String>>,
@@ -28,7 +26,10 @@ pub struct WalkConfig {
 pub struct DiscoveredFile {
     pub path: PathBuf,
     pub format: String,
-    pub map: memmap2::Mmap,
+    // File content is intentionally NOT stored here.  Each rayon worker
+    // opens and memory-maps its file in the processing step, so at most
+    // `num_threads` mmaps are live simultaneously — safe for any repo size
+    // regardless of vm.max_map_count.
 }
 
 /// Build a GlobSet for the positive `--pattern` filter.
@@ -113,10 +114,7 @@ fn walk_one(root: &Path, config: &WalkConfig, results: &mut Vec<DiscoveredFile>)
     // absolute or relative. We also add a `**/` prefix variant for
     // relative patterns so that `*.ts` matches at any depth (consistent
     // with how ignore patterns are handled).
-    let pattern_set = config
-        .pattern
-        .as_deref()
-        .map(|p| build_positive_glob_set(p));
+    let pattern_set = config.pattern.as_deref().map(build_positive_glob_set);
 
     // Canonicalize root once for relative path computation.
     let root_canon = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
@@ -126,8 +124,6 @@ fn walk_one(root: &Path, config: &WalkConfig, results: &mut Vec<DiscoveredFile>)
 
     let follow_symlinks = config.follow_symlinks;
     let max_size = config.max_size;
-    let min_lines = config.min_lines;
-    let max_lines = config.max_lines;
     let extensions = config.extensions.clone();
     let formats_exts = config.formats_exts.clone();
     let formats_names = config.formats_names.clone();
@@ -196,29 +192,7 @@ fn walk_one(root: &Path, config: &WalkConfig, results: &mut Vec<DiscoveredFile>)
                 return WalkState::Continue;
             }
 
-            let Ok(file) = File::open(&path) else {
-                return WalkState::Continue;
-            };
-
-            let Ok(map) = (unsafe { memmap2::Mmap::map(&file) }) else {
-                return WalkState::Continue;
-            };
-
-            // Line count check — read the file ONCE here if needed.
-            // Previous implementation read the file twice when min_lines/max_lines was set.
-            if min_lines.is_some() || max_lines.is_some() {
-                // Count lines by counting newline bytes — O(n) in bytes, no UTF-8 decode.
-                let lc = memchr::Memchr::new(b'\n', &map).count();
-
-                if min_lines.is_some_and(|m| lc < m) {
-                    return WalkState::Continue;
-                }
-                if max_lines.is_some_and(|m| lc > m) {
-                    return WalkState::Continue;
-                }
-            }
-
-            let _ = tx.send(DiscoveredFile { path, map, format });
+            let _ = tx.send(DiscoveredFile { path, format });
             WalkState::Continue
         })
     });

--- a/rust/crates/cpd-finder/tests/skip_local_integration.rs
+++ b/rust/crates/cpd-finder/tests/skip_local_integration.rs
@@ -75,7 +75,7 @@ fn cross_directory_clones_survive_skip_local() {
     let _ = fs::remove_dir_all(&dir);
 
     assert!(
-        result.clones.len() >= 1,
+        !result.clones.is_empty(),
         "skip_local=true must keep cross-directory clones"
     );
 }

--- a/rust/crates/cpd-tokenizer/src/tokenizer.rs
+++ b/rust/crates/cpd-tokenizer/src/tokenizer.rs
@@ -538,7 +538,7 @@ mod tests {
     fn with_code_ignore_patterns_builds_regexes() {
         let opts = TokenizeOptions::with_code_ignore_patterns(
             Mode::Mild,
-            &vec!["function".to_string(), r"//\s*cpd-disable".to_string()],
+            &["function".to_string(), r"//\s*cpd-disable".to_string()],
         );
         assert_eq!(opts.code_ignore_regexes.len(), 2);
         assert!(opts.code_ignore_regexes[0].is_match("function"));


### PR DESCRIPTION
## Problem

Closes #813

Scanning fails with a panic when the number of files exceeds `vm.max_map_count` (default 131\u202f072 on Linux):

```
thread '<unnamed>' panicked at library/std/src/sys/pal/unix/stack_overflow.rs:236:13:
failed to allocate an alternative stack: Cannot allocate memory (os error 12)
```

### Root cause

PR #808 stored a live `memmap2::Mmap` in every `DiscoveredFile`. The walker collected **all N files** before processing began, keeping N concurrent mmap regions open. The Linux kernel enforces a per-process limit via `vm.max_map_count`; exceeding it causes `mmap()` to return `ENOMEM`. This cascaded into rayon thread-pool initialisation panics disguised as `stack_overflow.rs` errors.

## Fix

Strip `DiscoveredFile` down to `(path, format)` only — no content, no mmap. Each rayon worker opens and mmaps its file for the duration of its `filter_map` closure; the `Mmap` drops on return.

This caps concurrent mappings to the rayon thread-pool size (typically 8–32), safe for any repository regardless of size.

### Additional improvements

- Moves the `min_lines`/`max_lines` line-count filter out of the walker and into the processing step, where it runs against the already-open mmap with a fast `memchr` pass before UTF-8 decoding.
- Fixes the trailing-newline off-by-one (`+1` when last byte ≠ `'\n'`) noted in the PR #808 review.

## Performance

No allocation regression vs PR #808: content is decoded directly from the mmap slice — no `Vec<u8>` copy. Max concurrent mmaps is bounded by the rayon thread count rather than the total file count.

| | PR #808 | Previous fix (Vec copy) | This PR |
|---|---|---|---|
| Concurrent mmaps | N (all files) | 0 (dropped immediately) | ≤ rayon threads |
| Vec\<u8\> alloc per file | ✗ | ✓ (regression) | ✗ |
| Safe for >131k files | ✗ | ✓ | ✓ |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/814)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized the clone-finding discovery pipeline: moved per-file content handling and line-count filtering into the parallel processing stage to improve efficiency and resource usage.
* **Tests**
  * Minor test assertions and input formatting updated to remain consistent with the refactor and preserve existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->