### PR TITLE
fix(tokenizer): recognize ';' line comments for lisp/clojure/scheme/racket

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "askama"

--- a/rust/crates/cpd-tokenizer/src/generic.rs
+++ b/rust/crates/cpd-tokenizer/src/generic.rs
@@ -40,7 +40,9 @@ fn comment_style(format: &str) -> CommentStyle {
 
         "lua" => CommentStyle::Lua,
 
-        "ini" | "properties" | "asm6502" | "nasm" => CommentStyle::Semicolon,
+        "ini" | "properties" | "asm6502" | "nasm" | "lisp" | "clojure" | "scheme" | "racket" => {
+            CommentStyle::Semicolon
+        }
 
         "vb" | "vbs" | "basic" | "vbnet" | "visual-basic" => CommentStyle::VisualBasic,
 
@@ -398,6 +400,15 @@ mod tests {
         let tokens = tokenize_generic("# this is a comment\nx = 1\n", "python");
         let has_comment = tokens.iter().any(|t| t.kind == TokenKind::Comment);
         assert!(has_comment, "Python # comments must be Comment kind");
+    }
+
+    #[test]
+    fn lisp_family_semicolon_comment_marked_as_comment() {
+        for format in ["lisp", "clojure", "scheme", "racket"] {
+            let tokens = tokenize_generic(";; a comment\n(def x 1)\n", format);
+            let has_comment = tokens.iter().any(|t| t.kind == TokenKind::Comment);
+            assert!(has_comment, "{format} ; comments must be Comment kind");
+        }
     }
 
     #[test]


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

Fixes #849. `lisp`, `clojure`, `scheme`, and `racket` are absent from `comment_style()` in `rust/crates/cpd-tokenizer/src/generic.rs`, so they fall through to `_ => CommentStyle::CStyle`. Their `;` line comments are never recognized and are tokenized as code, so `--mode weak` / `--skip-comments` cannot drop them — e.g. the identical GNU GPL header that every Emacs Lisp file carries gets reported as duplicate code in every file pair.

* **What is the new behavior (if this is a feature change)?**

Route `lisp`/`clojure`/`scheme`/`racket` to the existing `CommentStyle::Semicolon` (their line comment is `;`). `--mode weak` / `--skip-comments` now drops their comments.

Verified by building `cpd` and running it on two `.el` files sharing an identical license header but different code: `Found 1 clones` → `Found 0 clones` (exit 0). Added a `cpd-tokenizer` regression test `lisp_family_semicolon_comment_marked_as_comment`; `cargo test -p cpd-tokenizer` → 109 passed, 0 failed.

* **Other information**:

Block comments (`#| |#`, datum `#;`) in Common Lisp/Scheme/Racket are a separate, secondary concern not handled by the `Semicolon` style and are out of scope here. Disclosure: drafted with AI assistance and reviewed before submitting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/850)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded comment recognition for additional Lisp-family formats, including Lisp, Clojure, Scheme, and Racket.
* **Bug Fixes**
  * `;;` comments are now tokenized correctly in these languages, improving syntax highlighting and parsing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->