### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/docs/ai-ready.md
+++ b/docs/ai-ready.md
@@ -100,6 +100,14 @@ Add to your MCP client config (e.g. Claude Desktop):
 }
 ```
 
+With [Autohand Code](https://github.com/autohandai/code-cli/), register the running HTTP endpoint from the CLI:
+
+```bash
+autohand mcp add --transport http jscpd http://localhost:3000/mcp
+```
+
+Add `--scope project` to keep the registration in the current workspace.
+
 ### REST API
 
 | Method | Path | Description |


### PR DESCRIPTION
## What changed

- added a direct Autohand Code command for the running jscpd streamable HTTP endpoint
- noted the project-scoped alternative and linked to the current CLI documentation

## Why

The AI-ready guide already explains how to start jscpd-server and connect an MCP client. This gives Autohand Code users the equivalent copy-paste registration without changing the server workflow.

## Verification

- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/870)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP configuration instructions with steps for registering a running HTTP endpoint through the Autohand Code CLI.
  * Clarified how project-scoped registration works.
  * Documented isolated, temporary snippet checking with automatic cleanup and concurrency safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->