### PR TITLE
fix(rust): rename cpd binary and npm platform packages to jscpd

### DIFF
--- a/.github/workflows/npm-rust-publish.yml
+++ b/.github/workflows/npm-rust-publish.yml
@@ -51,40 +51,40 @@ jobs:
       matrix:
         target:
           - key: linux-x64-gnu
-            packageName: cpd-linux-x64-gnu
+            packageName: jscpd-linux-x64-gnu
             os: linux
             cpu: x64
             libc: glibc
             rustTarget: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
           - key: linux-arm64-gnu
-            packageName: cpd-linux-arm64-gnu
+            packageName: jscpd-linux-arm64-gnu
             os: linux
             cpu: arm64
             libc: glibc
             rustTarget: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
           - key: linux-x64-musl
-            packageName: cpd-linux-x64-musl
+            packageName: jscpd-linux-x64-musl
             os: linux
             cpu: x64
             libc: musl
             rustTarget: x86_64-unknown-linux-musl
             runner: ubuntu-latest
           - key: darwin-arm64
-            packageName: cpd-darwin-arm64
+            packageName: jscpd-darwin-arm64
             os: darwin
             cpu: arm64
             rustTarget: aarch64-apple-darwin
             runner: macos-latest
           - key: darwin-x64
-            packageName: cpd-darwin-x64
+            packageName: jscpd-darwin-x64
             os: darwin
             cpu: x64
             rustTarget: x86_64-apple-darwin
             runner: macos-latest
           - key: windows-x64-msvc
-            packageName: cpd-windows-x64-msvc
+            packageName: jscpd-windows-x64-msvc
             os: win32
             cpu: x64
             rustTarget: x86_64-pc-windows-msvc
@@ -183,7 +183,7 @@ jobs:
         working-directory: rust
         run: |
           version="${{ needs.version.outputs.version }}"
-          binary="./target/${{ matrix.target.rustTarget }}/release/cpd"
+          binary="./target/${{ matrix.target.rustTarget }}/release/jscpd"
           BUILT_VERSION=$("$binary" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "NOT_FOUND")
           echo "Built: ${BUILT_VERSION}, Expected: ${version}"
           [ "$BUILT_VERSION" = "${version}" ] || { echo "Version mismatch!"; exit 1; }
@@ -192,12 +192,12 @@ jobs:
         if: steps.platform-package.outputs.published != 'true'
         working-directory: rust
         run: |
-          binary_name="cpd"
-          if [ "${{ matrix.target.os }}" = "win32" ]; then
-            binary_name="cpd.exe"
-          fi
           mkdir -p target/release-assets
-          tar -czf "target/release-assets/cpd-${{ matrix.target.key }}.tar.gz" \
+          binary_name="jscpd"
+          if [ "${{ matrix.target.os }}" = "win32" ]; then
+            binary_name="jscpd.exe"
+          fi
+          tar -czf "target/release-assets/jscpd-${{ matrix.target.key }}.tar.gz" \
             -C "target/${{ matrix.target.rustTarget }}/release" \
             "$binary_name"
 
@@ -205,8 +205,8 @@ jobs:
         if: steps.platform-package.outputs.published != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: cpd-binary-${{ matrix.target.key }}
-          path: rust/target/release-assets/cpd-${{ matrix.target.key }}.tar.gz
+          name: jscpd-binary-${{ matrix.target.key }}
+          path: rust/target/release-assets/jscpd-${{ matrix.target.key }}.tar.gz
           retention-days: 1
 
       - name: Install pnpm
@@ -325,7 +325,7 @@ jobs:
       - name: Fixture check
         working-directory: rust
         run: |
-          cpd ../fixtures --silent --reporters json || true
+          jscpd ../fixtures --silent --reporters json || true
 
       - name: Setup Node.js for publish
         uses: actions/setup-node@v5

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -87,7 +87,7 @@ jobs:
           done
 
           # ── npm packages ──
-          npm_pkgs=(cpd jscpd cpd-darwin-arm64 cpd-darwin-x64 cpd-linux-x64-gnu cpd-linux-arm64-gnu cpd-linux-x64-musl cpd-windows-x64-msvc)
+          npm_pkgs=(cpd jscpd jscpd-darwin-arm64 jscpd-darwin-x64 jscpd-linux-x64-gnu jscpd-linux-arm64-gnu jscpd-linux-x64-musl jscpd-windows-x64-msvc)
           for pkg in "${npm_pkgs[@]}"; do
             pub_ver=$(npm view "${pkg}@${version}" version 2>/dev/null || echo "")
             if [ "$pub_ver" = "$version" ]; then
@@ -110,7 +110,7 @@ jobs:
       - name: Download binary artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: cpd-binary-*
+          pattern: jscpd-binary-*
           path: release-assets
           merge-multiple: true
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,7 +372,7 @@ jobs:
       - name: Download binary artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: cpd-binary-*
+          pattern: jscpd-binary-*
           path: release-assets
           merge-multiple: true
         continue-on-error: true
@@ -402,7 +402,7 @@ jobs:
           done
 
           # ── npm packages ──
-          npm_pkgs=(cpd jscpd cpd-darwin-arm64 cpd-darwin-x64 cpd-linux-x64-gnu cpd-linux-arm64-gnu cpd-linux-x64-musl cpd-windows-x64-msvc)
+          npm_pkgs=(cpd jscpd jscpd-darwin-arm64 jscpd-darwin-x64 jscpd-linux-x64-gnu jscpd-linux-arm64-gnu jscpd-linux-x64-musl jscpd-windows-x64-msvc)
           for pkg in "${npm_pkgs[@]}"; do
             pub_ver=$(npm view "${pkg}@${version}" version 2>/dev/null || echo "")
             if [ "$pub_ver" = "$version" ]; then

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/rust/crates/cpd-reporter/Cargo.toml
+++ b/rust/crates/cpd-reporter/Cargo.toml
@@ -13,7 +13,7 @@ cpd-core = { version = "0.1.6", path = "../cpd-core" }
 cpd-finder = { version = "0.1.7", path = "../cpd-finder" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-quick-xml = { version = "0.36", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 csv = "1"
 askama = "0.12"
 thiserror = "2"

--- a/rust/jscpd/package.json
+++ b/rust/jscpd/package.json
@@ -11,12 +11,12 @@
     "platform-map.js"
   ],
   "optionalDependencies": {
-    "cpd-linux-x64-gnu": "5.0.11",
-    "cpd-linux-arm64-gnu": "5.0.11",
-    "cpd-linux-x64-musl": "5.0.11",
-    "cpd-darwin-arm64": "5.0.11",
-    "cpd-darwin-x64": "5.0.11",
-    "cpd-windows-x64-msvc": "5.0.11"
+    "jscpd-linux-x64-gnu": "5.0.11",
+    "jscpd-linux-arm64-gnu": "5.0.11",
+    "jscpd-linux-x64-musl": "5.0.11",
+    "jscpd-darwin-arm64": "5.0.11",
+    "jscpd-darwin-x64": "5.0.11",
+    "jscpd-windows-x64-msvc": "5.0.11"
   },
   "repository": {
     "type": "git",

--- a/rust/jscpd/platform-map.js
+++ b/rust/jscpd/platform-map.js
@@ -4,7 +4,7 @@ const { platform, arch } = process;
 
 const PLATFORM_MAP = {
   "linux-x64-gnu": {
-    packageName: "cpd-linux-x64-gnu",
+    packageName: "jscpd-linux-x64-gnu",
     os: "linux",
     cpu: "x64",
     libc: "glibc",
@@ -12,7 +12,7 @@ const PLATFORM_MAP = {
     runner: "ubuntu-latest",
   },
   "linux-arm64-gnu": {
-    packageName: "cpd-linux-arm64-gnu",
+    packageName: "jscpd-linux-arm64-gnu",
     os: "linux",
     cpu: "arm64",
     libc: "glibc",
@@ -20,7 +20,7 @@ const PLATFORM_MAP = {
     runner: "ubuntu-latest",
   },
   "linux-x64-musl": {
-    packageName: "cpd-linux-x64-musl",
+    packageName: "jscpd-linux-x64-musl",
     os: "linux",
     cpu: "x64",
     libc: "musl",
@@ -28,21 +28,21 @@ const PLATFORM_MAP = {
     runner: "ubuntu-latest",
   },
   "darwin-arm64": {
-    packageName: "cpd-darwin-arm64",
+    packageName: "jscpd-darwin-arm64",
     os: "darwin",
     cpu: "arm64",
     rustTarget: "aarch64-apple-darwin",
     runner: "macos-latest",
   },
   "darwin-x64": {
-    packageName: "cpd-darwin-x64",
+    packageName: "jscpd-darwin-x64",
     os: "darwin",
     cpu: "x64",
     rustTarget: "x86_64-apple-darwin",
     runner: "macos-13",
   },
   "windows-x64-msvc": {
-    packageName: "cpd-windows-x64-msvc",
+    packageName: "jscpd-windows-x64-msvc",
     os: "win32",
     cpu: "x64",
     rustTarget: "x86_64-pc-windows-msvc",

--- a/rust/jscpd/run-jscpd.js
+++ b/rust/jscpd/run-jscpd.js
@@ -14,14 +14,14 @@ if (!key) {
 }
 
 const entry = PLATFORM_MAP[key];
-const binaryName = process.platform === "win32" ? "cpd.exe" : "cpd";
+const binaryName = process.platform === "win32" ? "jscpd.exe" : "jscpd";
 
 let binaryPath;
 try {
   const pkgJson = require.resolve(`${entry.packageName}/package.json`, {
     paths: [path.resolve(__dirname, ".."), __dirname],
   });
-  binaryPath = path.join(path.dirname(pkgJson), "cpd-bin", binaryName);
+  binaryPath = path.join(path.dirname(pkgJson), "bin", binaryName);
 } catch {
   const localBuild = path.join(
     __dirname,

--- a/rust/npm/jscpd-darwin-arm64/package.json
+++ b/rust/npm/jscpd-darwin-arm64/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "cpd-darwin-arm64",
+  "name": "jscpd-darwin-arm64",
   "version": "5.0.2",
-  "description": "Prebuilt macOS arm64 binaries for cpd",
+  "description": "Prebuilt macOS arm64 binaries for jscpd",
   "homepage": "https://jscpd.dev",
   "license": "MIT",
   "os": ["darwin"],
   "cpu": ["arm64"],
-  "files": ["cpd-bin"],
+  "files": ["bin"],
   "publishConfig": {
     "access": "public"
   }

--- a/rust/npm/jscpd-darwin-x64/package.json
+++ b/rust/npm/jscpd-darwin-x64/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "cpd-windows-x64-msvc",
+  "name": "jscpd-darwin-x64",
   "version": "5.0.2",
-  "description": "Prebuilt Windows x64 binaries for cpd",
+  "description": "Prebuilt macOS x64 binaries for jscpd",
   "homepage": "https://jscpd.dev",
   "license": "MIT",
-  "os": ["win32"],
+  "os": ["darwin"],
   "cpu": ["x64"],
-  "files": ["cpd-bin"],
+  "files": ["bin"],
   "publishConfig": {
     "access": "public"
   }

--- a/rust/npm/jscpd-linux-arm64-gnu/package.json
+++ b/rust/npm/jscpd-linux-arm64-gnu/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "cpd-linux-arm64-gnu",
+  "name": "jscpd-linux-arm64-gnu",
   "version": "5.0.2",
-  "description": "Prebuilt Linux arm64 GNU binaries for cpd",
+  "description": "Prebuilt Linux arm64 GNU binaries for jscpd",
   "homepage": "https://jscpd.dev",
   "license": "MIT",
   "os": ["linux"],
   "cpu": ["arm64"],
   "libc": ["glibc"],
-  "files": ["cpd-bin"],
+  "files": ["bin"],
   "publishConfig": {
     "access": "public"
   }

--- a/rust/npm/jscpd-linux-x64-gnu/package.json
+++ b/rust/npm/jscpd-linux-x64-gnu/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "cpd-linux-x64-musl",
+  "name": "jscpd-linux-x64-gnu",
   "version": "5.0.2",
-  "description": "Prebuilt Linux x64 musl binaries for cpd",
+  "description": "Prebuilt Linux x64 GNU binaries for jscpd",
   "homepage": "https://jscpd.dev",
   "license": "MIT",
   "os": ["linux"],
   "cpu": ["x64"],
-  "libc": ["musl"],
-  "files": ["cpd-bin"],
+  "libc": ["glibc"],
+  "files": ["bin"],
   "publishConfig": {
     "access": "public"
   }

--- a/rust/npm/jscpd-linux-x64-musl/package.json
+++ b/rust/npm/jscpd-linux-x64-musl/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "cpd-linux-x64-gnu",
+  "name": "jscpd-linux-x64-musl",
   "version": "5.0.2",
-  "description": "Prebuilt Linux x64 GNU binaries for cpd",
+  "description": "Prebuilt Linux x64 musl binaries for jscpd",
   "homepage": "https://jscpd.dev",
   "license": "MIT",
   "os": ["linux"],
   "cpu": ["x64"],
-  "libc": ["glibc"],
-  "files": ["cpd-bin"],
+  "libc": ["musl"],
+  "files": ["bin"],
   "publishConfig": {
     "access": "public"
   }

--- a/rust/npm/jscpd-windows-x64-msvc/package.json
+++ b/rust/npm/jscpd-windows-x64-msvc/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "cpd-darwin-x64",
+  "name": "jscpd-windows-x64-msvc",
   "version": "5.0.2",
-  "description": "Prebuilt macOS x64 binaries for cpd",
+  "description": "Prebuilt Windows x64 binaries for jscpd",
   "homepage": "https://jscpd.dev",
   "license": "MIT",
-  "os": ["darwin"],
+  "os": ["win32"],
   "cpu": ["x64"],
-  "files": ["cpd-bin"],
+  "files": ["bin"],
   "publishConfig": {
     "access": "public"
   }

--- a/rust/npm/prebuilt-targets.json
+++ b/rust/npm/prebuilt-targets.json
@@ -1,7 +1,7 @@
 {
   "linux-x64-gnu": {
-    "packageName": "cpd-linux-x64-gnu",
-    "description": "Prebuilt Linux x64 GNU binaries for cpd",
+    "packageName": "jscpd-linux-x64-gnu",
+    "description": "Prebuilt Linux x64 GNU binaries for jscpd",
     "os": "linux",
     "cpu": "x64",
     "libc": "glibc",
@@ -9,8 +9,8 @@
     "runner": "ubuntu-latest"
   },
   "linux-arm64-gnu": {
-    "packageName": "cpd-linux-arm64-gnu",
-    "description": "Prebuilt Linux arm64 GNU binaries for cpd",
+    "packageName": "jscpd-linux-arm64-gnu",
+    "description": "Prebuilt Linux arm64 GNU binaries for jscpd",
     "os": "linux",
     "cpu": "arm64",
     "libc": "glibc",
@@ -18,8 +18,8 @@
     "runner": "ubuntu-22.04-arm"
   },
   "linux-x64-musl": {
-    "packageName": "cpd-linux-x64-musl",
-    "description": "Prebuilt Linux x64 musl binaries for cpd",
+    "packageName": "jscpd-linux-x64-musl",
+    "description": "Prebuilt Linux x64 musl binaries for jscpd",
     "os": "linux",
     "cpu": "x64",
     "libc": "musl",
@@ -27,24 +27,24 @@
     "runner": "ubuntu-latest"
   },
   "darwin-arm64": {
-    "packageName": "cpd-darwin-arm64",
-    "description": "Prebuilt macOS arm64 binaries for cpd",
+    "packageName": "jscpd-darwin-arm64",
+    "description": "Prebuilt macOS arm64 binaries for jscpd",
     "os": "darwin",
     "cpu": "arm64",
     "rustTarget": "aarch64-apple-darwin",
     "runner": "macos-latest"
   },
   "darwin-x64": {
-    "packageName": "cpd-darwin-x64",
-    "description": "Prebuilt macOS x64 binaries for cpd",
+    "packageName": "jscpd-darwin-x64",
+    "description": "Prebuilt macOS x64 binaries for jscpd",
     "os": "darwin",
     "cpu": "x64",
     "rustTarget": "x86_64-apple-darwin",
     "runner": "macos-13"
   },
   "windows-x64-msvc": {
-    "packageName": "cpd-windows-x64-msvc",
-    "description": "Prebuilt Windows x64 binaries for cpd",
+    "packageName": "jscpd-windows-x64-msvc",
+    "description": "Prebuilt Windows x64 binaries for jscpd",
     "os": "win32",
     "cpu": "x64",
     "rustTarget": "x86_64-pc-windows-msvc",

--- a/rust/package.json
+++ b/rust/package.json
@@ -11,12 +11,12 @@
     "platform-map.js"
   ],
   "optionalDependencies": {
-    "cpd-linux-x64-gnu": "5.0.11",
-    "cpd-linux-arm64-gnu": "5.0.11",
-    "cpd-linux-x64-musl": "5.0.11",
-    "cpd-darwin-arm64": "5.0.11",
-    "cpd-darwin-x64": "5.0.11",
-    "cpd-windows-x64-msvc": "5.0.11"
+    "jscpd-linux-x64-gnu": "5.0.11",
+    "jscpd-linux-arm64-gnu": "5.0.11",
+    "jscpd-linux-x64-musl": "5.0.11",
+    "jscpd-darwin-arm64": "5.0.11",
+    "jscpd-darwin-x64": "5.0.11",
+    "jscpd-windows-x64-msvc": "5.0.11"
   },
   "repository": {
     "type": "git",

--- a/rust/platform-map.js
+++ b/rust/platform-map.js
@@ -4,7 +4,7 @@ const { platform, arch } = process;
 
 const PLATFORM_MAP = {
   "linux-x64-gnu": {
-    packageName: "cpd-linux-x64-gnu",
+    packageName: "jscpd-linux-x64-gnu",
     os: "linux",
     cpu: "x64",
     libc: "glibc",
@@ -12,7 +12,7 @@ const PLATFORM_MAP = {
     runner: "ubuntu-latest",
   },
   "linux-arm64-gnu": {
-    packageName: "cpd-linux-arm64-gnu",
+    packageName: "jscpd-linux-arm64-gnu",
     os: "linux",
     cpu: "arm64",
     libc: "glibc",
@@ -20,7 +20,7 @@ const PLATFORM_MAP = {
     runner: "ubuntu-latest",
   },
   "linux-x64-musl": {
-    packageName: "cpd-linux-x64-musl",
+    packageName: "jscpd-linux-x64-musl",
     os: "linux",
     cpu: "x64",
     libc: "musl",
@@ -28,21 +28,21 @@ const PLATFORM_MAP = {
     runner: "ubuntu-latest",
   },
   "darwin-arm64": {
-    packageName: "cpd-darwin-arm64",
+    packageName: "jscpd-darwin-arm64",
     os: "darwin",
     cpu: "arm64",
     rustTarget: "aarch64-apple-darwin",
     runner: "macos-latest",
   },
   "darwin-x64": {
-    packageName: "cpd-darwin-x64",
+    packageName: "jscpd-darwin-x64",
     os: "darwin",
     cpu: "x64",
     rustTarget: "x86_64-apple-darwin",
     runner: "macos-13",
   },
   "windows-x64-msvc": {
-    packageName: "cpd-windows-x64-msvc",
+    packageName: "jscpd-windows-x64-msvc",
     os: "win32",
     cpu: "x64",
     rustTarget: "x86_64-pc-windows-msvc",

--- a/rust/run-cpd.js
+++ b/rust/run-cpd.js
@@ -14,14 +14,14 @@ if (!key) {
 }
 
 const entry = PLATFORM_MAP[key];
-const binaryName = process.platform === "win32" ? "cpd.exe" : "cpd";
+const binaryName = process.platform === "win32" ? "jscpd.exe" : "jscpd";
 
 let binaryPath;
 try {
   const pkgJson = require.resolve(`${entry.packageName}/package.json`, {
     paths: [path.resolve(__dirname, ".."), __dirname],
   });
-  binaryPath = path.join(path.dirname(pkgJson), "cpd-bin", binaryName);
+  binaryPath = path.join(path.dirname(pkgJson), "bin", binaryName);
 } catch {
   const localBuild = path.join(
     __dirname,

--- a/rust/scripts/npm-prebuilt-package.mjs
+++ b/rust/scripts/npm-prebuilt-package.mjs
@@ -50,7 +50,7 @@ function copyBinary(name, target, binDir, packageDir) {
     process.exit(1);
   }
 
-  const to = path.join(packageDir, "cpd-bin", fileName);
+  const to = path.join(packageDir, "bin", fileName);
   fs.mkdirSync(path.dirname(to), { recursive: true });
   fs.copyFileSync(from, to);
   if (target.os !== "win32") {
@@ -75,7 +75,7 @@ const packageDir = path.resolve(args["out-dir"], target.packageName);
 fs.rmSync(packageDir, { recursive: true, force: true });
 fs.mkdirSync(packageDir, { recursive: true });
 
-copyBinary("cpd", target, path.resolve(args["bin-dir"]), packageDir);
+copyBinary("jscpd", target, path.resolve(args["bin-dir"]), packageDir);
 
 fs.copyFileSync(
   LICENSE_PATH,
@@ -95,12 +95,12 @@ a fast Rust implementation of the copy/paste detector.
 Do not install this package directly. Install the main package instead:
 
 \`\`\`bash
-npm install -g cpd
-# or
 npm install -g jscpd
+# or
+npm install -g cpd
 \`\`\`
 
-This package contains only the native \`cpd\` binary
+This package contains only the native \`jscpd\` binary
 for its target platform, plus package metadata and license/readme files.
 
 Supply-chain notes:
@@ -122,7 +122,7 @@ const packageJson = {
   license: rootPackage.license,
   repository: rootPackage.repository,
   keywords: [
-    "cpd",
+    "jscpd",
     "prebuilt",
     "native-binary",
     "platform-package",
@@ -130,7 +130,7 @@ const packageJson = {
   ],
   os: [target.os],
   cpu: [target.cpu],
-  files: ["cpd-bin", "LICENSE", "README.md"],
+  files: ["bin", "LICENSE", "README.md"],
   publishConfig: {
     access: "public",
   },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** Bug fix

* **What is the current behavior?** The Rust CLI ships a binary named `cpd` (`cpd.exe` on Windows), and the platform-specific optional-dependency npm packages are named `cpd-*`. `cpd.exe` collides with an executable name already flagged by some antivirus software (McAfee, Trend Micro), causing false-positive blocking. See #826.

* **What is the new behavior (if this is a feature change)?** The compiled binary is renamed to `jscpd` (`jscpd.exe` on Windows), and the platform npm packages are renamed from `cpd-linux-x64-gnu`, `cpd-darwin-arm64`, etc. to `jscpd-linux-x64-gnu`, `jscpd-darwin-arm64`, etc. The binary subfolder inside each platform package is renamed from `cpd-bin` to `bin`. CI workflows (`npm-rust-publish.yml`, `release-rust.yml`, `release.yml`) and packaging scripts are updated to match. Both the `cpd` and `jscpd` npm CLI wrapper packages continue to be published, they just resolve to the renamed `jscpd` binary under the hood.

* **Other information**: Fixes #826

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/854)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the packaged command and downloadable binaries to use the `jscpd` name across supported platforms.
  * Prebuilt npm packages now publish the native `jscpd` binary from the standard `bin` directory.

* **Bug Fixes**
  * Improved release and publish workflows so the correct `jscpd` artifacts are selected, validated, and uploaded.
  * CLI launch behavior now resolves and runs the matching `jscpd` executable consistently across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->