### PR TITLE
chore: use public repository URL for badge reporter

### DIFF
--- a/packages/badge-reporter/package.json
+++ b/packages/badge-reporter/package.json
@@ -41,7 +41,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kucherenko/jscpd.git"
+    "url": "git+https://github.com/kucherenko/jscpd.git"
   },
   "bugs": {
     "url": "https://github.com/kucherenko/jscpd/issues"


### PR DESCRIPTION
## Summary
- replace the `@jscpd/badge-reporter` package repository URL with a public HTTPS GitHub URL
- keep the existing homepage and bugs metadata unchanged

## Validation
- `node -e "const p=require('./packages/badge-reporter/package.json'); if (p.repository.url !== 'git+https://github.com/kucherenko/jscpd.git') { throw new Error(p.repository.url); } if (!p.homepage || !p.bugs?.url) { throw new Error('missing support metadata'); } console.log(p.name, p.repository.url);"`
- `npx -y pnpm@10.28.0 --filter @jscpd/badge-reporter... build`
- `npx -y pnpm@10.28.0 --filter @jscpd/badge-reporter exec npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

Note: `npx -y pnpm@10.28.0 --filter @jscpd/badge-reporter typecheck` could not start locally because this workspace package calls `tsc` but does not link a `typescript` binary. The build command above still completed successfully and generated declaration files via `tsup-node --dts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/835)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->