### PR TITLE
feat: add Codex skill install guidance

### DIFF
--- a/apps/jscpd/README.md
+++ b/apps/jscpd/README.md
@@ -629,6 +629,16 @@ npx skills add kucherenko/jscpd --skill jscpd
 npx skills add kucherenko/jscpd --skill dry-refactoring
 ```
 
+To install both skills for Codex explicitly:
+
+```bash
+npx skills add kucherenko/jscpd --skill jscpd --skill dry-refactoring --agent codex
+```
+
+Add `--global` to install into Codex's user skills directory
+(`~/.codex/skills/`) instead of the current project's `.agents/skills/`
+directory.
+
 ### PMD CPD XML
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/apps/jscpd/__tests__/options.test.ts
+++ b/apps/jscpd/__tests__/options.test.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {IClone} from '@jscpd/core';
 import {jscpd, detectClones, detectClonesAndStatistic} from '../src';
-import {bold, yellow} from 'colors/safe';
+import {bold, grey, yellow} from 'colors/safe';
 
 const pathToFixtures = __dirname + '/../../../fixtures';
 
@@ -202,6 +202,24 @@ describe('jscpd options', () => {
       });
       const log = (console.log as any);
       expect(log.mock.calls.length).toEqual(0);
+    });
+  });
+
+  describe('tips', () => {
+    it('should print the dry-refactoring skill install command by default', async () => {
+      await jscpd(['', '', fileWithClones]);
+      const log = (console.log as any);
+      expect(log).toHaveBeenCalledWith(
+        grey('💡 Auto-refactor with AI: npx skills add kucherenko/jscpd --skill dry-refactoring'),
+      );
+    });
+
+    it('should not print skill install tips when --noTips is enabled', async () => {
+      await jscpd(['', '', fileWithClones, '--noTips']);
+      const log = (console.log as any);
+      expect(log).not.toHaveBeenCalledWith(
+        expect.stringContaining('npx skills add'),
+      );
     });
   });
 

--- a/apps/jscpd/src/index.ts
+++ b/apps/jscpd/src/index.ts
@@ -25,6 +25,8 @@ import { registerHooks } from "./init/hooks";
 import { readJSONSync } from "fs-extra";
 
 const TIMER_LABEL = "time";
+const DRY_REFACTORING_SKILL_INSTALL_COMMAND =
+  "npx skills add kucherenko/jscpd --skill dry-refactoring";
 
 export const detectClones = (
   opts: IOptions,
@@ -63,7 +65,9 @@ export const detectClones = (
       if (!options.noTips) {
         console.log("");
         console.log(
-          grey("💡 Auto-refactor with AI: npx skills add kucherenko/jscpd"),
+          grey(
+            `💡 Auto-refactor with AI: ${DRY_REFACTORING_SKILL_INSTALL_COMMAND}`,
+          ),
         );
         console.log(
           grey(

--- a/docs/ai-ready.md
+++ b/docs/ai-ready.md
@@ -59,6 +59,18 @@ A guided process for reading clone output, choosing the right extraction strateg
 npx skills add kucherenko/jscpd --skill dry-refactoring
 ```
 
+### Codex
+
+To install both skills for Codex explicitly:
+
+```bash
+npx skills add kucherenko/jscpd --skill jscpd --skill dry-refactoring --agent codex
+```
+
+Use `--global` to install them into the Codex user skills directory
+(`~/.codex/skills/`) instead of the current project's `.agents/skills/`
+directory.
+
 After installation, ask your agent to "find and fix code duplication" and it will invoke jscpd with the right options and act on the results.
 
 ## MCP Server


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature / docs update.

Closes #800.

* **What is the current behavior?** (You can also link to an open issue here)

The AI skill documentation lists generic `npx skills add` commands, and the CLI tip points to `npx skills add kucherenko/jscpd` without naming the refactoring skill. Users looking for Codex support have to infer that the existing agent skills can be installed for Codex via the `skills` CLI.

* **What is the new behavior (if this is a feature change)?**

- Documents an explicit Codex install command for both bundled skills:
  `npx skills add kucherenko/jscpd --skill jscpd --skill dry-refactoring --agent codex`
- Notes where `--global` installs the skills for Codex.
- Updates the CLI tip to show the exact `dry-refactoring` skill install command.
- Adds tests for the default skill tip and `--noTips` suppression.

* **Other information**:

Validation run locally:

- `npx skills add . --list`
- `pnpm --filter jscpd test -- __tests__/options.test.ts -t tips`
- `pnpm --filter jscpd typecheck`
- `pnpm build`
- `git diff --check HEAD`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/815)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance for agent skills with explicit `--global` flag examples for user-level installation.
  * Clarified snippet checking mechanisms and request isolation behavior.

* **New Features**
  * Introduced helpful tips guiding users to install auto-refactor skills with the Codex agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->