### PR TITLE
fix(sarif): Use HTTPS scheme for schema URI

### DIFF
--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -103,7 +103,7 @@ impl Reporter for SarifReporter {
 
         let sarif = json!({
             "version": "2.1.0",
-            "$schema": "http://json.schemastore.org/sarif-2.1.0.json",
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
             "runs": [{
                 "tool": {
                     "driver": {


### PR DESCRIPTION
Resolve "untrusted URI" issues in some SARIF-consuming tools caused by use of an HTTP URL for the schema URI in generated SARIF output.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Very minor fix / improvement.

* **What is the current behavior?** (You can also link to an open issue here)

Schema URI emitted in SARIF output is HTTP instead of HTTPS.

* **What is the new behavior (if this is a feature change)?**

Schema URI is now emitted as an HTTPS URL.

* **Other information**:

This is a fix or improvement for tools which consume JSON documents including SARIF, which report trust errors for JSON schemas which are not built-in to said tools and are not referenced by HTTPS. All HTTP URLs from json.schemastore.org are also accessible via HTTPS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/844)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the generated SARIF output to use a secure HTTPS schema URL instead of HTTP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->