### PR TITLE
fix(rust): populate reporter snippets when scan root differs from CWD

### DIFF
--- a/rust/crates/cpd-reporter/tests/reporters_integration.rs
+++ b/rust/crates/cpd-reporter/tests/reporters_integration.rs
@@ -88,10 +88,63 @@ fn make_test_clone() -> CpdClone {
 // Test Helper Functions
 // ============================================================================
 
+const SNIPPET_MARKER: &str = "test_snippet_marker_xyzzy";
+
 fn create_test_output_dir(test_name: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!("cpd-reporter-test-{}", test_name));
+    let dir = std::env::temp_dir().join(format!(
+        "cpd-reporter-test-{}-{}",
+        test_name,
+        std::process::id()
+    ));
     std::fs::create_dir_all(&dir).expect("Failed to create test output dir");
     dir
+}
+
+/// Create a clone backed by real files on disk so reporters can read snippets.
+fn make_test_clone_with_real_files(dir: &PathBuf) -> CpdClone {
+    let code = format!(
+        "function hello() {{\n  console.log(\"{}\");\n  return 42;\n}}\n",
+        SNIPPET_MARKER
+    );
+    let file_a = dir.join("a.js");
+    let file_b = dir.join("b.js");
+    std::fs::write(&file_a, &code).expect("write a.js");
+    std::fs::write(&file_b, &code).expect("write b.js");
+
+    CpdClone {
+        format: "javascript".to_string(),
+        fragment_a: Fragment {
+            source_id: file_a.to_string_lossy().into_owned(),
+            start: Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            end: Location {
+                line: 4,
+                column: 1,
+                offset: code.len() as u32,
+            },
+            range: [0, 100],
+            blame: None,
+        },
+        fragment_b: Fragment {
+            source_id: file_b.to_string_lossy().into_owned(),
+            start: Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            end: Location {
+                line: 4,
+                column: 1,
+                offset: code.len() as u32,
+            },
+            range: [0, 100],
+            blame: None,
+        },
+        token_count: 50,
+    }
 }
 
 fn assert_file_exists(output_dir: &PathBuf, filename: &str) {
@@ -281,4 +334,65 @@ fn threshold_reporter_runs() {
     let clones = vec![make_test_clone()];
 
     let _ = reporter.report(&clones, &ctx, &PathBuf::from("/tmp"));
+}
+
+// ============================================================================
+// Snippet content tests — verify reporters read files and include code
+// ============================================================================
+
+#[test]
+fn json_report_contains_snippet_text() {
+    let output_dir = create_test_output_dir("json-snippet");
+    let clone = make_test_clone_with_real_files(&output_dir);
+    let opts = ReporterOptions::new(output_dir.clone());
+    let reporter = create_reporter("json", &opts).unwrap();
+    let ctx = make_test_ctx();
+
+    reporter
+        .report(&[clone], &ctx, &output_dir)
+        .expect("json reporter must succeed");
+
+    let content = read_output_file(&output_dir, "jscpd-report.json");
+    assert!(
+        content.contains(SNIPPET_MARKER),
+        "JSON fragment must contain source code, got empty snippet"
+    );
+}
+
+#[test]
+fn html_report_contains_snippet_text() {
+    let output_dir = create_test_output_dir("html-snippet");
+    let clone = make_test_clone_with_real_files(&output_dir);
+    let opts = ReporterOptions::new(output_dir.clone());
+    let reporter = create_reporter("html", &opts).unwrap();
+    let ctx = make_test_ctx();
+
+    reporter
+        .report(&[clone], &ctx, &output_dir)
+        .expect("html reporter must succeed");
+
+    let content = read_output_file(&output_dir, "jscpd-report.html");
+    assert!(
+        content.contains(SNIPPET_MARKER),
+        "HTML report must contain source code, got empty snippet"
+    );
+}
+
+#[test]
+fn xml_report_contains_snippet_text() {
+    let output_dir = create_test_output_dir("xml-snippet");
+    let clone = make_test_clone_with_real_files(&output_dir);
+    let opts = ReporterOptions::new(output_dir.clone());
+    let reporter = create_reporter("xml", &opts).unwrap();
+    let ctx = make_test_ctx();
+
+    reporter
+        .report(&[clone], &ctx, &output_dir)
+        .expect("xml reporter must succeed");
+
+    let content = read_output_file(&output_dir, "jscpd-report.xml");
+    assert!(
+        content.contains(SNIPPET_MARKER),
+        "XML report must contain source code, got empty snippet"
+    );
 }

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -237,25 +237,25 @@ fn main() {
     let mut clones = run_result.clones;
     let statistics = run_result.statistics;
 
-    // Path normalization: by default, relativize source_ids to their scan
-    // root (falling back to CWD) for cleaner display. With --absolute,
-    // ensure they stay absolute. Source IDs arrive canonicalized from the
-    // finder, so we canonicalize the scan roots here too — this makes
-    // prefix stripping work regardless of how the user invoked the CLI
-    // (`jscpd .` vs `jscpd /abs/path`) and across macOS symlinked roots
-    // (`/var` vs `/private/var`) or Windows verbatim prefixes (`\\?\`).
+    // Path normalization: relativize source_ids to the CWD so they remain
+    // resolvable from the CWD. File reporters (html, json, console-full)
+    // re-read sources from disk to render snippets — a path that doesn't
+    // resolve produces empty code. Relativizing to the CWD (not the scan
+    // root) keeps paths readable: scanning `frontend/` from the project
+    // root yields `frontend/src/a.js`, which both reads back correctly and
+    // distinguishes multiple scan roots. Paths outside the CWD are left
+    // absolute (still readable). Source IDs arrive canonicalized from the
+    // finder, so we canonicalize the CWD too for reliable prefix stripping
+    // across macOS symlinked roots (`/var` vs `/private/var`).
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-    let scan_roots: Vec<std::path::PathBuf> = paths
-        .iter()
-        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
-        .collect();
+    let cwd = std::fs::canonicalize(&cwd).unwrap_or(cwd);
     for clone in &mut clones {
         if opts.absolute {
             make_path_absolute(&mut clone.fragment_a.source_id);
             make_path_absolute(&mut clone.fragment_b.source_id);
         } else {
-            relativize_to_scan_root(&mut clone.fragment_a.source_id, &scan_roots, &cwd);
-            relativize_to_scan_root(&mut clone.fragment_b.source_id, &scan_roots, &cwd);
+            relativize_to_cwd(&mut clone.fragment_a.source_id, &cwd);
+            relativize_to_cwd(&mut clone.fragment_b.source_id, &cwd);
         }
     }
 
@@ -426,24 +426,14 @@ fn strip_dot_prefix(s: &str) -> String {
     }
 }
 
-/// Relativize a canonicalized `source_id` for display when `--absolute` is off.
+/// Relativize a canonicalized `source_id` to the CWD when `--absolute` is off.
 ///
-/// Tries each canonicalized scan root first (so `jscpd /abs/path` emits paths
-/// relative to `/abs/path`), then falls back to CWD. Strips any leading `./`
-/// or `.\` component. If nothing matches, the path is returned with the dot
-/// prefix removed but otherwise unchanged.
-fn relativize_to_scan_root(
-    source_id: &mut String,
-    scan_roots: &[std::path::PathBuf],
-    cwd: &std::path::Path,
-) {
+/// Stripping the CWD prefix keeps the path resolvable from the CWD, which file
+/// reporters rely on when they re-read source files to render snippets. Paths
+/// outside the CWD are left unchanged (absolute, still readable). Any leading
+/// `./` or `.\` component is stripped.
+fn relativize_to_cwd(source_id: &mut String, cwd: &std::path::Path) {
     let path = std::path::Path::new(source_id);
-    for root in scan_roots {
-        if let Ok(stripped) = path.strip_prefix(root) {
-            *source_id = strip_dot_prefix(&stripped.to_string_lossy());
-            return;
-        }
-    }
     if let Ok(stripped) = path.strip_prefix(cwd) {
         *source_id = strip_dot_prefix(&stripped.to_string_lossy());
         return;
@@ -512,10 +502,6 @@ mod tests {
         assert!(!is_console_reporter("html"));
     }
 
-    fn pathbuf(s: &str) -> std::path::PathBuf {
-        std::path::PathBuf::from(s)
-    }
-
     #[test]
     fn strip_dot_prefix_unix() {
         assert_eq!(strip_dot_prefix("./src/foo.rs"), "src/foo.rs");
@@ -530,57 +516,27 @@ mod tests {
     }
 
     #[test]
-    fn relativize_strips_matching_scan_root() {
-        let mut id = "/project/src/foo.rs".to_string();
-        relativize_to_scan_root(
-            &mut id,
-            &[pathbuf("/project")],
-            std::path::Path::new("/elsewhere"),
-        );
-        assert_eq!(id, "src/foo.rs");
+    fn relativize_strips_cwd_prefix() {
+        let mut id = "/project/frontend/src/foo.rs".to_string();
+        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
+        assert_eq!(id, "frontend/src/foo.rs");
     }
 
     #[test]
-    fn relativize_falls_back_to_cwd_when_not_under_scan_root() {
-        let mut id = "/project/src/foo.rs".to_string();
-        relativize_to_scan_root(
-            &mut id,
-            &[pathbuf("/other")],
-            std::path::Path::new("/project"),
-        );
-        assert_eq!(id, "src/foo.rs");
-    }
-
-    #[test]
-    fn relativize_picks_correct_root_when_multiple_given() {
-        let mut id = "/b/x.rs".to_string();
-        relativize_to_scan_root(
-            &mut id,
-            &[pathbuf("/a"), pathbuf("/b")],
-            std::path::Path::new("/c"),
-        );
-        assert_eq!(id, "x.rs");
-    }
-
-    #[test]
-    fn relativize_keeps_path_when_under_no_root_or_cwd() {
+    fn relativize_keeps_absolute_when_outside_cwd() {
         let mut id = "/elsewhere/src/foo.rs".to_string();
-        relativize_to_scan_root(
-            &mut id,
-            &[pathbuf("/project")],
-            std::path::Path::new("/project"),
-        );
+        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
         assert_eq!(id, "/elsewhere/src/foo.rs");
     }
 
     #[test]
-    fn relativize_strips_dot_prefix_when_canonicalize_failed() {
+    fn relativize_strips_dot_prefix() {
         let mut id = "./src/foo.rs".to_string();
-        relativize_to_scan_root(&mut id, &[], std::path::Path::new("/project"));
+        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
         assert_eq!(id, "src/foo.rs");
 
         let mut id = ".\\src\\foo.rs".to_string();
-        relativize_to_scan_root(&mut id, &[], std::path::Path::new("/project"));
+        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
         assert_eq!(id, "src\\foo.rs");
     }
 }

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -315,6 +315,72 @@ fn cli_ignore_pattern_flag_accepted() {
     );
 }
 
+// --- snippet regression test (scan root != CWD) --------------------------------
+
+#[test]
+fn report_snippets_populated_when_scan_root_differs_from_cwd() {
+    let bin = match maybe_bin() {
+        Some(b) => b,
+        None => return,
+    };
+
+    let root = std::env::temp_dir().join(format!("cpd-snippet-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let pkg = root.join("pkg");
+    std::fs::create_dir_all(&pkg).expect("create pkg dir");
+
+    let dup = "function greet(name) {\n  \
+        const message = \"Hello, \" + name + \"!\";\n  \
+        console.log(message);\n  \
+        console.log(\"Welcome to the system\");\n  \
+        console.log(\"Have a nice day now\");\n  \
+        return message;\n}\n";
+    std::fs::write(pkg.join("a.js"), dup).expect("write a.js");
+    std::fs::write(pkg.join("b.js"), dup).expect("write b.js");
+
+    let out = root.join("report");
+
+    let output = Command::new(&bin)
+        .args([
+            "pkg",
+            "--min-tokens",
+            "10",
+            "--reporters",
+            "json,html",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cpd");
+    assert!(
+        output.status.success(),
+        "cpd must succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let marker = "Welcome to the system";
+
+    let json = std::fs::read_to_string(out.join("jscpd-report.json")).expect("json report exists");
+    assert!(
+        json.contains(marker),
+        "JSON fragment must contain snippet text, not be empty"
+    );
+
+    let html = std::fs::read_to_string(out.join("jscpd-report.html")).expect("html report exists");
+    assert!(
+        html.contains(marker),
+        "HTML report must contain snippet text, not be empty"
+    );
+
+    assert!(
+        json.contains("pkg/a.js") || json.contains(r"pkg\\a.js"),
+        "source path must be CWD-relative (keep the pkg/ prefix)"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 #[test]
 fn cli_both_ignore_flags_work_together() {
     let output = run_cpd([


### PR DESCRIPTION
Fixes #872

## Problem

When the scan target is not the current working directory (e.g. `jscpd frontend/`, or `path: ["frontend"]` in `.jscpd.json`), the HTML/JSON/XML/console-full reports show clone locations but **no code snippets** — the JSON `fragment` field is an empty string, HTML "show code" blocks are blank. Running `jscpd .` from within the target masks the bug.

## Root cause

The file reporters re-read each source file from disk to render its snippet. Since the v5 Rust rewrite, source paths are rewritten relative to the *scan root* for display (`/proj/frontend/src/a.js` → `src/a.js`). Reporters then call `read_to_string("src/a.js")`, which resolves against the CWD (`/proj`) where that path doesn't exist. The read fails and is swallowed by `read_file_cached`'s `unwrap_or_default()`, yielding empty code.

## Fix

Relativize display paths to the **CWD** instead of the scan root, so they stay resolvable when reporters re-read them. Scanning `frontend/` from the project root now yields `frontend/src/a.js` — which both renders code correctly and disambiguates multiple scan roots. Paths outside the CWD are left absolute (still readable). `--absolute` is unaffected.

## Tests

- Integration regression test (`report_snippets_populated_when_scan_root_differs_from_cwd`): scans a subdirectory (scan root ≠ CWD) and asserts both JSON and HTML contain the snippet text. Fails on old behavior, passes with the fix.
- Reporter tests now use **real files on disk** and assert snippet content appears in json/html/xml output — previously they used non-existent paths and only checked `is_ok()`, which is why this class of bug shipped undetected.
- Full workspace: 676 passed, 0 failed (Rust 1.93).

## Credit

The path-resolution approach mirrors #869; this PR adds the reporter-level test coverage that prevents regressions across all snippet-reading reporters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/892)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured JSON, HTML, and XML reports reliably include the actual snippet text.
  * Improved `source_id` path handling when not using absolute mode by making paths relative to the current working directory (while preserving paths outside it) and cleaning leading `./` segments.
* **Tests**
  * Added file-backed integration tests that verify snippet-marker text appears in all report formats.
  * Added/updated integration coverage to confirm correct CWD-relative source paths when the scan root differs from the working directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- brian settings start --><!--{}--><!-- brian settings end -->