### PR TITLE
fix(tokenizer): count source lines inclusively

### DIFF
--- a/apps/jscpd/__tests__/options.test.ts
+++ b/apps/jscpd/__tests__/options.test.ts
@@ -191,7 +191,7 @@ describe('jscpd options', () => {
       expect(log.mock.calls.length).toEqual(1);
       expect(
         log
-      ).toHaveBeenCalledWith(`Duplications detection: Found ${bold('1')} exact clones with ${bold('10')}(35.71%) duplicated lines in ${bold('1')} (1 formats) files.`);
+      ).toHaveBeenCalledWith(`Duplications detection: Found ${bold('1')} exact clones with ${bold('10')}(34.48%) duplicated lines in ${bold('1')} (1 formats) files.`);
     });
 
     it('should not print information about clones', async () => {
@@ -237,7 +237,7 @@ describe('jscpd options', () => {
 			try {
         await jscpd(['', '', fileWithClones, '--threshold', '10']);
       } catch (e) {
-				expect(e.message).toEqual('ERROR: jscpd found too many duplicates (35.71%) over threshold (10%)');
+				expect(e.message).toEqual('ERROR: jscpd found too many duplicates (34.48%) over threshold (10%)');
 			}
 		});
 	});
@@ -275,7 +275,7 @@ describe('jscpd options', () => {
       const log = (console.log as any);
       expect(
         log
-      ).toHaveBeenCalledWith(`Duplications detection: Found ${bold('1')} exact clones with ${bold('10')}(35.71%) duplicated lines in ${bold('1')} (1 formats) files.`)
+      ).toHaveBeenCalledWith(`Duplications detection: Found ${bold('1')} exact clones with ${bold('10')}(34.48%) duplicated lines in ${bold('1')} (1 formats) files.`)
     });
     it('should show warning if reporter does not installed', async () => {
       await jscpd(['', '', fileWithClones, '--reporters', 'badgezz', '--silent']);

--- a/packages/tokenizer/__tests__/token-map.test.ts
+++ b/packages/tokenizer/__tests__/token-map.test.ts
@@ -50,21 +50,20 @@ describe('TokensMap', () => {
       expect(typeof map.getTokensCount()).toBe('number');
     });
 
-    it('getLinesCount returns difference between last and first token line', () => {
+    it('getLinesCount includes the first and last token lines', () => {
       const tokens = makeTokens(5);
       const map = new TokensMap('id', 'source', tokens, 'javascript', baseOptions);
-      // first token at line 1, last at line 5 → diff = 4
-      expect(map.getLinesCount()).toBe(4);
+      expect(map.getLinesCount()).toBe(5);
     });
 
-    it('getLinesCount is 0 for single-line tokens', () => {
+    it('getLinesCount is 1 for single-line tokens', () => {
       const tokens = [
         makeToken('a', 'keyword', 'javascript', 0, 1),
         makeToken('b', 'keyword', 'javascript', 2, 1),
         makeToken('c', 'keyword', 'javascript', 4, 1),
       ];
       const map = new TokensMap('id', 'data', tokens, 'javascript', baseOptions);
-      expect(map.getLinesCount()).toBe(0);
+      expect(map.getLinesCount()).toBe(1);
     });
 
     it('lowercases token values when ignoreCase is true', () => {

--- a/packages/tokenizer/src/token-map.ts
+++ b/packages/tokenizer/src/token-map.ts
@@ -55,7 +55,7 @@ export class TokensMap implements ITokensMap, Iterator<IMapFrame|boolean>, Itera
   }
 
   public getLinesCount(): number {
-    return this.tokens[this.tokens.length - 1].loc.end.line - this.tokens[0].loc.start.line;
+    return this.tokens[this.tokens.length - 1].loc.end.line - this.tokens[0].loc.start.line + 1;
   }
 
   public getFormat(): string {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

Closes #475.

* **What is the current behavior?** (You can also link to an open issue here)

`TokensMap.getLinesCount()` subtracts the first token line from the last token line without including both endpoints. A one-line source is therefore reported as 0 lines, and every multi-line source is undercounted by one.

* **What is the new behavior (if this is a feature change)?**

Line counts use the inclusive source span. A one-line token map reports 1 line and tokens spanning lines 1 through 5 report 5 lines.

* **Other information**:

- Updated the focused unit tests for one-line and multi-line token maps.
- `@jscpd/tokenizer` tests: 279 passed.
- `@jscpd/tokenizer` typecheck: passed.
- `@jscpd/tokenizer` build: passed.
- `git diff --check`: passed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/881)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected line counting so ranges include both the starting and ending lines.
  * Updated token line-count behavior to return 1 for single-line tokens instead of 0.
* **Tests**
  * Adjusted unit tests to match the updated `getLinesCount` semantics.
  * Updated option-related assertions to reflect revised duplicate-line percentage calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->