### PR TITLE
chore: use public repository URL for sarif reporter

### DIFF
--- a/packages/sarif-reporter/package.json
+++ b/packages/sarif-reporter/package.json
@@ -43,7 +43,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kucherenko/jscpd.git"
+    "url": "git+https://github.com/kucherenko/jscpd.git"
   },
   "bugs": {
     "url": "https://github.com/kucherenko/jscpd/issues"


### PR DESCRIPTION
## Summary
- replace the `jscpd-sarif-reporter` package repository URL with a public HTTPS GitHub URL
- keep the existing homepage and bugs metadata unchanged

## Validation
- `node -e "const p=require('./packages/sarif-reporter/package.json'); if (p.repository.url !== 'git+https://github.com/kucherenko/jscpd.git') { throw new Error(p.repository.url); } if (!p.bugs?.url || !p.homepage) { throw new Error('missing support metadata'); } console.log(p.name, p.repository.url);"`
- `npx -y pnpm@10.28.0 install --frozen-lockfile --ignore-scripts`
- `npx -y pnpm@10.28.0 --filter jscpd-sarif-reporter... build`
- `npx -y pnpm@10.28.0 --filter jscpd-sarif-reporter typecheck`
- `npx -y pnpm@10.28.0 --filter jscpd-sarif-reporter exec npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/830)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to use HTTPS Git URL instead of SSH for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->