### PR TITLE
Add token-count badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ![NPM License](https://img.shields.io/npm/l/jscpd)
 [![jscpd CI](https://github.com/kucherenko/jscpd/actions/workflows/nodejs.yml/badge.svg)](https://github.com/kucherenko/jscpd/actions/workflows/nodejs.yml)
+![tokens](https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/kucherenko/jscpd)
 
 > Copy/paste detector for programming source code. Supports 224+ formats. AI-ready with MCP server and token-efficient reporter. Now with a Rust-powered engine — 24-37x faster.
 


### PR DESCRIPTION
Hi! This PR adds one line to the README: a badge showing an estimate of how many LLM tokens this repo weighs. Since this project is the kind of thing people load into an LLM's context window, the number seemed genuinely useful to surface.

Preview: ![tokens](https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/kucherenko/jscpd)

Full disclosure: I built the free, open-source service behind the badge (https://github.com/rsamf/gittokens), and I'm proposing it to a small, hand-picked set of repos where it seems like a good fit. If it isn't a fit here, please just close this, and I won't resubmit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/873)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a tokens badge to the project README alongside the existing status badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->