### PR TITLE
fix(rust): keep reporter source paths resolvable from CWD

### DIFF
--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -221,25 +221,27 @@ fn main() {
     let mut clones = run_result.clones;
     let statistics = run_result.statistics;
 
-    // Path normalization: by default, relativize source_ids to their scan
-    // root (falling back to CWD) for cleaner display. With --absolute,
-    // ensure they stay absolute. Source IDs arrive canonicalized from the
-    // finder, so we canonicalize the scan roots here too — this makes
-    // prefix stripping work regardless of how the user invoked the CLI
-    // (`jscpd .` vs `jscpd /abs/path`) and across macOS symlinked roots
-    // (`/var` vs `/private/var`) or Windows verbatim prefixes (`\\?\`).
+    // Path normalization: by default, relativize source_ids to the current
+    // working directory for cleaner display. Crucially, the resulting paths
+    // must stay resolvable from the CWD — every file reporter (html, json,
+    // console-full) re-reads the source from disk to render snippets, so a
+    // path that doesn't resolve produces empty code. That means we relativize
+    // to the CWD (not the scan root): scanning `frontend-server` from the
+    // project root yields `frontend-server/src/a.js`, which both reads back
+    // and distinguishes multiple scan roots. Source IDs arrive canonicalized
+    // from the finder, so we canonicalize the CWD too — this makes prefix
+    // stripping work across macOS symlinked roots (`/var` vs `/private/var`)
+    // or Windows verbatim prefixes (`\\?\`). Paths outside the CWD are left
+    // absolute (still readable). With --absolute, force absolute.
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-    let scan_roots: Vec<std::path::PathBuf> = paths
-        .iter()
-        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
-        .collect();
+    let cwd = std::fs::canonicalize(&cwd).unwrap_or(cwd);
     for clone in &mut clones {
         if opts.absolute {
             make_path_absolute(&mut clone.fragment_a.source_id);
             make_path_absolute(&mut clone.fragment_b.source_id);
         } else {
-            relativize_to_scan_root(&mut clone.fragment_a.source_id, &scan_roots, &cwd);
-            relativize_to_scan_root(&mut clone.fragment_b.source_id, &scan_roots, &cwd);
+            relativize_to_cwd(&mut clone.fragment_a.source_id, &cwd);
+            relativize_to_cwd(&mut clone.fragment_b.source_id, &cwd);
         }
     }
 
@@ -410,24 +412,17 @@ fn strip_dot_prefix(s: &str) -> String {
     }
 }
 
-/// Relativize a canonicalized `source_id` for display when `--absolute` is off.
+/// Relativize a canonicalized `source_id` to the CWD for display when
+/// `--absolute` is off.
 ///
-/// Tries each canonicalized scan root first (so `jscpd /abs/path` emits paths
-/// relative to `/abs/path`), then falls back to CWD. Strips any leading `./`
-/// or `.\` component. If nothing matches, the path is returned with the dot
-/// prefix removed but otherwise unchanged.
-fn relativize_to_scan_root(
-    source_id: &mut String,
-    scan_roots: &[std::path::PathBuf],
-    cwd: &std::path::Path,
-) {
+/// Stripping the CWD prefix keeps the path resolvable from the CWD, which the
+/// file reporters rely on when they re-read the source to render snippets.
+/// Paths outside the CWD are left unchanged (they remain absolute, and thus
+/// still readable) rather than being made relative to a scan root — a
+/// scan-root-relative path would not resolve from the CWD and would render as
+/// empty code. Any leading `./` or `.\` component is stripped.
+fn relativize_to_cwd(source_id: &mut String, cwd: &std::path::Path) {
     let path = std::path::Path::new(source_id);
-    for root in scan_roots {
-        if let Ok(stripped) = path.strip_prefix(root) {
-            *source_id = strip_dot_prefix(&stripped.to_string_lossy());
-            return;
-        }
-    }
     if let Ok(stripped) = path.strip_prefix(cwd) {
         *source_id = strip_dot_prefix(&stripped.to_string_lossy());
         return;
@@ -496,10 +491,6 @@ mod tests {
         assert!(!is_console_reporter("html"));
     }
 
-    fn pathbuf(s: &str) -> std::path::PathBuf {
-        std::path::PathBuf::from(s)
-    }
-
     #[test]
     fn strip_dot_prefix_unix() {
         assert_eq!(strip_dot_prefix("./src/foo.rs"), "src/foo.rs");
@@ -514,57 +505,31 @@ mod tests {
     }
 
     #[test]
-    fn relativize_strips_matching_scan_root() {
-        let mut id = "/project/src/foo.rs".to_string();
-        relativize_to_scan_root(
-            &mut id,
-            &[pathbuf("/project")],
-            std::path::Path::new("/elsewhere"),
-        );
-        assert_eq!(id, "src/foo.rs");
+    fn relativize_strips_cwd_prefix() {
+        // Scanning a subdirectory of the CWD yields a CWD-relative path that
+        // still resolves from the CWD (so reporters can re-read the file).
+        let mut id = "/project/frontend-server/src/foo.rs".to_string();
+        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
+        assert_eq!(id, "frontend-server/src/foo.rs");
     }
 
     #[test]
-    fn relativize_falls_back_to_cwd_when_not_under_scan_root() {
-        let mut id = "/project/src/foo.rs".to_string();
-        relativize_to_scan_root(
-            &mut id,
-            &[pathbuf("/other")],
-            std::path::Path::new("/project"),
-        );
-        assert_eq!(id, "src/foo.rs");
-    }
-
-    #[test]
-    fn relativize_picks_correct_root_when_multiple_given() {
-        let mut id = "/b/x.rs".to_string();
-        relativize_to_scan_root(
-            &mut id,
-            &[pathbuf("/a"), pathbuf("/b")],
-            std::path::Path::new("/c"),
-        );
-        assert_eq!(id, "x.rs");
-    }
-
-    #[test]
-    fn relativize_keeps_path_when_under_no_root_or_cwd() {
+    fn relativize_keeps_absolute_path_outside_cwd() {
+        // A file outside the CWD stays absolute (still readable) rather than
+        // being rewritten to a non-resolvable relative path.
         let mut id = "/elsewhere/src/foo.rs".to_string();
-        relativize_to_scan_root(
-            &mut id,
-            &[pathbuf("/project")],
-            std::path::Path::new("/project"),
-        );
+        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
         assert_eq!(id, "/elsewhere/src/foo.rs");
     }
 
     #[test]
-    fn relativize_strips_dot_prefix_when_canonicalize_failed() {
+    fn relativize_strips_dot_prefix_when_not_under_cwd() {
         let mut id = "./src/foo.rs".to_string();
-        relativize_to_scan_root(&mut id, &[], std::path::Path::new("/project"));
+        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
         assert_eq!(id, "src/foo.rs");
 
         let mut id = ".\\src\\foo.rs".to_string();
-        relativize_to_scan_root(&mut id, &[], std::path::Path::new("/project"));
+        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
         assert_eq!(id, "src\\foo.rs");
     }
 }

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -383,7 +383,7 @@ fn report_snippets_populated_when_scan_root_differs_from_cwd() {
     // Display path must be CWD-relative and therefore keep the scan-root
     // subdirectory prefix (so it still resolves from the CWD).
     assert!(
-        json.contains("pkg/a.js") || json.contains("pkg\\a.js"),
+        json.contains("pkg/a.js") || json.contains(r"pkg\\a.js"),
         "source path must stay relative to the CWD (keep the `pkg/` prefix)"
     );
 

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -316,6 +316,81 @@ fn cli_ignore_pattern_flag_accepted() {
 }
 
 #[test]
+fn report_snippets_populated_when_scan_root_differs_from_cwd() {
+    // Regression test for the empty "show code" bug: the html/json reporters
+    // re-read each source file from disk to render snippets. When the scan
+    // root is a *subdirectory* of the CWD (e.g. config `path: ["pkg"]`, or
+    // `cpd pkg`), the displayed source path must stay resolvable from the CWD
+    // — otherwise the read fails silently and the snippet renders empty.
+    let bin = match maybe_bin() {
+        Some(b) => b,
+        None => return,
+    };
+
+    // Fresh, uniquely-named temp workspace with a `pkg/` subdirectory.
+    let root = std::env::temp_dir().join(format!("cpd-snippet-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let pkg = root.join("pkg");
+    std::fs::create_dir_all(&pkg).expect("create pkg dir");
+
+    let dup = "function greet(name) {\n  \
+        const message = \"Hello, \" + name + \"!\";\n  \
+        console.log(message);\n  \
+        console.log(\"Welcome to the system\");\n  \
+        console.log(\"Have a nice day now\");\n  \
+        return message;\n}\n";
+    std::fs::write(pkg.join("a.js"), dup).expect("write a.js");
+    std::fs::write(pkg.join("b.js"), dup).expect("write b.js");
+
+    let out = root.join("report");
+
+    // Run from `root`, scanning the `pkg` subdirectory: scan root != CWD.
+    let output = Command::new(&bin)
+        .args([
+            "pkg",
+            "--min-tokens",
+            "10",
+            "--reporters",
+            "json,html",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cpd");
+    assert!(
+        output.status.success(),
+        "cpd must succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // A code line that appears only inside the duplicated snippet, never in
+    // report metadata — so its presence proves the snippet was read.
+    let marker = "Welcome to the system";
+
+    let json = std::fs::read_to_string(out.join("jscpd-report.json")).expect("json report exists");
+    assert!(
+        json.contains(marker),
+        "JSON report must contain the duplicated snippet; empty means the read path regressed"
+    );
+
+    let html = std::fs::read_to_string(out.join("jscpd-report.html")).expect("html report exists");
+    assert!(
+        html.contains(marker),
+        "HTML report must contain the duplicated snippet; empty means the read path regressed"
+    );
+
+    // Display path must be CWD-relative and therefore keep the scan-root
+    // subdirectory prefix (so it still resolves from the CWD).
+    assert!(
+        json.contains("pkg/a.js") || json.contains("pkg\\a.js"),
+        "source path must stay relative to the CWD (keep the `pkg/` prefix)"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn cli_both_ignore_flags_work_together() {
     let output = run_cpd([
         "--ignore",


### PR DESCRIPTION
fix(rust): keep reporter source paths resolvable from CWD (empty HTML/JSON code)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix (Rust cpd / v5).


* **What is the current behavior?** (You can also link to an open issue here)

When a scan target is a subdirectory of the current working directory - e.g. `path: ["frontend", "backend"]` in `.jscpd.json`, or `cpd some-subdir` - the HTML report's "show code" blocks are empty, and the JSON report's fragment field is an empty string. Running `cpd .` (scanning the `CWD` directly) works, which is the confusing part.

Root cause: the file reporters (`html`, `json`, `console-full`) re-read each source file from disk to render its snippet. Since #827, source paths are rewritten to be relative to the scan root for display (`/proj/frontend/src/a.js` -> `src/a.js`). The reporters then call `std::fs::read_to_string("src/a.js")`, which resolves against the `CWD` (/proj), where that path does not exist. The read fails and is swallowed by read_file_cached's `unwrap_or_default()`, yielding empty code. Passing `.` masks the bug because the scan root then equals the `CWD`, so the rewritten path still resolves.

* **What is the new behavior (if this is a feature change)?**

Display paths are now made relative to the `CWD` instead of the scan root, so they remain resolvable from the `CWD` and the reporters can re-read the source. Scanning `frontend` from the project root now yields `frontend/src/a.js` -- which both renders code correctly and disambiguates multiple scan roots (`frontend/...` vs `backend/...`). Files outside the `CWD` are left absolute (still readable). `--absolute` is unaffected.

* **Other information**:

- Implementation: replaced `relativize_to_scan_root` with `relativize_to_cwd` in `rust/crates/cpd/src/main.rs` (canonicalizes the `CWD` for reliable prefix stripping); updated unit tests.
- Added an integration regression test (`report_snippets_populated_when_scan_root_differs_from_cwd`) that scans a subdirectory (scan root != `CWD`) and asserts both HTML and JSON contain the snippet. Verified it fails on the old behavior and passes with the fix.
- Test suite: cargo test passes (620+ across the workspace; 375 in the jscpd crate).
- Behavior note for reviewers familiar with #827: scanning an absolute path outside the `CWD` now displays absolute paths rather than scan-root-relative ones. This is the deliberate tradeoff -- a scan-root-relative path is not resolvable from the `CWD` and is exactly what caused the empty-code bug.
- Known follow-up (not in this PR): `read_file_cached` swallows read failures via `unwrap_or_default()`; it should emit a warning so this class of bug is not silent.
- If this behavior is preferred, an alternative is to keep scan-root-relative display and resolve reads against the scan roots.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/869)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed source path handling in JSON and HTML reports when the scan root is a subdirectory of the current working directory, preventing rendered snippet output from appearing empty.
  * Improved path normalization so paths inside the current directory stay relative, while paths outside it keep absolute forms to remain resolvable.

* **Tests**
  * Added a regression test covering snippet rendering and source path preservation across JSON and HTML outputs when scan roots differ from the process working directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- brian settings start --><!--{}--><!-- brian settings end -->