### PR TITLE
feat: add flake.nix for Nix package manager support (#818)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 dist
 .agents/
+result
+result-*
 results
 .nyc_output
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ cpd /path/to/code
 
 # Rust-native install (exposes both jscpd and cpd)
 cargo install jscpd
+
+# Nix (installs both jscpd and cpd)
+nix run github:kucherenko/jscpd -- /path/to/code
+# or install permanently
+nix profile install github:kucherenko/jscpd
+
+# Homebrew (macOS/Linux)
+brew install jscpd
 ```
 
 ## Documentation

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -37,6 +37,15 @@ cpd /path/to/code
 cargo install jscpd
 jscpd /path/to/code
 cpd /path/to/code
+
+# Nix — run without installing
+nix run github:kucherenko/jscpd -- /path/to/code
+
+# Nix — install permanently
+nix profile install github:kucherenko/jscpd
+
+# Homebrew (macOS/Linux)
+brew install jscpd
 ```
 
 The npm packages ship prebuilt binaries for 6 platforms: macOS arm64/x64, Linux arm64/x64 (glibc/musl), Windows x64. No Node.js runtime is required — the binary is self-contained.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1781430890,
+        "narHash": "sha256-Dict8ZPqm3fei8iFXh75sPBNPqCdn7a8GJytgLajbGw=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "1b9586dd32bb28519cf6eea855e2df5b4d5eca15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781359544,
+        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781382341,
+        "narHash": "sha256-1AuqkRHiBSuU8AjzPW4gFgwyPhFaMZhYJVtMormLvb8=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "5017a50153285a2d9bfa286e6fa96723e997d5b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+{
+  description = "Copy/paste detector — fast Rust-based CLI for code duplication detection";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, fenix, crane, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        rustToolchain = fenix.packages.${system}.fromToolchainFile {
+          file = ./rust/rust-toolchain.toml;
+          sha256 = "sha256-SBKjxhC6zHTu0SyJwxLlQHItzMzYZ71VCWQC2hOzpRY=";
+        };
+
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+        src = pkgs.lib.cleanSourceWith {
+          src = ./rust;
+          filter = path: type:
+            (craneLib.filterCargoSources path type) ||
+            (pkgs.lib.hasSuffix ".html" path && pkgs.lib.hasInfix "/templates/" path);
+        };
+
+        commonArgs = {
+          inherit src;
+          pname = "jscpd";
+          version = (craneLib.crateNameFromCargoToml { cargoToml = ./rust/crates/cpd/Cargo.toml; }).version;
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+            pkgs.apple-sdk
+          ];
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+        jscpd = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+          doCheck = false;
+          meta = {
+            description = "Copy/paste detector for programming source code";
+            homepage = "https://jscpd.dev";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "jscpd";
+          };
+        });
+      in
+      {
+        packages = {
+          inherit jscpd;
+          default = jscpd;
+        };
+
+        checks = {
+          jscpd-tests = craneLib.cargoNextest (commonArgs // {
+            inherit cargoArtifacts;
+            cargoExtraArgs = "--lib -p cpd-core -p cpd-tokenizer -p cpd-reporter";
+          });
+        };
+
+        devShells.default = craneLib.devShell (commonArgs // {
+          packages = with pkgs; [
+            cargo-nextest
+            cargo-deny
+            pkg-config
+          ];
+        });
+      }
+    );
+}

--- a/rust/README.md
+++ b/rust/README.md
@@ -36,6 +36,22 @@ cargo install jscpd
 
 Installs both `jscpd` and `cpd` binaries.
 
+### Nix
+
+```bash
+# Run without installing
+nix run github:kucherenko/jscpd -- /path/to/code
+
+# Install permanently
+nix profile install github:kucherenko/jscpd
+```
+
+### Homebrew
+
+```bash
+brew install jscpd
+```
+
 ### From source
 
 ```bash

--- a/rust/jscpd/README.md
+++ b/rust/jscpd/README.md
@@ -35,6 +35,15 @@ npm install -g cpd
 
 # crates.io — installs both jscpd and cpd binaries
 cargo install jscpd
+
+# Nix — run without installing
+nix run github:kucherenko/jscpd -- /path/to/code
+
+# Nix — install permanently
+nix profile install github:kucherenko/jscpd
+
+# Homebrew (macOS/Linux)
+brew install jscpd
 ```
 
 Prebuilt binaries for 6 platforms — no Node.js runtime required.

--- a/rust/npm/README.md
+++ b/rust/npm/README.md
@@ -24,6 +24,15 @@ npm install -g cpd
 
 # crates.io — installs both jscpd and cpd binaries
 cargo install jscpd
+
+# Nix — run without installing
+nix run github:kucherenko/jscpd -- /path/to/code
+
+# Nix — install permanently
+nix profile install github:kucherenko/jscpd
+
+# Homebrew (macOS/Linux)
+brew install jscpd
 ```
 
 Prebuilt binaries for 6 platforms — no Node.js runtime required.


### PR DESCRIPTION
## Summary

Adds Nix package manager support via a `flake.nix` file, as requested in #818.

### What's new

- **`flake.nix`** at the repository root — builds the `jscpd`/`cpd` Rust binaries (v5.x) using crane + fenix
- **`nix build .#jscpd`** — produces a package with both `jscpd` and `cpd` binaries
- **`nix run .#jscpd -- --version`** — run without installing
- **`nix develop`** — dev shell with Rust 1.93 toolchain, cargo-nextest, cargo-deny
- **`nix flake check`** — runs library unit tests (cpd-core, cpd-tokenizer, cpd-reporter)
- **`.gitignore`** — added `result` and `result-*` for Nix build symlinks

### Design decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Build library | crane | `buildDepsOnly` caching for 149 deps |
| Toolchain | fenix `fromToolchainFile` | Reads `rust-toolchain.toml`; single source of truth |
| Placement | Repo root | `src` points to `./rust`; standard for monorepos |
| Source filter | `cleanSourceWith` + custom filter | Preserves `templates/*.html` for Askama |
| Binary naming | Both natural | Cargo produces `cpd` and `jscpd` from two `[[bin]]` entries |
| Darwin support | `apple-sdk` + `libiconv` | Replaces removed `darwin.apple_sdk_11_0` |
| Package tests | `doCheck = false` in build | Integration tests need filesystem access not in Nix sandbox |

### Usage

```bash
nix build .#jscpd
nix run .#jscpd -- --version
nix develop
nix flake check
```

### Notes

- Integration tests excluded from `nix flake check` (need filesystem fixtures) — run via `cargo test` locally
- Rust-only (v5.x); TypeScript/Node.js packages out of scope

Closes #818

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/819)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nix flake packaging and a Nix-based build/test/dev workflow for the Rust project.
  * Added Nix “run without installing” and “permanent install” options, plus Homebrew install guidance.
* **Chores**
  * Enhanced build and packaging infrastructure to support the development workflow
  * Updated repository ignore patterns for cleaner state management
* **Documentation**
  * Updated installation instructions across multiple READMEs to include Nix and Homebrew steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->