### PR TITLE
chore: use public repository URL for tokenizer package

### DIFF
--- a/packages/tokenizer/package.json
+++ b/packages/tokenizer/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kucherenko/jscpd.git"
+    "url": "git+https://github.com/kucherenko/jscpd.git"
   },
   "devDependencies": {
     "@jscpd/tsconfig": "workspace:*",


### PR DESCRIPTION
## Summary
- replace the `@jscpd/tokenizer` package repository URL with a public HTTPS GitHub URL
- keep the existing homepage metadata unchanged

## Validation
- `node -e "const p=require('./packages/tokenizer/package.json'); if (p.repository.url !== 'git+https://github.com/kucherenko/jscpd.git') { throw new Error(p.repository.url); } if (!p.homepage) { throw new Error('missing homepage'); } console.log(p.name, p.repository.url);"`
- `npx -y pnpm@10.28.0 --filter @jscpd/tokenizer build`
- `npx -y pnpm@10.28.0 --filter @jscpd/tokenizer typecheck`
- `npx -y pnpm@10.28.0 --filter @jscpd/tokenizer test` (9 files / 279 tests passed)
- `npx -y pnpm@10.28.0 --filter @jscpd/tokenizer exec npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/834)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository URL configuration in package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->