### PR TITLE
chore: use public repository URL for finder package

### DIFF
--- a/packages/finder/package.json
+++ b/packages/finder/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kucherenko/jscpd.git"
+    "url": "git+https://github.com/kucherenko/jscpd.git"
   },
   "dependencies": {
     "@jscpd/core": "workspace:*",


### PR DESCRIPTION
## Summary
- replace the `@jscpd/finder` package repository URL with a public HTTPS GitHub URL
- keep the existing homepage metadata unchanged

## Validation
- `node -e "const p=require('./packages/finder/package.json'); if (p.repository.url !== 'git+https://github.com/kucherenko/jscpd.git') { throw new Error(p.repository.url); } if (!p.homepage) { throw new Error('missing homepage'); } console.log(p.name, p.repository.url);"`
- `npx -y pnpm@10.28.0 --filter @jscpd/finder... build`
- `npx -y pnpm@10.28.0 --filter @jscpd/finder typecheck`
- `npx -y pnpm@10.28.0 --filter @jscpd/finder test` (10 files / 97 tests passed)
- `npx -y pnpm@10.28.0 --filter @jscpd/finder exec npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/833)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration format in package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->