### PR TITLE
chore: use public repository URL for leveldb store

### DIFF
--- a/packages/leveldb-store/package.json
+++ b/packages/leveldb-store/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kucherenko/jscpd.git"
+    "url": "git+https://github.com/kucherenko/jscpd.git"
   },
   "bugs": {
     "url": "https://github.com/kucherenko/jscpd/issues"


### PR DESCRIPTION
## Summary
- replace the `@jscpd/leveldb-store` package repository URL with a public HTTPS GitHub URL
- keep the existing homepage and bugs metadata unchanged

## Validation
- `node -e "const p=require('./packages/leveldb-store/package.json'); if (p.repository.url !== 'git+https://github.com/kucherenko/jscpd.git') { throw new Error(p.repository.url); } if (!p.homepage || !p.bugs?.url) { throw new Error('missing support metadata'); } console.log(p.name, p.repository.url);"`
- `npx -y pnpm@10.28.0 --filter @jscpd/leveldb-store build`
- `npx -y pnpm@10.28.0 --filter @jscpd/leveldb-store typecheck`
- `npx -y pnpm@10.28.0 --filter @jscpd/leveldb-store exec npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

Note: this package does not define a test script; `test:dev` is watch-mode only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/836)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository URL configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->