### PR TITLE
docs: clarify camelCase config keys

### DIFF
--- a/apps/jscpd/README.md
+++ b/apps/jscpd/README.md
@@ -199,7 +199,9 @@ The threshold for duplication level, check if current level of duplications bigg
  - Default: **null**
 ### Config
 
-The path to configuration file. The config should be in `json` format. Supported options in config file can be the same with cli options.
+The path to the configuration file. The config should be in `json` format.
+Configuration keys match the CLI options but use camelCase instead of
+kebab-case (for example, `minLines` instead of `--min-lines`).
 
  - Cli options: `--config`, `-c`
  - Type: **path**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Documentation update.

Closes #605.

* **What is the current behavior?** (You can also link to an open issue here)

The npm README says configuration options are the same as CLI options without explaining that CLI flags are kebab-case while JSON configuration keys are camelCase. This can lead users to try unsupported keys such as `min-lines`.

* **What is the new behavior (if this is a feature change)?**

The Config option documentation now states the casing rule explicitly and gives the concrete `--min-lines` to `minLines` mapping.

* **Other information**:

- `git diff --check` passes.
- The existing Config File examples already use camelCase and remain unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/880)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that configuration files use JSON format.
  * Documented that configuration keys use camelCase equivalents of CLI options, with an example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->