### PR TITLE
fix(finder): emit valid XML for fragments with control characters

### DIFF
--- a/packages/finder/__tests__/utils.test.ts
+++ b/packages/finder/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest';
-import {compareDates, escapeXml, getPath, getPathConsoleString, getSourceLocation, generateLine, convertStatisticToArray} from "../src/utils/reports";
+import {compareDates, escapeXml, sanitizeCdata, getPath, getPathConsoleString, getSourceLocation, generateLine, convertStatisticToArray} from "../src/utils/reports";
 import {buildClone, buildBlameData} from './helpers/clone-builder';
 import {relative} from 'path';
 import {cwd} from 'process';
@@ -8,6 +8,25 @@ describe('jscpd finder: utils', () => {
   describe('escapeXml', () => {
     it('should replace unsafe symbols', () => {
       expect(escapeXml(`<>&'"`)).to.eq('&lt;&gt;&amp;&apos;&quot;')
+    });
+  });
+
+  describe('sanitizeCdata', () => {
+    it('should neutralize every CDATA terminator, not only the first', () => {
+      expect(sanitizeCdata('a]]>b]]>c')).to.eq('aCDATA_ENDbCDATA_ENDc');
+    });
+
+    it('should strip control characters that are invalid in XML', () => {
+      const input = 'a\u0000b\u0008c\u000Bd\u000Ce\u001Ff\uFFFEg\uFFFFh';
+      expect(sanitizeCdata(input)).to.eq('abcdefgh');
+    });
+
+    it('should keep tab, line feed and carriage return', () => {
+      expect(sanitizeCdata('a\tb\nc\rd')).to.eq('a\tb\nc\rd');
+    });
+
+    it('should leave ordinary text untouched', () => {
+      expect(sanitizeCdata('const a = 1;')).to.eq('const a = 1;');
     });
   });
 

--- a/packages/finder/src/reporters/xml.ts
+++ b/packages/finder/src/reporters/xml.ts
@@ -2,7 +2,7 @@ import {writeFileSync} from 'fs';
 import {ensureDirSync} from 'fs-extra';
 import {IReporter} from '..';
 import {getOption, IClone, IOptions} from '@jscpd/core';
-import {escapeXml, getPath} from '../utils/reports';
+import {escapeXml, getPath, sanitizeCdata} from '../utils/reports';
 import {green} from 'colors/safe';
 import {join} from "path";
 
@@ -17,15 +17,17 @@ export class XmlReporter implements IReporter {
     xmlDoc += '<pmd-cpd>';
 
     clones.forEach((clone: IClone) => {
+      const fragmentA = sanitizeCdata(clone.duplicationA.fragment ?? '');
+      const fragmentB = sanitizeCdata(clone.duplicationB.fragment ?? '');
       xmlDoc = `${xmlDoc}
       <duplication lines="${clone.duplicationA.end.line - clone.duplicationA.start.line}">
             <file path="${escapeXml(getPath(clone.duplicationA.sourceId, this.options))}" line="${clone.duplicationA.start.line}">
-              <codefragment><![CDATA[${clone.duplicationA.fragment?.replace(/]]>/i, 'CDATA_END')}]]></codefragment>
+              <codefragment><![CDATA[${fragmentA}]]></codefragment>
             </file>
             <file path="${escapeXml(getPath(clone.duplicationB.sourceId, this.options))}" line="${clone.duplicationB.start.line}">
-              <codefragment><![CDATA[${clone.duplicationB.fragment?.replace(/]]>/i, 'CDATA_END')}]]></codefragment>
+              <codefragment><![CDATA[${fragmentB}]]></codefragment>
             </file>
-            <codefragment><![CDATA[${clone.duplicationA.fragment?.replace(/]]>/i, 'CDATA_END')}]]></codefragment>
+            <codefragment><![CDATA[${fragmentA}]]></codefragment>
         </duplication>
       `;
 		});

--- a/packages/finder/src/utils/reports.ts
+++ b/packages/finder/src/utils/reports.ts
@@ -29,6 +29,18 @@ export function escapeXml(unsafe: string): string {
   });
 }
 
+// Characters that are not allowed anywhere in an XML 1.0 document, not even
+// inside CDATA: the C0 controls except tab, line feed and carriage return,
+// plus the U+FFFE/U+FFFF noncharacters.
+const INVALID_XML_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/g;
+
+export function sanitizeCdata(unsafe: string): string {
+  return unsafe
+    // Every `]]>` closes the CDATA section early, not just the first one.
+    .replace(/]]>/g, 'CDATA_END')
+    .replace(INVALID_XML_CHARS, '');
+}
+
 export function getPath(path: string, options: IOptions): string {
   return options.absolute ? path : relative(cwd(), path);
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Bug fix.

* **What is the current behavior?**

Fixes #375 — the XML reporter can emit malformed XML.

Two separate defects in `packages/finder/src/reporters/xml.ts`:

1. Code fragments are wrapped in `CDATA`, and `]]>` inside a fragment is neutralised with
   `fragment?.replace(/]]>/i, 'CDATA_END')`. That regex has no `g` flag, so only the **first**
   `]]>` is replaced — a fragment containing a second one closes its CDATA section early and
   corrupts the document. (The `i` flag is also a no-op on `]]>`.)

2. Raw C0 control characters are never stripped. These are invalid *anywhere* in an XML 1.0
   document — including inside CDATA — so a duplicate detected in a file with binary content
   makes the report unparseable, which is the `ExpatError: not well-formed` symptom in #375.

The same expression was duplicated three times, so both bugs existed in triplicate.

* **What is the new behavior (if this is a feature change)?**

Adds a shared `sanitizeCdata()` helper next to `escapeXml()` in `utils/reports.ts` that:

- replaces **every** `]]>` (keeping the existing `CDATA_END` substitution, so output is
  unchanged for fragments that were already handled correctly), and
- drops characters XML 1.0 forbids: `U+0000`–`U+0008`, `U+000B`, `U+000C`, `U+000E`–`U+001F`,
  `U+FFFE`, `U+FFFF`. Tab, line feed and carriage return are deliberately preserved.

The three interpolations now share two hoisted `fragmentA` / `fragmentB` constants.

Four unit tests added in `packages/finder/__tests__/utils.test.ts`.

* **Other information**:

- A missing `fragment` now renders as an empty CDATA rather than the literal string
  `undefined` (the previous `?.` chain interpolated `undefined` into the report). Happy to
  revert that detail if you'd rather keep it strictly scoped.
- I noticed #613 also touches the missing `g` flag. It's currently marked conflicting and
  hasn't moved since 2023; this PR additionally covers the control-character half of #375,
  which is the part that actually triggers the reported parser error. Glad to rebase around
  it instead if you'd prefer to land that one first.

**Testing done:** `vitest run` in `packages/finder` — the 4 new tests pass and
`utils.test.ts` + `reporters.test.ts` are fully green (35/35).

Two things I hit locally that are worth flagging, both pre-existing on `master` and unrelated
to this change:

- `pnpm install --frozen-lockfile` fails with `ERR_PNPM_BROKEN_LOCKFILE` — `pnpm-lock.yaml`
  has `picomatch@4.0.5` as a duplicated mapping key (around line 2615). I installed with
  `--no-frozen-lockfile` and reverted the lockfile, so it is untouched in this PR.
- The full `packages/finder` suite reports 20 failures in `hooks.test.ts` and
  `in-files-detector.test.ts`. I confirmed these are pre-existing by stashing my changes and
  re-running on a clean tree: identical 20 failures there (77 passed), versus 81 passed with
  this branch. No new failures introduced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/886)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML report generation for duplicated code fragments.
  * Prevented malformed XML when fragments contain CDATA terminators or invalid control characters.
  * Preserved supported whitespace characters, including tabs and line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- brian settings start --><!--{}--><!-- brian settings end -->