### PR TITLE
feat(rust): add --cross-formats for cross-format clone detection (#810)

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -74,6 +74,7 @@ cpd [OPTIONS] [PATH]...
 | `--ignore-case` | | Ignore case of symbols in code (experimental) | off |
 | `--formats-exts` | | Custom format-to-extension mapping (e.g. `javascript:es,es6;dart:dt`) | — |
 | `--formats-names` | | Custom format-to-filename mapping | — |
+| `--cross-formats` | | Detect clones across formats: `;`-separated groups of `,`-separated formats (e.g. `javascript,typescript`). Preset `js-ts` = `javascript,jsx,typescript,tsx` | — |
 | `--list` | | List all supported formats and exit | — |
 | `--skip-local` | | Skip clones where both fragments are in the same directory | off |
 | `--min-duplicated-lines` | | Minimum percentage of duplication to report (0-100) | 0 |
@@ -165,6 +166,32 @@ v5 supports **223 formats** (verified via `--list`). Use `cpd --list` to see the
 ### Cross-Format Detection
 
 Vue SFC (`.vue`), Svelte (`.svelte`), Astro (`.astro`), and Markdown (`.md`) files are tokenized per-block/per-section, enabling duplicate detection across file types — same as v4.
+
+### Cross-Format Groups (`--cross-formats`)
+
+By default every format is compared in its own isolated pool, so a TypeScript file never matches a near-identical JavaScript file. `--cross-formats` declares format equivalence groups that share one comparison pool — useful for finding leftover `.js` copies during a TypeScript migration:
+
+```bash
+cpd --cross-formats "javascript,typescript" ./src
+cpd --cross-formats js-ts ./src                      # preset: javascript,jsx,typescript,tsx
+cpd --cross-formats "js-ts;css,scss" ./src           # multiple groups
+```
+
+When a group mixes TypeScript (`typescript`/`tsx`) with JavaScript (`javascript`/`jsx`), TypeScript files are compared with erasable type syntax stripped from the detection token stream — type annotations, generics, `interface`/`type` declarations, `as`/`satisfies`, `?`/`!` markers, access modifiers, `implements` clauses, type-only imports/exports, overload signatures, and `declare` statements. Reported clone positions always reference the original sources.
+
+Config file equivalents (all three shapes are accepted):
+
+```json
+{ "crossFormats": "javascript,typescript;css,scss" }
+{ "crossFormats": ["javascript,typescript", "css,scss"] }
+{ "crossFormats": [["javascript", "typescript"], ["css", "scss"]] }
+```
+
+Notes:
+
+- TypeScript syntax with runtime semantics is not erased and will not cross-match: `enum`, non-declare `namespace`, parameter properties (`constructor(private x)`), `import x = require()`, `export =`.
+- A cross-format clone is attributed to one member format in the per-format statistics.
+- Overlapping groups are merged; groups with fewer than two formats are ignored.
 
 ## Differences from jscpd v4 (Node.js)
 

--- a/fixtures/cross-formats/a.ts
+++ b/fixtures/cross-formats/a.ts
@@ -1,0 +1,19 @@
+interface Totals {
+    sum: number;
+    max: number;
+}
+
+function computeTotals(values: number[], threshold: number): Totals {
+    let sum: number = 0;
+    let max: number = 0;
+    for (const value of values) {
+        sum = sum + value;
+        if (value > max) {
+            max = value;
+        }
+    }
+    if (sum > threshold) {
+        sum = sum - threshold;
+    }
+    return { sum: sum, max: max } as Totals;
+}

--- a/fixtures/cross-formats/b.js
+++ b/fixtures/cross-formats/b.js
@@ -1,0 +1,14 @@
+function computeTotals(values, threshold) {
+    let sum = 0;
+    let max = 0;
+    for (const value of values) {
+        sum = sum + value;
+        if (value > max) {
+            max = value;
+        }
+    }
+    if (sum > threshold) {
+        sum = sum - threshold;
+    }
+    return { sum: sum, max: max };
+}

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to **cpd (Rust)** are documented here. Releases follow [Sema
 
 ---
 
+## Unreleased
+
+### New Features
+
+- `--cross-formats` — detect clones across related formats via format equivalence groups sharing one comparison pool, e.g. `--cross-formats "javascript,typescript"` or the `js-ts` preset (`javascript,jsx,typescript,tsx`). When a group mixes TypeScript with JavaScript, TS files are compared with erasable type syntax stripped (positions still reference the original source), so `function f(a: number): void` matches `function f(a)`. Also configurable as `crossFormats` in `.jscpd.json` / `package.json` (string, array-of-strings, or array-of-arrays). Cross-format clones are attributed to one member format in per-format statistics. ([#810](https://github.com/kucherenko/jscpd/issues/810))
+
+---
+
 ## 5.0.12
 
 ### Dependencies

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -333,8 +333,11 @@ dependencies = [
  "cpd-core",
  "log",
  "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
+ "oxc_syntax",
  "regex",
  "serde_json",
  "xxhash-rust",
@@ -739,6 +742,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "oxc_ast_visit"
+version = "0.133.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976e4c8e1874fd007c4e9a729ac0975e15cbc6b715b620cbb9616b73a30828be"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_span",
+ "oxc_syntax",
 ]
 
 [[package]]

--- a/rust/crates/cpd-core/src/detect.rs
+++ b/rust/crates/cpd-core/src/detect.rs
@@ -972,6 +972,38 @@ mod tests {
     }
 
     #[test]
+    fn cross_format_group_detected() {
+        // Inverse of different_formats_not_cross_detected: when two formats
+        // are pooled into ONE prepared group (--cross-formats), identical
+        // token streams match across formats.
+        let to_prepared = |id: &str, format: &str| {
+            let tokens = js_tokens_ab();
+            let mut hashes = Vec::new();
+            let mut spans = Vec::new();
+            for t in &tokens {
+                hashes.push(token_hash(t.kind.discriminant(), &t.value));
+                spans.push((t.start.clone(), t.end.clone()));
+            }
+            PreparedSource {
+                id: id.to_string(),
+                format: format.to_string(),
+                hashes,
+                spans,
+            }
+        };
+        let group = vec![
+            to_prepared("a.js", "javascript"),
+            to_prepared("a.ts", "typescript"),
+        ];
+        let clones = detect_prepared(vec![group], 5, false, 0, &[]);
+        assert_eq!(
+            clones.len(),
+            1,
+            "identical token streams in one pool must match across formats"
+        );
+    }
+
+    #[test]
     fn identical_files_maximal_clone() {
         // With the open_clone state machine, a single maximal clone is emitted
         // instead of multiple sliding-window sub-clones.

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -30,6 +30,9 @@ pub struct RunConfig {
     pub formats_exts: std::collections::HashMap<String, Vec<String>>,
     pub formats_names: std::collections::HashMap<String, Vec<String>>,
     pub pattern: Option<String>,
+    /// Format equivalence groups: formats in the same group share one clone
+    /// detection pool (`--cross-formats`). Empty = every format is isolated.
+    pub cross_formats: Vec<Vec<String>>,
 }
 
 impl Default for RunConfig {
@@ -53,6 +56,7 @@ impl Default for RunConfig {
             formats_exts: std::collections::HashMap::new(),
             formats_names: std::collections::HashMap::new(),
             pattern: None,
+            cross_formats: vec![],
         }
     }
 }
@@ -143,6 +147,8 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
         .filter_map(|p| regex::Regex::new(p).ok())
         .collect();
 
+    let strip_types_formats = strip_types_formats(&config.cross_formats);
+
     const MULTI_FORMAT_EXTS: &[&str] = &["md", "markdown", "mkd", "vue", "svelte", "astro"];
 
     fn is_multi_format(format: &str) -> bool {
@@ -203,6 +209,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
                         ignore_case,
                         ignore_ranges: code_ranges,
                         code_ignore_regexes: code_ignore_regexes.clone(),
+                        strip_types_formats: strip_types_formats.clone(),
                     };
                     let maps = tokenize_to_detection_maps(&file.format, content, &opts);
 
@@ -272,6 +279,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
                         ignore_case,
                         ignore_ranges: code_ranges,
                         code_ignore_regexes: code_ignore_regexes.clone(),
+                        strip_types_formats: strip_types_formats.clone(),
                     };
                     let det_tokens = tokenize_to_detection(&file.format, content, &opts);
                     if det_tokens.len() < min_tokens {
@@ -287,7 +295,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
             .collect()
     });
 
-    let (source_files, mut prepared_sources): (Vec<SourceFile>, Vec<PreparedSource>) =
+    let (source_files, prepared_sources): (Vec<SourceFile>, Vec<PreparedSource>) =
         results.into_iter().fold(
             (Vec::new(), Vec::new()),
             |(mut ss, mut ps), (more_s, more_p)| {
@@ -297,17 +305,8 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
             },
         );
 
-    // 3. Group prepared sources by format (deterministic order).
-    prepared_sources.sort_unstable_by(|a, b| a.format.cmp(&b.format).then(a.id.cmp(&b.id)));
-
-    let mut format_map: std::collections::HashMap<String, Vec<PreparedSource>> =
-        std::collections::HashMap::default();
-    for ps in prepared_sources {
-        format_map.entry(ps.format.clone()).or_default().push(ps);
-    }
-    let mut format_groups: Vec<Vec<PreparedSource>> = format_map.into_values().collect();
-    // Sort groups by format name for determinism.
-    format_groups.sort_by(|a, b| a[0].format.cmp(&b[0].format));
+    // 3. Group prepared sources into detection pools (deterministic order).
+    let format_groups = build_pools(prepared_sources, &config.cross_formats);
 
     // 4. Detect clones — skip_local uses scan roots to determine same-directory pairs.
     //    Both scan roots and file IDs must use the same path normalization so
@@ -340,10 +339,131 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
     })
 }
 
+/// Group prepared sources into detection pools.
+///
+/// Formats named in the same `cross_formats` group share one pool; every
+/// other format keeps its own isolated pool. With no groups configured this
+/// reproduces the historical per-format pools exactly (same membership, same
+/// deterministic order).
+fn build_pools(
+    mut prepared_sources: Vec<PreparedSource>,
+    cross_formats: &[Vec<String>],
+) -> Vec<Vec<PreparedSource>> {
+    let mut group_of: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for (idx, group) in cross_formats.iter().enumerate() {
+        for format in group {
+            group_of.insert(format.as_str(), idx);
+        }
+    }
+
+    // Deterministic file order inside each pool.
+    prepared_sources.sort_unstable_by(|a, b| a.format.cmp(&b.format).then(a.id.cmp(&b.id)));
+
+    let pool_key = |format: &str| match group_of.get(format) {
+        Some(idx) => format!("cross:{idx:04}"),
+        None => format!("format:{format}"),
+    };
+
+    let mut pool_map: std::collections::HashMap<String, Vec<PreparedSource>> =
+        std::collections::HashMap::default();
+    for ps in prepared_sources {
+        pool_map.entry(pool_key(&ps.format)).or_default().push(ps);
+    }
+    let mut pools: Vec<(String, Vec<PreparedSource>)> = pool_map.into_iter().collect();
+    // Sort pools by key for determinism.
+    pools.sort_by(|a, b| a.0.cmp(&b.0));
+    pools.into_iter().map(|(_, sources)| sources).collect()
+}
+
+/// Formats whose TypeScript-only syntax must be stripped before detection:
+/// TS-family formats that share a cross-format group with a JS-family format
+/// (a TS-only group needs no normalization — pooling alone suffices).
+fn strip_types_formats(cross_formats: &[Vec<String>]) -> std::collections::HashSet<String> {
+    const TS_FAMILY: &[&str] = &["typescript", "tsx"];
+    const JS_FAMILY: &[&str] = &["javascript", "jsx"];
+    cross_formats
+        .iter()
+        .filter(|group| group.iter().any(|f| JS_FAMILY.contains(&f.as_str())))
+        .flat_map(|group| {
+            group
+                .iter()
+                .filter(|f| TS_FAMILY.contains(&f.as_str()))
+                .cloned()
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    fn prepared(id: &str, format: &str) -> PreparedSource {
+        PreparedSource {
+            id: id.to_string(),
+            format: format.to_string(),
+            hashes: vec![],
+            spans: vec![],
+        }
+    }
+
+    fn pool_formats(pools: &[Vec<PreparedSource>]) -> Vec<Vec<&str>> {
+        pools
+            .iter()
+            .map(|pool| pool.iter().map(|ps| ps.format.as_str()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn build_pools_default_isolated() {
+        let sources = vec![
+            prepared("b.ts", "typescript"),
+            prepared("a.js", "javascript"),
+            prepared("c.py", "python"),
+        ];
+        let pools = build_pools(sources, &[]);
+        assert_eq!(
+            pool_formats(&pools),
+            vec![vec!["javascript"], vec!["python"], vec!["typescript"]],
+            "no cross-formats: one pool per format, sorted by format"
+        );
+    }
+
+    #[test]
+    fn build_pools_merges_grouped_formats() {
+        let sources = vec![
+            prepared("a.js", "javascript"),
+            prepared("b.ts", "typescript"),
+            prepared("c.py", "python"),
+        ];
+        let groups = vec![vec!["javascript".to_string(), "typescript".to_string()]];
+        let pools = build_pools(sources, &groups);
+        assert_eq!(
+            pool_formats(&pools),
+            vec![vec!["javascript", "typescript"], vec!["python"]],
+            "grouped formats share one pool; python stays isolated"
+        );
+    }
+
+    #[test]
+    fn strip_types_only_when_group_mixes_ts_and_js() {
+        let mixed = vec![vec![
+            "javascript".to_string(),
+            "typescript".to_string(),
+            "tsx".to_string(),
+        ]];
+        let set = strip_types_formats(&mixed);
+        assert!(set.contains("typescript") && set.contains("tsx"));
+        assert!(!set.contains("javascript"));
+
+        let ts_only = vec![vec!["typescript".to_string(), "tsx".to_string()]];
+        assert!(
+            strip_types_formats(&ts_only).is_empty(),
+            "TS-only groups need no type stripping"
+        );
+
+        assert!(strip_types_formats(&[]).is_empty());
+    }
 
     #[test]
     fn empty_paths_returns_empty_result() {

--- a/rust/crates/cpd-finder/tests/cross_formats_integration.rs
+++ b/rust/crates/cpd-finder/tests/cross_formats_integration.rs
@@ -1,0 +1,145 @@
+use cpd_finder::orchestrate::{RunConfig, run};
+use cpd_tokenizer::tokenizer::Mode;
+use std::{fs, path::PathBuf};
+
+fn setup_temp_dir(suffix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("cpd-cross-formats-{}", suffix));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Typed TypeScript source and its untyped JavaScript twin. The bodies are
+/// identical apart from TypeScript-only syntax.
+fn typed_ts() -> &'static str {
+    r#"interface Totals {
+    sum: number;
+    max: number;
+}
+
+function computeTotals(values: number[], threshold: number): Totals {
+    let sum: number = 0;
+    let max: number = 0;
+    for (const value of values) {
+        sum = sum + value;
+        if (value > max) {
+            max = value;
+        }
+    }
+    if (sum > threshold) {
+        sum = sum - threshold;
+    }
+    return { sum: sum, max: max } as Totals;
+}
+"#
+}
+
+fn untyped_js() -> &'static str {
+    r#"function computeTotals(values, threshold) {
+    let sum = 0;
+    let max = 0;
+    for (const value of values) {
+        sum = sum + value;
+        if (value > max) {
+            max = value;
+        }
+    }
+    if (sum > threshold) {
+        sum = sum - threshold;
+    }
+    return { sum: sum, max: max };
+}
+"#
+}
+
+fn write_pair(dir: &PathBuf) {
+    fs::write(dir.join("a.ts"), typed_ts()).unwrap();
+    fs::write(dir.join("b.js"), untyped_js()).unwrap();
+}
+
+fn config(paths: Vec<PathBuf>, cross_formats: Vec<Vec<String>>) -> RunConfig {
+    RunConfig {
+        paths,
+        min_tokens: 20,
+        min_lines: 1,
+        mode: Mode::Mild,
+        cross_formats,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn ts_js_pair_not_detected_by_default() {
+    let dir = setup_temp_dir("default");
+    write_pair(&dir);
+    let result = run(&config(vec![dir], vec![])).unwrap();
+    assert_eq!(
+        result.clones.len(),
+        0,
+        "without --cross-formats, TS and JS stay in isolated pools"
+    );
+}
+
+#[test]
+fn ts_js_pair_detected_with_cross_formats() {
+    let dir = setup_temp_dir("enabled");
+    write_pair(&dir);
+    let groups = vec![vec!["javascript".to_string(), "typescript".to_string()]];
+    let result = run(&config(vec![dir], groups)).unwrap();
+    assert_eq!(
+        result.clones.len(),
+        1,
+        "cross-formats group must match the TS file against its JS twin"
+    );
+
+    let clone = &result.clones[0];
+    let ids = [
+        clone.fragment_a.source_id.as_str(),
+        clone.fragment_b.source_id.as_str(),
+    ];
+    assert!(
+        ids.iter().any(|id| id.ends_with("a.ts")),
+        "one side is the TS file"
+    );
+    assert!(
+        ids.iter().any(|id| id.ends_with("b.js")),
+        "one side is the JS file"
+    );
+
+    // Positions reference the ORIGINAL sources: the TS function body starts
+    // after the interface block (line 6 of a.ts), the JS twin at line 1.
+    let (ts_frag, js_frag) = if clone.fragment_a.source_id.ends_with("a.ts") {
+        (&clone.fragment_a, &clone.fragment_b)
+    } else {
+        (&clone.fragment_b, &clone.fragment_a)
+    };
+    assert!(
+        ts_frag.start.line >= 6,
+        "TS fragment must start after the stripped interface block, got line {}",
+        ts_frag.start.line
+    );
+    assert!(
+        js_frag.start.line <= 2,
+        "JS fragment must start at the top of the file, got line {}",
+        js_frag.start.line
+    );
+}
+
+#[test]
+fn unrelated_format_stays_isolated() {
+    let dir = setup_temp_dir("unrelated");
+    write_pair(&dir);
+    // Same content in a Python file: same tokens would match, but python is
+    // not part of the cross-formats group.
+    fs::write(dir.join("c.py"), untyped_js()).unwrap();
+    let groups = vec![vec!["javascript".to_string(), "typescript".to_string()]];
+    let result = run(&config(vec![dir], groups)).unwrap();
+    for clone in &result.clones {
+        for id in [&clone.fragment_a.source_id, &clone.fragment_b.source_id] {
+            assert!(
+                !id.ends_with("c.py"),
+                "python file must not join the javascript/typescript pool"
+            );
+        }
+    }
+}

--- a/rust/crates/cpd-tokenizer/Cargo.toml
+++ b/rust/crates/cpd-tokenizer/Cargo.toml
@@ -13,6 +13,9 @@ cpd-core = { version = "0.1.6", path = "../cpd-core" }
 oxc_parser = "0.133"
 oxc_allocator = "0.133"
 oxc_span = "0.133"
+oxc_ast = "0.133"
+oxc_ast_visit = "0.133"
+oxc_syntax = "0.133"
 log = "0.4"
 regex = "1"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/rust/crates/cpd-tokenizer/src/javascript.rs
+++ b/rust/crates/cpd-tokenizer/src/javascript.rs
@@ -172,11 +172,27 @@ fn source_type_for_format(format: &str) -> SourceType {
 
 /// Tokenize JS/TS/JSX/TSX source. Never panics.
 pub fn tokenize_js(source: &str, format: &str) -> Vec<Token> {
+    tokenize_js_impl(source, format, false)
+}
+
+/// Tokenize TS/TSX source with erasable TypeScript-only syntax stripped from
+/// the token stream (cross-format detection). Token locations still reference
+/// the original source. Never panics.
+///
+/// Sources that fail to parse fall back to the word-split tokenizer WITHOUT
+/// stripping — they simply won't cross-match JavaScript files.
+pub fn tokenize_js_stripped(source: &str, format: &str) -> Vec<Token> {
+    tokenize_js_impl(source, format, true)
+}
+
+fn tokenize_js_impl(source: &str, format: &str, strip_types: bool) -> Vec<Token> {
     if source.is_empty() {
         return Vec::new();
     }
 
-    match catch_unwind(AssertUnwindSafe(|| parse_with_oxc(source, format))) {
+    match catch_unwind(AssertUnwindSafe(|| {
+        parse_with_oxc(source, format, strip_types)
+    })) {
         Ok(Some(tokens)) => tokens,
         Ok(None) => {
             log::debug!("cpd-tokenizer: OXC parse errors in {format} source, using fallback");
@@ -189,7 +205,7 @@ pub fn tokenize_js(source: &str, format: &str) -> Vec<Token> {
     }
 }
 
-fn parse_with_oxc(source: &str, format: &str) -> Option<Vec<Token>> {
+fn parse_with_oxc(source: &str, format: &str, strip_types: bool) -> Option<Vec<Token>> {
     let allocator = Allocator::new();
     let source_type = source_type_for_format(format);
 
@@ -200,6 +216,12 @@ fn parse_with_oxc(source: &str, format: &str) -> Option<Vec<Token>> {
     if !parser_return.errors.is_empty() {
         return None;
     }
+
+    let erasable = if strip_types {
+        crate::ts_strip::collect_erasable_spans(&parser_return.program, source)
+    } else {
+        crate::ts_strip::ErasableSpans::default()
+    };
 
     let ignore_ranges = find_ignore_ranges(source);
     let bytes = source.as_bytes();
@@ -220,6 +242,12 @@ fn parse_with_oxc(source: &str, format: &str) -> Option<Vec<Token>> {
                 return None;
             }
             let value = &source[start..end];
+            if !erasable.is_empty()
+                && (erasable.intersects_range(start as u32, end as u32)
+                    || erasable.is_modifier_token(start as u32, end as u32, value))
+            {
+                return None;
+            }
             let token_kind = if in_ignore(start, end, &ignore_ranges) {
                 TokenKind::Ignore
             } else {

--- a/rust/crates/cpd-tokenizer/src/lib.rs
+++ b/rust/crates/cpd-tokenizer/src/lib.rs
@@ -7,3 +7,4 @@ pub mod markdown;
 pub mod razor;
 pub mod sfc;
 pub mod tokenizer;
+pub mod ts_strip;

--- a/rust/crates/cpd-tokenizer/src/tokenizer.rs
+++ b/rust/crates/cpd-tokenizer/src/tokenizer.rs
@@ -61,6 +61,11 @@ pub struct TokenizeOptions {
     /// Before tokenization, these are matched against the source text and
     /// overlapping byte ranges are added to `ignore_ranges`.
     pub code_ignore_regexes: Vec<regex::Regex>,
+    /// Formats whose TypeScript-only syntax is stripped from the detection
+    /// token stream (`--cross-formats` groups mixing TS with JS). Only
+    /// `typescript` and `tsx` are meaningful here; empty by default so the
+    /// standard detection path is untouched.
+    pub strip_types_formats: std::collections::HashSet<String>,
 }
 
 impl TokenizeOptions {
@@ -70,6 +75,7 @@ impl TokenizeOptions {
             ignore_case: false,
             ignore_ranges: Vec::new(),
             code_ignore_regexes: Vec::new(),
+            strip_types_formats: std::collections::HashSet::new(),
         }
     }
 
@@ -85,6 +91,7 @@ impl TokenizeOptions {
             ignore_case: false,
             ignore_ranges: Vec::new(),
             code_ignore_regexes,
+            strip_types_formats: std::collections::HashSet::new(),
         }
     }
 }
@@ -100,13 +107,23 @@ pub fn tokenize_format_to_detection(
 ) -> Vec<DetectionToken> {
     let raw = match format {
         "javascript" | "typescript" | "jsx" | "tsx" => {
-            crate::javascript::tokenize_js(source, format)
+            if should_strip_types(format, options) {
+                crate::javascript::tokenize_js_stripped(source, format)
+            } else {
+                crate::javascript::tokenize_js(source, format)
+            }
         }
         "vue" | "svelte" | "astro" => crate::sfc::tokenize_sfc(source, format, options.mode),
         "markdown" | "md" => crate::generic::tokenize_generic(source, format),
         _ => crate::generic::tokenize_generic(source, format),
     };
     tokens_to_detection(raw, options)
+}
+
+/// True when this format's TypeScript-only syntax must be stripped for
+/// cross-format detection (see `TokenizeOptions::strip_types_formats`).
+fn should_strip_types(format: &str, options: &TokenizeOptions) -> bool {
+    matches!(format, "typescript" | "tsx") && options.strip_types_formats.contains(format)
 }
 
 /// Compute byte ranges of all regex matches against source text.
@@ -230,7 +247,11 @@ pub fn tokenize_to_detection(
     // without risk of introducing per-tokenizer bugs. The conversion is O(n)
     // and eliminates the separate filter pass and hash computation that
     // previously happened inside detect.rs.
-    let raw = dispatch_tokenizer(format, source, options.mode);
+    let raw = if should_strip_types(format, options) {
+        crate::javascript::tokenize_js_stripped(source, format)
+    } else {
+        dispatch_tokenizer(format, source, options.mode)
+    };
     let mut detection = Vec::with_capacity(raw.len());
     for t in raw {
         let byte_start = t.start.offset as usize;

--- a/rust/crates/cpd-tokenizer/src/ts_strip.rs
+++ b/rust/crates/cpd-tokenizer/src/ts_strip.rs
@@ -1,0 +1,553 @@
+// cpd-tokenizer: collect byte spans of erasable TypeScript-only syntax.
+//
+// Used by the --cross-formats feature: when a TypeScript file shares a
+// detection pool with JavaScript files, tokens inside these spans are dropped
+// so the remaining token stream (and therefore its hashes) matches the
+// equivalent plain-JavaScript source. Spans reference the ORIGINAL source, so
+// token locations — and reported clone positions — are unaffected.
+//
+// Non-erasable TypeScript syntax with runtime semantics is left intact and
+// simply will not cross-match: enum, non-declare namespace, parameter
+// properties (`constructor(private x)`), `import x = require()`, `export =`.
+
+use oxc_ast::ast::{
+    Class, ExportDefaultDeclaration, ExportDefaultDeclarationKind, ExportNamedDeclaration,
+    Function, ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind, MethodDefinition,
+    Program, PropertyDefinition, TSAsExpression, TSEnumDeclaration, TSInterfaceDeclaration,
+    TSModuleDeclaration, TSNonNullExpression, TSSatisfiesExpression, TSThisParameter,
+    TSTypeAliasDeclaration, TSTypeAnnotation, TSTypeAssertion, TSTypeParameterDeclaration,
+    TSTypeParameterInstantiation, VariableDeclaration, VariableDeclarator,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::GetSpan;
+use oxc_syntax::scope::ScopeFlags;
+
+/// TypeScript-only modifier keywords that may appear in a class-member head
+/// (between member start and key start) or before `class`. Tokens inside a
+/// modifier zone are dropped only when their text is one of these words, so
+/// `static`, `async`, `get`, `set` and decorators survive.
+const TS_MODIFIER_WORDS: &[&str] = &[
+    "public",
+    "private",
+    "protected",
+    "readonly",
+    "abstract",
+    "override",
+    "declare",
+];
+
+pub fn is_ts_modifier_word(word: &str) -> bool {
+    TS_MODIFIER_WORDS.contains(&word)
+}
+
+/// Byte spans of erasable TypeScript syntax in one source file.
+#[derive(Debug, Default)]
+pub struct ErasableSpans {
+    /// Sorted, merged `[start, end)` byte ranges removed wholesale.
+    pub ranges: Vec<[u32; 2]>,
+    /// Sorted `[start, end)` zones where tokens are dropped only if their
+    /// text is a TypeScript modifier word (see [`is_ts_modifier_word`]).
+    pub modifier_zones: Vec<[u32; 2]>,
+}
+
+impl ErasableSpans {
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty() && self.modifier_zones.is_empty()
+    }
+
+    /// True when the `[start, end)` byte range intersects an erased range.
+    pub fn intersects_range(&self, start: u32, end: u32) -> bool {
+        // ranges are sorted and merged; find the first range ending after `start`.
+        let idx = self.ranges.partition_point(|[_, re]| *re <= start);
+        self.ranges.get(idx).is_some_and(|[rs, _]| *rs < end)
+    }
+
+    /// True when a token at `[start, end)` with text `value` should be
+    /// dropped because it is a TS modifier word inside a modifier zone.
+    pub fn is_modifier_token(&self, start: u32, end: u32, value: &str) -> bool {
+        if !is_ts_modifier_word(value) {
+            return false;
+        }
+        let idx = self.modifier_zones.partition_point(|[_, ze]| *ze <= start);
+        self.modifier_zones
+            .get(idx)
+            .is_some_and(|[zs, _]| *zs < end)
+    }
+}
+
+/// Walk `program` and collect the byte spans of all erasable
+/// TypeScript-only syntax.
+pub fn collect_erasable_spans(program: &Program, source: &str) -> ErasableSpans {
+    let mut collector = Collector {
+        source,
+        ranges: Vec::new(),
+        modifier_zones: Vec::new(),
+    };
+    collector.visit_program(program);
+
+    collector.ranges.sort_unstable();
+    let mut merged: Vec<[u32; 2]> = Vec::with_capacity(collector.ranges.len());
+    for range in collector.ranges {
+        match merged.last_mut() {
+            Some(last) if range[0] <= last[1] => last[1] = last[1].max(range[1]),
+            _ => merged.push(range),
+        }
+    }
+    collector.modifier_zones.sort_unstable();
+
+    ErasableSpans {
+        ranges: merged,
+        modifier_zones: collector.modifier_zones,
+    }
+}
+
+struct Collector<'s> {
+    source: &'s str,
+    ranges: Vec<[u32; 2]>,
+    modifier_zones: Vec<[u32; 2]>,
+}
+
+impl Collector<'_> {
+    fn push(&mut self, start: u32, end: u32) {
+        if start < end {
+            self.ranges.push([start, end]);
+        }
+    }
+
+    /// Push the 1-byte span of `needle` if it occurs in `[start, end)`.
+    /// Used for markers stored as bools in the AST (`?`, `!`).
+    fn push_char_in(&mut self, needle: u8, start: u32, end: u32) {
+        let (start, end) = (start as usize, end.min(self.source.len() as u32) as usize);
+        if start >= end {
+            return;
+        }
+        if let Some(pos) = self.source.as_bytes()[start..end]
+            .iter()
+            .position(|&b| b == needle)
+        {
+            let at = (start + pos) as u32;
+            self.push(at, at + 1);
+        }
+    }
+}
+
+impl<'a> Visit<'a> for Collector<'_> {
+    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
+        // Span starts at the `:` token — dropping it removes the colon too.
+        self.push(it.span.start, it.span.end);
+    }
+
+    fn visit_ts_type_parameter_declaration(&mut self, it: &TSTypeParameterDeclaration<'a>) {
+        self.push(it.span.start, it.span.end);
+    }
+
+    fn visit_ts_type_parameter_instantiation(&mut self, it: &TSTypeParameterInstantiation<'a>) {
+        self.push(it.span.start, it.span.end);
+    }
+
+    fn visit_ts_interface_declaration(&mut self, it: &TSInterfaceDeclaration<'a>) {
+        self.push(it.span.start, it.span.end);
+    }
+
+    fn visit_ts_type_alias_declaration(&mut self, it: &TSTypeAliasDeclaration<'a>) {
+        self.push(it.span.start, it.span.end);
+    }
+
+    fn visit_ts_as_expression(&mut self, it: &TSAsExpression<'a>) {
+        // Drop the ` as T` tail, keep the expression.
+        self.push(it.expression.span().end, it.span.end);
+        self.visit_expression(&it.expression);
+    }
+
+    fn visit_ts_satisfies_expression(&mut self, it: &TSSatisfiesExpression<'a>) {
+        self.push(it.expression.span().end, it.span.end);
+        self.visit_expression(&it.expression);
+    }
+
+    fn visit_ts_type_assertion(&mut self, it: &TSTypeAssertion<'a>) {
+        // `<T>expr` — drop the leading `<T>`.
+        self.push(it.span.start, it.expression.span().start);
+        self.visit_expression(&it.expression);
+    }
+
+    fn visit_ts_non_null_expression(&mut self, it: &TSNonNullExpression<'a>) {
+        // The trailing `!`.
+        self.push(it.expression.span().end, it.span.end);
+        self.visit_expression(&it.expression);
+    }
+
+    fn visit_ts_this_parameter(&mut self, it: &TSThisParameter<'a>) {
+        // Drop `this: T` and, when present, the comma separating it from the
+        // next parameter.
+        let mut end = it.span.end;
+        let bytes = self.source.as_bytes();
+        let mut i = end as usize;
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b',' {
+            end = (i + 1) as u32;
+        }
+        self.push(it.span.start, end);
+    }
+
+    fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
+        if it.import_kind == ImportOrExportKind::Type {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        if let Some(specifiers) = &it.specifiers {
+            for specifier in specifiers {
+                if let ImportDeclarationSpecifier::ImportSpecifier(s) = specifier {
+                    if s.import_kind == ImportOrExportKind::Type {
+                        // Leaves a stray `,` behind — documented limitation.
+                        self.push(s.span.start, s.span.end);
+                    }
+                }
+            }
+        }
+    }
+
+    fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'a>) {
+        if it.export_kind == ImportOrExportKind::Type {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        for specifier in &it.specifiers {
+            if specifier.export_kind == ImportOrExportKind::Type {
+                self.push(specifier.span.start, specifier.span.end);
+            }
+        }
+        walk::walk_export_named_declaration(self, it);
+    }
+
+    fn visit_export_default_declaration(&mut self, it: &ExportDefaultDeclaration<'a>) {
+        if matches!(
+            it.declaration,
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(_)
+        ) {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        walk::walk_export_default_declaration(self, it);
+    }
+
+    fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
+        // Ambient declarations and overload signatures have no body and are
+        // fully erasable. (Overload signatures of class methods are handled
+        // in visit_method_definition, which owns the surrounding span.)
+        if it.declare || it.body.is_none() {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        walk::walk_function(self, it, flags);
+    }
+
+    fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
+        if it.declare {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        walk::walk_variable_declaration(self, it);
+    }
+
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
+        if it.definite {
+            // `let x!: T` — the `!` sits between the binding and the annotation.
+            let bound = it
+                .type_annotation
+                .as_ref()
+                .map(|t| t.span.start)
+                .or_else(|| it.init.as_ref().map(|i| i.span().start))
+                .unwrap_or(it.span.end);
+            self.push_char_in(b'!', it.id.span().end, bound);
+        }
+        walk::walk_variable_declarator(self, it);
+    }
+
+    fn visit_class(&mut self, it: &Class<'a>) {
+        if it.declare {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        if it.r#abstract {
+            // `abstract` appears between the class span start (which includes
+            // decorators and `export` is outside the span) and the `class`
+            // keyword; word-filtering keeps everything else in the zone.
+            let zone_end = it
+                .id
+                .as_ref()
+                .map(|id| id.span.start)
+                .unwrap_or(it.body.span.start);
+            self.modifier_zones.push([it.span.start, zone_end]);
+        }
+        if let (Some(first), Some(last)) = (it.implements.first(), it.implements.last()) {
+            // Scan back from the first heritage type for the `implements`
+            // keyword and drop the whole clause.
+            let clause_start = self.source[..first.span.start as usize]
+                .rfind("implements")
+                .map(|p| p as u32)
+                .unwrap_or(first.span.start);
+            self.push(clause_start, last.span.end);
+        }
+        walk::walk_class(self, it);
+    }
+
+    fn visit_method_definition(&mut self, it: &MethodDefinition<'a>) {
+        // Overload signatures and abstract methods have no body: erasable.
+        if it.value.body.is_none() {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        self.modifier_zones
+            .push([it.span.start, it.key.span().start]);
+        if it.optional {
+            self.push_char_in(b'?', it.key.span().end, it.value.span.start);
+        }
+        walk::walk_method_definition(self, it);
+    }
+
+    fn visit_property_definition(&mut self, it: &PropertyDefinition<'a>) {
+        if it.declare {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        self.modifier_zones
+            .push([it.span.start, it.key.span().start]);
+        if it.optional || it.definite {
+            let bound = it
+                .type_annotation
+                .as_ref()
+                .map(|t| t.span.start)
+                .or_else(|| it.value.as_ref().map(|v| v.span().start))
+                .unwrap_or(it.span.end);
+            let marker = if it.optional { b'?' } else { b'!' };
+            self.push_char_in(marker, it.key.span().end, bound);
+        }
+        walk::walk_property_definition(self, it);
+    }
+
+    fn visit_formal_parameter(&mut self, it: &oxc_ast::ast::FormalParameter<'a>) {
+        // Parameter properties (`constructor(private x)`) have runtime
+        // semantics: keep the modifiers (and the `?`), but still walk so the
+        // type annotation is stripped like everywhere else.
+        let is_parameter_property = it.accessibility.is_some() || it.readonly || it.r#override;
+        if !is_parameter_property && it.optional {
+            let bound = it
+                .type_annotation
+                .as_ref()
+                .map(|t| t.span.start)
+                .or_else(|| it.initializer.as_ref().map(|i| i.span().start))
+                .unwrap_or(it.span.end);
+            self.push_char_in(b'?', it.pattern.span().end, bound);
+        }
+        walk::walk_formal_parameter(self, it);
+    }
+
+    fn visit_ts_enum_declaration(&mut self, it: &TSEnumDeclaration<'a>) {
+        // Non-declare enums generate runtime code: left intact (non-goal).
+        if it.declare {
+            self.push(it.span.start, it.span.end);
+        }
+    }
+
+    fn visit_ts_module_declaration(&mut self, it: &TSModuleDeclaration<'a>) {
+        if it.declare {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        // Non-declare namespace: keep the header (runtime semantics) but
+        // still strip annotations inside the body.
+        walk::walk_ts_module_declaration(self, it);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tokenizer::{Mode, TokenizeOptions, tokenize_to_detection};
+
+    /// Detection hash sequence with TS stripping enabled for typescript/tsx.
+    fn ts_hashes(source: &str, format: &str) -> Vec<u64> {
+        let mut opts = TokenizeOptions::new(Mode::Mild);
+        opts.strip_types_formats = ["typescript".to_string(), "tsx".to_string()]
+            .into_iter()
+            .collect();
+        tokenize_to_detection(format, source, &opts)
+            .into_iter()
+            .map(|t| t.hash)
+            .collect()
+    }
+
+    fn js_hashes(source: &str) -> Vec<u64> {
+        let opts = TokenizeOptions::new(Mode::Mild);
+        tokenize_to_detection("javascript", source, &opts)
+            .into_iter()
+            .map(|t| t.hash)
+            .collect()
+    }
+
+    #[track_caller]
+    fn assert_ts_matches_js(ts: &str, js: &str) {
+        let ts_h = ts_hashes(ts, "typescript");
+        let js_h = js_hashes(js);
+        assert!(!js_h.is_empty(), "JS twin produced no tokens");
+        assert_eq!(
+            ts_h, js_h,
+            "stripped TS must hash-match its JS twin\nTS: {ts}\nJS: {js}"
+        );
+    }
+
+    #[test]
+    fn strips_annotations_and_return_types() {
+        assert_ts_matches_js(
+            "function add(a: number, b: number): number { return a + b; }",
+            "function add(a, b) { return a + b; }",
+        );
+    }
+
+    #[test]
+    fn strips_variable_annotations() {
+        assert_ts_matches_js("const x: number = 5;", "const x = 5;");
+    }
+
+    #[test]
+    fn strips_generics_declaration_and_instantiation() {
+        assert_ts_matches_js(
+            "function id<T>(x: T): T { return x; }\nconst y = id<number>(1);",
+            "function id(x) { return x; }\nconst y = id(1);",
+        );
+    }
+
+    #[test]
+    fn strips_interface_and_type_alias() {
+        assert_ts_matches_js(
+            "interface P { x: number }\ntype Q = string;\nconst a = 1;",
+            "const a = 1;",
+        );
+    }
+
+    #[test]
+    fn strips_as_and_satisfies_tails() {
+        assert_ts_matches_js(
+            "const a = foo as unknown as string; const b = bar satisfies object;",
+            "const a = foo; const b = bar;",
+        );
+    }
+
+    #[test]
+    fn strips_non_null_and_definite_assignment() {
+        assert_ts_matches_js(
+            "let v!: number;\nconst w = obj!.prop!;",
+            "let v;\nconst w = obj.prop;",
+        );
+    }
+
+    #[test]
+    fn strips_optional_markers() {
+        assert_ts_matches_js(
+            "function f(a?: number) { return a; }\nclass C { p?: string; m?() { return 1; } }",
+            "function f(a) { return a; }\nclass C { p; m() { return 1; } }",
+        );
+    }
+
+    #[test]
+    fn strips_class_modifiers_and_implements() {
+        assert_ts_matches_js(
+            "abstract class C implements A, B { private readonly x = 1; protected m(): void {} }",
+            "class C { x = 1; m() {} }",
+        );
+    }
+
+    #[test]
+    fn keeps_static_async_get_set_in_modifier_zones() {
+        assert_ts_matches_js(
+            "class C { private static async m(): Promise<void> {} public get x(): number { return 1; } }",
+            "class C { static async m() {} get x() { return 1; } }",
+        );
+    }
+
+    #[test]
+    fn strips_type_only_imports_and_exports() {
+        assert_ts_matches_js(
+            "import type { A } from './a';\nimport { b } from './b';\nexport type { A };\nconst c = b;",
+            "import { b } from './b';\nconst c = b;",
+        );
+    }
+
+    #[test]
+    fn strips_overload_signatures_and_declares() {
+        assert_ts_matches_js(
+            "declare const g: number;\nfunction f(a: string): string;\nfunction f(a: unknown) { return a; }",
+            "function f(a) { return a; }",
+        );
+    }
+
+    #[test]
+    fn strips_this_parameter_with_comma() {
+        assert_ts_matches_js(
+            "function f(this: Window, a: number) { return a; }",
+            "function f(a) { return a; }",
+        );
+    }
+
+    #[test]
+    fn strips_type_assertion_prefix() {
+        // `<T>expr` assertions are only valid in .ts (not .tsx).
+        assert_ts_matches_js("const a = <string>foo;", "const a = foo;");
+    }
+
+    #[test]
+    fn tsx_annotations_stripped() {
+        let ts_h = ts_hashes(
+            "const f = (x: number): JSX.Element => <div>{x}</div>;",
+            "tsx",
+        );
+        let mut opts = TokenizeOptions::new(Mode::Mild);
+        opts.strip_types_formats = std::collections::HashSet::new();
+        let jsx_h: Vec<u64> =
+            tokenize_to_detection("jsx", "const f = (x) => <div>{x}</div>;", &opts)
+                .into_iter()
+                .map(|t| t.hash)
+                .collect();
+        assert_eq!(ts_h, jsx_h);
+    }
+
+    #[test]
+    fn non_erasable_enum_left_intact() {
+        let stripped = ts_hashes("enum E { A, B }", "typescript");
+        let opts = TokenizeOptions::new(Mode::Mild);
+        let unstripped: Vec<u64> = tokenize_to_detection("typescript", "enum E { A, B }", &opts)
+            .into_iter()
+            .map(|t| t.hash)
+            .collect();
+        assert_eq!(stripped, unstripped, "enums must not be stripped");
+    }
+
+    #[test]
+    fn non_erasable_parameter_properties_left_intact() {
+        let ts = "class C { constructor(private x: number) {} }";
+        let stripped = ts_hashes(ts, "typescript");
+        // `private` survives; only the type annotation is dropped.
+        let expected = ts_hashes("class C { constructor(private x) {} }", "typescript");
+        assert_eq!(
+            stripped, expected,
+            "annotation must be dropped, modifier kept"
+        );
+        assert_ne!(stripped, js_hashes("class C { constructor(x) {} }"));
+    }
+
+    #[test]
+    fn no_strip_when_format_not_in_set() {
+        let opts = TokenizeOptions::new(Mode::Mild);
+        let ts = "const x: number = 5;";
+        let plain: Vec<u64> = tokenize_to_detection("typescript", ts, &opts)
+            .into_iter()
+            .map(|t| t.hash)
+            .collect();
+        assert_ne!(
+            plain,
+            js_hashes("const x = 5;"),
+            "default path must not strip"
+        );
+    }
+}

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -57,6 +57,78 @@ pub fn parse_format_mappings(input: &str) -> HashMap<String, Vec<String>> {
     result
 }
 
+/// Named shortcuts for common cross-format groups.
+pub const CROSS_FORMAT_PRESETS: &[(&str, &[&str])] =
+    &[("js-ts", &["javascript", "jsx", "typescript", "tsx"])];
+
+/// Parse a `--cross-formats` value: semicolon-separated groups of
+/// comma-separated format names, e.g. "javascript,typescript;css,scss".
+/// Preset names (see [`CROSS_FORMAT_PRESETS`]) expand in place. Groups that
+/// end up with fewer than two formats are dropped; groups sharing a format
+/// are merged (union).
+pub fn parse_cross_formats(input: &str) -> Vec<Vec<String>> {
+    let mut groups: Vec<Vec<String>> = Vec::new();
+    for group in input.split(';') {
+        let mut formats: Vec<String> = Vec::new();
+        for entry in group.split(',') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            let expanded = CROSS_FORMAT_PRESETS
+                .iter()
+                .find(|(name, _)| *name == entry)
+                .map(|(_, members)| members.iter().map(|m| m.to_string()).collect())
+                .unwrap_or_else(|| vec![entry.to_string()]);
+            for format in expanded {
+                if !formats.contains(&format) {
+                    formats.push(format);
+                }
+            }
+        }
+        if formats.len() < 2 {
+            if !formats.is_empty() {
+                eprintln!(
+                    "Warning: --cross-formats group '{}' has fewer than two formats, ignored",
+                    group.trim()
+                );
+            }
+            continue;
+        }
+        groups.push(formats);
+    }
+
+    // Merge groups that share a format (union semantics): a format can only
+    // belong to one detection pool.
+    let mut merged: Vec<Vec<String>> = Vec::new();
+    for group in groups {
+        let mut group = group;
+        loop {
+            let overlap = merged
+                .iter()
+                .position(|m| m.iter().any(|f| group.contains(f)));
+            match overlap {
+                Some(idx) => {
+                    let existing = merged.remove(idx);
+                    eprintln!(
+                        "Warning: --cross-formats groups '{}' and '{}' overlap, merged",
+                        existing.join(","),
+                        group.join(",")
+                    );
+                    for format in existing.into_iter().rev() {
+                        if !group.contains(&format) {
+                            group.insert(0, format);
+                        }
+                    }
+                }
+                None => break,
+            }
+        }
+        merged.push(group);
+    }
+    merged
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "cpd",
@@ -161,6 +233,14 @@ pub struct Cli {
     #[arg(long)]
     pub formats_names: Option<String>,
 
+    /// Detect clones across formats: semicolon-separated groups of
+    /// comma-separated formats (e.g. "javascript,typescript;css,scss").
+    /// Preset: js-ts = javascript,jsx,typescript,tsx. TypeScript files in a
+    /// group that also contains JavaScript are compared with type
+    /// annotations stripped.
+    #[arg(long)]
+    pub cross_formats: Option<String>,
+
     /// Accepted for compatibility; external store backend not supported in V1
     #[arg(long, hide = true)]
     pub store: Option<String>,
@@ -235,6 +315,8 @@ pub struct ConfigFile {
     pub formats_exts: Option<String>,
     #[serde(alias = "formats-names")]
     pub formats_names: Option<String>,
+    #[serde(alias = "cross-formats")]
+    pub cross_formats: Option<String>,
     #[serde(alias = "skip-local")]
     pub skip_local: Option<bool>,
     #[serde(alias = "exit-code")]
@@ -417,6 +499,7 @@ pub(crate) static KNOWN_CONFIG_FIELDS: &[&str] = &[
     "ignoreCase",
     "formatsExts",
     "formatsNames",
+    "crossFormats",
     "skipLocal",
     "exitCode",
     "noTips",
@@ -435,6 +518,7 @@ pub(crate) static KNOWN_CONFIG_FIELDS: &[&str] = &[
     "no-tips",
     "formats-exts",
     "formats-names",
+    "cross-formats",
     "ignore-pattern",
 ];
 
@@ -574,6 +658,44 @@ fn normalize_v4_config(value: &mut serde_json::Value) {
     // "formatsNames" / "formats-names" same treatment
     for key in &["formatsNames", "formats-names"] {
         coerce_formats_mapping(obj, key);
+    }
+    // "crossFormats" / "cross-formats" type coercion: accept array forms,
+    // convert to the canonical "a,b;c,d" string.
+    for key in &["crossFormats", "cross-formats"] {
+        coerce_cross_formats(obj, key);
+    }
+}
+
+/// Coerce a crossFormats field from array forms to the canonical string.
+///
+/// Accepted forms:
+///   - String: "javascript,typescript;css,scss" (canonical, no conversion)
+///   - Array of strings: ["javascript,typescript", "css,scss"] → joined with ";"
+///   - Array of arrays: [["javascript","typescript"],["css","scss"]] → inner
+///     joined with ",", outer with ";"
+fn coerce_cross_formats(obj: &mut serde_json::Map<String, serde_json::Value>, key: &str) {
+    if let Some(val) = obj.remove(key) {
+        let coerced = match val {
+            serde_json::Value::Array(arr) => {
+                let groups: Vec<String> = arr
+                    .into_iter()
+                    .filter_map(|v| match v {
+                        serde_json::Value::String(s) => Some(s),
+                        serde_json::Value::Array(inner) => Some(
+                            inner
+                                .into_iter()
+                                .filter_map(|f| f.as_str().map(|s| s.to_string()))
+                                .collect::<Vec<_>>()
+                                .join(","),
+                        ),
+                        _ => None,
+                    })
+                    .collect();
+                serde_json::Value::String(groups.join(";"))
+            }
+            other => other,
+        };
+        obj.insert(key.to_string(), coerced);
     }
 }
 
@@ -1431,6 +1553,138 @@ mod tests {
         let opts = crate::options::Options::from_cli_and_config(&cli, &config);
         assert!(opts.formats_exts.contains_key("javascript"));
         assert!(!opts.formats_exts.contains_key("dart"));
+    }
+
+    #[test]
+    fn cross_formats_flag_parsing() {
+        let cli = Cli::parse_from(["cpd", "--cross-formats", "javascript,typescript", "."]);
+        assert_eq!(cli.cross_formats, Some("javascript,typescript".to_string()));
+    }
+
+    #[test]
+    fn parse_cross_formats_groups() {
+        assert_eq!(
+            parse_cross_formats("javascript, typescript ; css,scss"),
+            vec![
+                vec!["javascript".to_string(), "typescript".to_string()],
+                vec!["css".to_string(), "scss".to_string()],
+            ]
+        );
+        assert_eq!(parse_cross_formats(""), Vec::<Vec<String>>::new());
+        assert_eq!(parse_cross_formats(";;"), Vec::<Vec<String>>::new());
+    }
+
+    #[test]
+    fn parse_cross_formats_preset() {
+        let expected_js_ts = vec![
+            "javascript".to_string(),
+            "jsx".to_string(),
+            "typescript".to_string(),
+            "tsx".to_string(),
+        ];
+        assert_eq!(parse_cross_formats("js-ts"), vec![expected_js_ts.clone()]);
+        assert_eq!(
+            parse_cross_formats("js-ts;css,scss"),
+            vec![
+                expected_js_ts.clone(),
+                vec!["css".to_string(), "scss".to_string()]
+            ]
+        );
+        // Preset inside a group merges with the extra format, deduped.
+        assert_eq!(
+            parse_cross_formats("js-ts,vue,typescript"),
+            vec![{
+                let mut g = expected_js_ts;
+                g.push("vue".to_string());
+                g
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_cross_formats_single_format_group_dropped() {
+        assert_eq!(
+            parse_cross_formats("javascript;css,scss"),
+            vec![vec!["css".to_string(), "scss".to_string()]]
+        );
+    }
+
+    #[test]
+    fn parse_cross_formats_overlapping_groups_merged() {
+        let groups = parse_cross_formats("javascript,typescript;typescript,tsx");
+        assert_eq!(groups.len(), 1, "overlapping groups must merge");
+        let merged = &groups[0];
+        for format in ["javascript", "typescript", "tsx"] {
+            assert!(merged.contains(&format.to_string()), "missing {format}");
+        }
+    }
+
+    #[test]
+    fn cross_formats_propagates_to_options() {
+        let cli = Cli::parse_from(["cpd", "--cross-formats", "javascript,typescript", "."]);
+        let config = ConfigFile::default();
+        let opts = crate::options::Options::from_cli_and_config(&cli, &config);
+        assert_eq!(
+            opts.cross_formats,
+            vec![vec!["javascript".to_string(), "typescript".to_string()]]
+        );
+    }
+
+    #[test]
+    fn cli_cross_formats_overrides_config() {
+        let config = ConfigFile {
+            cross_formats: Some("css,scss".to_string()),
+            ..Default::default()
+        };
+        let cli = Cli::parse_from(["cpd", "--cross-formats", "javascript,typescript", "."]);
+        let opts = crate::options::Options::from_cli_and_config(&cli, &config);
+        assert_eq!(
+            opts.cross_formats,
+            vec![vec!["javascript".to_string(), "typescript".to_string()]]
+        );
+    }
+
+    #[test]
+    fn cross_formats_from_config() {
+        assert_config_overrides_default(
+            |c| c.cross_formats = Some("javascript,typescript".to_string()),
+            |o| &o.cross_formats,
+            vec![vec!["javascript".to_string(), "typescript".to_string()]],
+            "config cross_formats should parse into groups",
+        );
+    }
+
+    #[test]
+    fn cross_formats_config_coercion_shapes() {
+        // string / array-of-strings / array-of-arrays all normalize to the
+        // canonical string before ConfigFile deserialization.
+        let cases = [
+            serde_json::json!({"crossFormats": "javascript,typescript;css,scss"}),
+            serde_json::json!({"crossFormats": ["javascript,typescript", "css,scss"]}),
+            serde_json::json!({"crossFormats": [["javascript","typescript"],["css","scss"]]}),
+            serde_json::json!({"cross-formats": [["javascript","typescript"],["css","scss"]]}),
+        ];
+        for mut value in cases {
+            normalize_v4_config(&mut value);
+            let cfg: ConfigFile = serde_json::from_value(value.clone()).unwrap();
+            assert_eq!(
+                cfg.cross_formats,
+                Some("javascript,typescript;css,scss".to_string()),
+                "shape {value} must coerce to canonical string"
+            );
+        }
+    }
+
+    #[test]
+    fn cross_formats_is_known_config_field() {
+        for key in ["crossFormats", "cross-formats"] {
+            let value = serde_json::json!({key: "javascript,typescript"});
+            let diags = scan_unknown_fields(&value, Path::new(".jscpd.json"));
+            assert!(
+                diags.is_empty(),
+                "'{key}' must not be reported as unknown: {diags:?}"
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -48,6 +48,7 @@ struct MergedConfig {
     ignore_case: bool,
     formats_exts: std::collections::HashMap<String, Vec<String>>,
     formats_names: std::collections::HashMap<String, Vec<String>>,
+    cross_formats: Vec<Vec<String>>,
     skip_local: bool,
     no_tips: bool,
     silent: bool,
@@ -83,6 +84,7 @@ impl MergedConfig {
             ignore_case: opts.ignore_case,
             formats_exts: opts.formats_exts.clone(),
             formats_names: opts.formats_names.clone(),
+            cross_formats: opts.cross_formats.clone(),
             skip_local: opts.skip_local,
             no_tips: opts.no_tips,
             silent: opts.silent,
@@ -157,6 +159,19 @@ fn main() {
     let config = config_result.config;
     let opts = Options::from_cli_and_config(&cli, &config);
 
+    // Warn about unknown format names in --cross-formats. Custom formats
+    // introduced via --formats-exts are legal, so validate against both.
+    if !opts.cross_formats.is_empty() {
+        let known = cpd_tokenizer::formats::list_formats();
+        for group in &opts.cross_formats {
+            for format in group {
+                if !known.contains(&format.as_str()) && !opts.formats_exts.contains_key(format) {
+                    eprintln!("Warning: --cross-formats: unknown format '{}'", format);
+                }
+            }
+        }
+    }
+
     // Handle --debug: print merged config as JSON and exit
     if cli.debug {
         let merged = MergedConfig::from_options(&opts);
@@ -204,6 +219,7 @@ fn main() {
         formats_exts: opts.formats_exts.clone(),
         formats_names: opts.formats_names.clone(),
         pattern: opts.pattern.clone(),
+        cross_formats: opts.cross_formats.clone(),
     };
 
     // Start timing before detection

--- a/rust/crates/cpd/src/options.rs
+++ b/rust/crates/cpd/src/options.rs
@@ -29,6 +29,7 @@ pub struct Options {
     pub ignore_case: bool,
     pub formats_exts: HashMap<String, Vec<String>>,
     pub formats_names: HashMap<String, Vec<String>>,
+    pub cross_formats: Vec<Vec<String>>,
     pub skip_local: bool,
     pub no_tips: bool,
     pub silent: bool,
@@ -69,6 +70,13 @@ impl Options {
             .as_deref()
             .or(config.formats_names.as_deref())
             .map(super::cli::parse_format_mappings)
+            .unwrap_or_default();
+
+        let cross_formats = cli
+            .cross_formats
+            .as_deref()
+            .or(config.cross_formats.as_deref())
+            .map(super::cli::parse_cross_formats)
             .unwrap_or_default();
 
         Self {
@@ -130,6 +138,7 @@ impl Options {
             ignore_case: cli.ignore_case || config.ignore_case.unwrap_or(false),
             formats_exts,
             formats_names,
+            cross_formats,
             skip_local: cli.skip_local || config.skip_local.unwrap_or(false),
             no_tips: cli.no_tips || config.no_tips.unwrap_or(false) || std::env::var("CI").is_ok(),
             silent: cli.silent || config.silent.unwrap_or(false),

--- a/rust/crates/cpd/tests/fixtures/cross_formats.jscpd.json
+++ b/rust/crates/cpd/tests/fixtures/cross_formats.jscpd.json
@@ -1,0 +1,5 @@
+{
+  "minTokens": 20,
+  "minLines": 1,
+  "crossFormats": [["javascript", "typescript"]]
+}

--- a/rust/crates/cpd/tests/fixtures/cross_formats/a.ts
+++ b/rust/crates/cpd/tests/fixtures/cross_formats/a.ts
@@ -1,0 +1,19 @@
+interface Totals {
+    sum: number;
+    max: number;
+}
+
+function computeTotals(values: number[], threshold: number): Totals {
+    let sum: number = 0;
+    let max: number = 0;
+    for (const value of values) {
+        sum = sum + value;
+        if (value > max) {
+            max = value;
+        }
+    }
+    if (sum > threshold) {
+        sum = sum - threshold;
+    }
+    return { sum: sum, max: max } as Totals;
+}

--- a/rust/crates/cpd/tests/fixtures/cross_formats/b.js
+++ b/rust/crates/cpd/tests/fixtures/cross_formats/b.js
@@ -1,0 +1,14 @@
+function computeTotals(values, threshold) {
+    let sum = 0;
+    let max = 0;
+    for (const value of values) {
+        sum = sum + value;
+        if (value > max) {
+            max = value;
+        }
+    }
+    if (sum > threshold) {
+        sum = sum - threshold;
+    }
+    return { sum: sum, max: max };
+}

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -334,3 +334,93 @@ fn cli_both_ignore_flags_work_together() {
         output.status
     );
 }
+
+// --- cross-formats e2e -------------------------------------------------------
+
+fn cross_formats_fixture_dir() -> PathBuf {
+    fixtures_dir().join("cross_formats")
+}
+
+fn run_cross_formats(extra_args: &[&str]) -> Output {
+    let dir = cross_formats_fixture_dir();
+    let mut args: Vec<&str> = vec![
+        "--min-tokens",
+        "20",
+        "--min-lines",
+        "1",
+        "--reporters",
+        "console",
+    ];
+    args.extend_from_slice(extra_args);
+    let dir_str = dir.to_str().unwrap();
+    args.push(dir_str);
+    run_cpd(args).expect("cpd binary must exist")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+#[test]
+fn cross_formats_off_no_ts_js_clone() {
+    let output = run_cross_formats(&[]);
+    let stdout = stdout_of(&output);
+    assert!(
+        !(stdout.contains("a.ts") && stdout.contains("b.js")),
+        "without --cross-formats the TS/JS pair must not be reported, got: {stdout}"
+    );
+}
+
+#[test]
+fn cross_formats_flag_detects_ts_js_clone() {
+    let output = run_cross_formats(&["--cross-formats", "javascript,typescript"]);
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("a.ts") && stdout.contains("b.js"),
+        "--cross-formats must report the TS/JS pair, got: {stdout}"
+    );
+}
+
+#[test]
+fn cross_formats_preset_detects_ts_js_clone() {
+    let output = run_cross_formats(&["--cross-formats", "js-ts"]);
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("a.ts") && stdout.contains("b.js"),
+        "--cross-formats js-ts preset must report the TS/JS pair, got: {stdout}"
+    );
+}
+
+#[test]
+fn cross_formats_from_config_file() {
+    let config_path = fixtures_dir().join("cross_formats.jscpd.json");
+    let dir = cross_formats_fixture_dir();
+    let output = run_cpd([
+        "--config",
+        config_path.to_str().unwrap(),
+        "--reporters",
+        "console",
+        dir.to_str().unwrap(),
+    ])
+    .expect("cpd binary must exist");
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("a.ts") && stdout.contains("b.js"),
+        "crossFormats from config file must report the TS/JS pair, got: {stdout}"
+    );
+}
+
+#[test]
+fn cross_formats_shown_in_debug_output() {
+    let output = run_cpd(["--cross-formats", "javascript,typescript", "--debug", "."])
+        .expect("cpd binary must exist");
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("cross_formats"),
+        "--debug must include cross_formats in merged config, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("typescript"),
+        "--debug must show the configured group, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes #810

## What

New `--cross-formats` option for the Rust engine: declare **format equivalence groups** that share one clone-comparison pool, so near-identical files in related formats (the TS-migration case: `.ts` vs `.js`) are reported as duplicates.

```bash
cpd --cross-formats "javascript,typescript" ./src
cpd --cross-formats js-ts ./src                 # preset: javascript,jsx,typescript,tsx
cpd --cross-formats "js-ts;css,scss" ./src      # multiple groups
```

Config-file equivalent (`crossFormats` / `cross-formats`), accepting string, array-of-strings, or array-of-arrays shapes.

## How

- **Pooling** (`cpd-finder`): detection pools were keyed by format; grouped formats now collapse into one pool (`build_pools()` in `orchestrate.rs`). Token hashes were already format-agnostic, so the detection core needed no changes.
- **TS type-stripping** (`cpd-tokenizer`): when a group mixes TS (`typescript`/`tsx`) with JS (`javascript`/`jsx`), TypeScript files are compared with erasable type-only syntax stripped from the detection token stream — type annotations, generics, `interface`/`type` declarations, `as`/`satisfies`/`<T>` assertions, `?`/`!` markers, access modifiers, `implements` clauses, type-only imports/exports, overload signatures, `declare` statements — so `function f(a: number): void {}` matches `function f(a) {}`. Stripping is AST-driven (`oxc_ast_visit` over the program the tokenizer already parses) and only drops tokens; **reported clone positions always reference the original source**.
- Files keep their native tokenizers throughout, as proposed in the issue.

## Behavior notes

- Default behavior (no flag) is byte-identical: golden parity and full `fixtures/` regression baseline unchanged (214 clones before and after; 215 with `--cross-formats js-ts`, the extra one being the new fixture pair).
- Non-erasable TS syntax with runtime semantics is left intact and won't cross-match: `enum`, non-declare `namespace`, parameter properties, `import x = require()`, `export =`.
- Cross-format clones are attributed to one member format in per-format statistics (single `format` field on clones — documented; per-fragment formats deferred).
- Overlapping groups merge with a warning; single-format groups are ignored; unknown format names warn.

## Tests

- `cpd-tokenizer`: per-construct strip tests asserting stripped TS hash-sequences equal their untyped JS twins; non-erasable regression tests; default-path no-strip regression.
- `cpd-core`: `cross_format_group_detected` — inverse of the existing `different_formats_not_cross_detected`.
- `cpd-finder`: `build_pools`/strip-set unit tests + `cross_formats_integration.rs` (temp-dir TS/JS pair: 0 clones by default, 1 with the flag, positions on original lines).
- `cpd`: CLI parse tests (groups, preset, overlap merge, config shapes/aliases) + 5 e2e binary tests with new fixtures (`crates/cpd/tests/fixtures/cross_formats/`).
- New demo fixtures at `fixtures/cross-formats/{a.ts,b.js}`.
- Full workspace `cargo test` green; `cargo clippy` and `cargo fmt --check` clean.

## Docs

`docs/rust.md` — options table entry + "Cross-Format Groups" section (syntax, config shapes, stripping scope, caveats). `rust/CHANGELOG.md` — Unreleased entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/884)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cross-formats` support for detecting duplicate code across related language formats.
  * Supports explicit format groups, presets, and configuration-file equivalents.
  * TypeScript-only syntax is ignored when matching TypeScript with JavaScript.
  * Added validation and warnings for invalid or unknown format groups.
* **Documentation**
  * Added CLI and configuration guidance, examples, presets, and cross-format matching limitations.
* **Tests**
  * Added coverage for CLI, configuration, presets, format isolation, and TypeScript/JavaScript detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->