### PR TITLE
chore: use public repository URL for redis store

### DIFF
--- a/packages/redis-store/package.json
+++ b/packages/redis-store/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kucherenko/jscpd.git"
+    "url": "git+https://github.com/kucherenko/jscpd.git"
   },
   "bugs": {
     "url": "https://github.com/kucherenko/jscpd/issues"


### PR DESCRIPTION
## Summary
- replace the `@jscpd/redis-store` package repository URL with a public HTTPS GitHub URL
- keep the existing homepage and bugs metadata unchanged

## Validation
- `node -e "const p=require('./packages/redis-store/package.json'); if (p.repository.url !== 'git+https://github.com/kucherenko/jscpd.git') { throw new Error(p.repository.url); } if (!p.homepage || !p.bugs?.url) { throw new Error('missing support metadata'); } console.log(p.name, p.repository.url);"`
- `npx -y pnpm@10.28.0 --filter @jscpd/redis-store build`
- `npx -y pnpm@10.28.0 --filter @jscpd/redis-store typecheck`
- `npx -y pnpm@10.28.0 --filter @jscpd/redis-store exec npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

Note: this package does not define a test script; `test:dev` is watch-mode only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/837)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->