### PR TITLE
chore: use public repository URL for core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kucherenko/jscpd.git"
+    "url": "git+https://github.com/kucherenko/jscpd.git"
   },
   "bugs": {
     "url": "https://github.com/kucherenko/jscpd/issues"


### PR DESCRIPTION
## Summary
- replace the `@jscpd/core` package repository URL with a public HTTPS GitHub URL
- keep the existing homepage and bugs metadata unchanged

## Validation
- `node -e "const p=require('./packages/core/package.json'); if (p.repository.url !== 'git+https://github.com/kucherenko/jscpd.git') { throw new Error(p.repository.url); } if (!p.bugs?.url || !p.homepage) { throw new Error('missing support metadata'); } console.log(p.name, p.repository.url);"`
- `npx -y pnpm@10.28.0 --filter @jscpd/core build`
- `npx -y pnpm@10.28.0 --filter @jscpd/core test` (7 files / 65 tests passed)
- `npx -y pnpm@10.28.0 --filter @jscpd/core exec npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

Note: `npx -y pnpm@10.28.0 --filter @jscpd/core typecheck` could not start in this workspace because the package script calls `tsc` but no `typescript` binary is linked for `@jscpd/core`; the build command above still completed successfully and generated declaration files via `tsup-node --dts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/832)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository URL configuration to HTTPS format for improved connectivity standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->