### PR TITLE
fix(tokenizer): analyze prose-only markdown files (#883)

### DIFF
--- a/rust/crates/cpd-finder/tests/fixtures/markdown_embedded/guide-a.md
+++ b/rust/crates/cpd-finder/tests/fixtures/markdown_embedded/guide-a.md
@@ -1,0 +1,22 @@
+# Setup guide
+
+This page explains how to configure the widget factory for production use.
+
+```javascript
+function computeTotals(values, threshold) {
+    let sum = 0;
+    let max = 0;
+    for (const value of values) {
+        sum = sum + value;
+        if (value > max) {
+            max = value;
+        }
+    }
+    if (sum > threshold) {
+        sum = sum - threshold;
+    }
+    return { sum: sum, max: max };
+}
+```
+
+Some closing remarks unique to the first document.

--- a/rust/crates/cpd-finder/tests/fixtures/markdown_embedded/guide-b.md
+++ b/rust/crates/cpd-finder/tests/fixtures/markdown_embedded/guide-b.md
@@ -1,0 +1,22 @@
+# Troubleshooting
+
+Entirely different prose so only the fenced code is duplicated here.
+
+```javascript
+function computeTotals(values, threshold) {
+    let sum = 0;
+    let max = 0;
+    for (const value of values) {
+        sum = sum + value;
+        if (value > max) {
+            max = value;
+        }
+    }
+    if (sum > threshold) {
+        sum = sum - threshold;
+    }
+    return { sum: sum, max: max };
+}
+```
+
+And a totally different ending for the second document.

--- a/rust/crates/cpd-finder/tests/fixtures/markdown_prose/first.md
+++ b/rust/crates/cpd-finder/tests/fixtures/markdown_prose/first.md
@@ -1,0 +1,7 @@
+# Contributing guide
+
+The quick brown fox jumps over the lazy dog while the sun sets slowly.
+Institutional memory outlives any single meeting when the work happens in the open.
+Asynchronous updates let contributors participate across every time zone without friction.
+Write down decisions where future readers can find them without asking anyone.
+Prefer small reviewable changes over sweeping rewrites that nobody can verify.

--- a/rust/crates/cpd-finder/tests/fixtures/markdown_prose/notes-a.txt
+++ b/rust/crates/cpd-finder/tests/fixtures/markdown_prose/notes-a.txt
@@ -1,0 +1,3 @@
+The quick brown fox jumps over the lazy dog while the sun sets slowly.
+Institutional memory outlives any single meeting when the work happens in the open.
+Asynchronous updates let contributors participate across every time zone without friction.

--- a/rust/crates/cpd-finder/tests/fixtures/markdown_prose/notes-b.txt
+++ b/rust/crates/cpd-finder/tests/fixtures/markdown_prose/notes-b.txt
@@ -1,0 +1,3 @@
+The quick brown fox jumps over the lazy dog while the sun sets slowly.
+Institutional memory outlives any single meeting when the work happens in the open.
+Asynchronous updates let contributors participate across every time zone without friction.

--- a/rust/crates/cpd-finder/tests/fixtures/markdown_prose/second.md
+++ b/rust/crates/cpd-finder/tests/fixtures/markdown_prose/second.md
@@ -1,0 +1,7 @@
+# Maintainer notes
+
+The quick brown fox jumps over the lazy dog while the sun sets slowly.
+Institutional memory outlives any single meeting when the work happens in the open.
+Asynchronous updates let contributors participate across every time zone without friction.
+Write down decisions where future readers can find them without asking anyone.
+Prefer small reviewable changes over sweeping rewrites that nobody can verify.

--- a/rust/crates/cpd-finder/tests/markdown_prose_integration.rs
+++ b/rust/crates/cpd-finder/tests/markdown_prose_integration.rs
@@ -1,0 +1,102 @@
+// Regression tests for https://github.com/kucherenko/jscpd/issues/883:
+// prose-only Markdown files (no code fences) were silently dropped — they
+// never counted as analyzed and `-f markdown` matched 0 files.
+
+use cpd_finder::orchestrate::{RunConfig, run};
+use cpd_tokenizer::tokenizer::Mode;
+use std::path::PathBuf;
+
+fn fixtures(dir: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{dir}"))
+}
+
+fn config(paths: Vec<PathBuf>, formats: Vec<String>) -> RunConfig {
+    RunConfig {
+        paths,
+        min_tokens: 20,
+        min_lines: 2,
+        mode: Mode::Mild,
+        formats,
+        no_gitignore: true,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn autodetect_analyzes_prose_markdown_files() {
+    let result = run(&config(vec![fixtures("markdown_prose")], vec![])).unwrap();
+
+    let md_sources: Vec<_> = result
+        .sources
+        .iter()
+        .filter(|s| s.format == "markdown")
+        .collect();
+    assert_eq!(
+        md_sources.len(),
+        2,
+        "both prose-only .md files must be analyzed during autodetect"
+    );
+    assert!(
+        md_sources.iter().all(|s| !s.tokens.is_empty()),
+        "prose-only markdown must produce display tokens"
+    );
+
+    assert!(
+        result.clones.iter().any(|c| c.format == "markdown"),
+        "identical prose-only .md pair must be reported as a markdown clone"
+    );
+    assert!(
+        result.clones.iter().any(|c| c.format == "txt"),
+        "the identical .txt pair must still be detected alongside markdown"
+    );
+}
+
+#[test]
+fn markdown_format_filter_matches_prose_markdown_files() {
+    let result = run(&config(
+        vec![fixtures("markdown_prose")],
+        vec!["markdown".to_string()],
+    ))
+    .unwrap();
+
+    assert_eq!(
+        result
+            .sources
+            .iter()
+            .filter(|s| s.format == "markdown")
+            .count(),
+        2,
+        "-f markdown must analyze prose-only .md files"
+    );
+    assert!(
+        result.sources.iter().all(|s| s.format == "markdown"),
+        "-f markdown must not pick up the .txt files"
+    );
+    assert!(
+        result.clones.iter().any(|c| c.format == "markdown"),
+        "identical prose-only .md pair must be reported as a clone with -f markdown"
+    );
+}
+
+#[test]
+fn embedded_code_fences_detected_as_sub_format_clones() {
+    let result = run(&config(vec![fixtures("markdown_embedded")], vec![])).unwrap();
+
+    assert_eq!(
+        result
+            .sources
+            .iter()
+            .filter(|s| s.format == "markdown")
+            .count(),
+        2,
+        "both fence-bearing .md files must be analyzed"
+    );
+    assert!(
+        result.clones.iter().any(|c| c.format == "javascript"),
+        "identical javascript fences in two .md files must be reported as a javascript clone"
+    );
+    assert!(
+        !result.clones.iter().any(|c| c.format == "markdown"),
+        "differing prose must not be reported as a markdown clone"
+    );
+}

--- a/rust/crates/cpd-tokenizer/src/markdown.rs
+++ b/rust/crates/cpd-tokenizer/src/markdown.rs
@@ -366,6 +366,30 @@ pub fn tokenize_markdown(source: &str, mode: Mode) -> Vec<Token> {
     let fences = extract_fences(source);
     let mut all_tokens = Vec::new();
 
+    // Prose body: blank out fenced code blocks and front matter, then
+    // tokenize the remainder as markdown — mirrors tokenize_markdown_maps so
+    // prose-only files (no code fences) still produce display tokens and are
+    // counted as analyzed.
+    let mut blanked_ranges: Vec<[usize; 2]> = extract_code_fences(source)
+        .iter()
+        .map(|f| [f.block_start, f.block_end])
+        .collect();
+    if let Some(fm) = extract_front_matter(source) {
+        blanked_ranges.push([fm.block_start, fm.block_end]);
+        blanked_ranges.sort_by_key(|r| r[0]);
+    }
+    let sanitized = blank_ranges_preserve_newlines(source, &blanked_ranges);
+    let mut body_tokens = crate::generic::tokenize_generic(&sanitized, "markdown");
+    for token in &mut body_tokens {
+        let in_outer_ignore = ignore_ranges
+            .iter()
+            .any(|(start, end)| token.start.line >= *start && token.start.line <= *end);
+        if in_outer_ignore {
+            token.kind = TokenKind::Ignore;
+        }
+    }
+    all_tokens.extend(body_tokens);
+
     for fence in &fences {
         let in_outer_ignore = ignore_ranges
             .iter()
@@ -386,6 +410,8 @@ pub fn tokenize_markdown(source: &str, mode: Mode) -> Vec<Token> {
         all_tokens.extend(fence_tokens);
     }
 
+    // Body and fence tokens are collected separately — restore source order.
+    all_tokens.sort_by_key(|t| (t.start.line, t.start.column));
     all_tokens
 }
 
@@ -472,11 +498,11 @@ mod tests {
     }
 
     #[test]
-    fn no_fences_produces_empty() {
+    fn no_fences_produces_prose_tokens() {
         let tokens = tokenize_markdown(MD_NO_FENCES, Mode::Mild);
         assert!(
-            tokens.is_empty(),
-            "Markdown with no fences must produce no tokens"
+            !tokens.is_empty(),
+            "Markdown with no fences must still produce prose tokens (issue #883)"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #883 — in v5, prose-only Markdown files (no fenced code blocks) were silently skipped: they never counted toward "Files analyzed" during autodetect, and `-f markdown` matched 0 files, so a Markdown-only project got a passing exit code while nothing was scanned.

## Root cause

The `.md`/`.markdown`/`.mkd` extension bindings were intact, and the detection path (`tokenize_markdown_maps`) tokenizes prose correctly. The bug was in the display-path tokenizer `tokenize_markdown`, which only extracted fenced code blocks — prose-only files returned 0 display tokens, and the orchestrator's `tokens.len() < min_tokens` gate then dropped the file before detection ever ran. All existing markdown fixtures happen to contain fences, which is why this went unnoticed.

## Fix

`tokenize_markdown` now also tokenizes the prose body: fenced code and YAML front matter are blanked out (reusing the same helpers as the detection path), the remainder goes through the generic markdown tokenizer, `jscpd:ignore` regions are honored, and body + fence tokens are merged in source order.

## Verification

- Issue repro now passes: autodetect analyzes the `.md` pair and reports a `markdown` clone; `-f markdown` analyzes 2 files instead of 0.
- Sub-format detection for embedded code fences is unaffected and covered by a new test: identical `javascript` fences in two `.md` files with differing prose are reported as a `javascript` clone (and prose is not).
- Full `fixtures/` sweep: clone output is byte-identical to master (214 clones, same pairs/positions, 353 sources) — the change only adds previously-dropped files. Markdown token statistics now include prose, matching what detection already counted.
- All workspace test suites pass.

## Tests / fixtures added

- `rust/crates/cpd-finder/tests/fixtures/markdown_prose/` — prose-only `.md` pair + `.txt` pair (issue repro)
- `rust/crates/cpd-finder/tests/fixtures/markdown_embedded/` — `.md` pair with identical JS fences, differing prose
- `rust/crates/cpd-finder/tests/markdown_prose_integration.rs` — autodetect, `-f markdown`, and sub-format clone assertions
- Inverted the unit test that encoded the old behavior (`no_fences_produces_empty` → `no_fences_produces_prose_tokens`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/885)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Markdown analysis now detects duplicate prose in `.md` files, including documents without code blocks.
  - Embedded code blocks remain independently analyzable, allowing duplicate code to be identified without incorrectly matching surrounding prose.
  - Markdown filtering now distinguishes prose content from embedded JavaScript and other fenced code.

- **Bug Fixes**
  - Improved Markdown tokenization while preserving source order and ignore directives.
  - YAML front matter and fenced code are excluded from prose comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->