### PR TITLE
fix(cli): do not print clones twice with the consoleFull reporter

### DIFF
--- a/apps/jscpd/__tests__/reporters.test.ts
+++ b/apps/jscpd/__tests__/reporters.test.ts
@@ -76,11 +76,28 @@ describe('jscpd reporters', () => {
   });
 
   describe('Console Full', () => {
+    const cloneHeaders = (log: any): string[] =>
+      log.mock.calls
+        .map(([line]: [unknown]) => line)
+        .filter((line: unknown): line is string => typeof line === 'string' && line.startsWith('Clone found'));
+
     it('should generate report with table', async () => {
       const log = (console.log as any);
       await jscpd(['', '', pathToFixtures + '/clike/file2.c', '--reporters', 'consoleFull']);
       expect(log).toHaveBeenCalledWith(grey('Found 1 clones.'));
 		});
+
+    it('should announce every clone only once', async () => {
+      const log = (console.log as any);
+      await jscpd(['', '', pathToFixtures + '/clike/file2.c', '--reporters', 'consoleFull']);
+      expect(cloneHeaders(log)).toHaveLength(1);
+    });
+
+    it('should keep announcing clones for reporters that do not print them', async () => {
+      const log = (console.log as any);
+      await jscpd(['', '', pathToFixtures + '/clike/file2.c', '--reporters', 'console']);
+      expect(cloneHeaders(log)).toHaveLength(1);
+    });
 	});
 
 	describe('Xcode', () => {

--- a/apps/jscpd/__tests__/reporters.test.ts
+++ b/apps/jscpd/__tests__/reporters.test.ts
@@ -76,10 +76,13 @@ describe('jscpd reporters', () => {
   });
 
   describe('Console Full', () => {
-    const cloneHeaders = (log: any): string[] =>
+    const loggedLines = (log: any): string[] =>
       log.mock.calls
         .map(([line]: [unknown]) => line)
-        .filter((line: unknown): line is string => typeof line === 'string' && line.startsWith('Clone found'));
+        .filter((line: unknown): line is string => typeof line === 'string');
+
+    const cloneHeaders = (log: any): string[] =>
+      loggedLines(log).filter((line: string) => line.startsWith('Clone found'));
 
     it('should generate report with table', async () => {
       const log = (console.log as any);
@@ -97,6 +100,17 @@ describe('jscpd reporters', () => {
       const log = (console.log as any);
       await jscpd(['', '', pathToFixtures + '/clike/file2.c', '--reporters', 'console']);
       expect(cloneHeaders(log)).toHaveLength(1);
+    });
+
+    it('should announce every clone only once when combined with the console reporter', async () => {
+      const log = (console.log as any);
+      await jscpd(['', '', pathToFixtures + '/clike/file2.c', '--reporters', 'console,consoleFull']);
+      const lines = loggedLines(log);
+      expect(cloneHeaders(log)).toHaveLength(1);
+      // consoleFull still prints the duplicated code...
+      expect(lines.some((line: string) => line.includes('frame_new_height'))).toBe(true);
+      // ...and console still prints the statistic table.
+      expect(lines.some((line: string) => line.includes('Files analyzed'))).toBe(true);
     });
 	});
 

--- a/apps/jscpd/src/init/subscribers.ts
+++ b/apps/jscpd/src/init/subscribers.ts
@@ -1,12 +1,20 @@
 import {InFilesDetector, ProgressSubscriber, VerboseSubscriber} from '@jscpd/finder';
 import {IOptions} from '@jscpd/core';
 
+// Reporters that print every clone themselves. Streaming the same clones from
+// the progress subscriber would print each one twice.
+const REPORTERS_PRINTING_CLONES = ['ai', 'consoleFull'];
+
 export function registerSubscribers(options: IOptions, detector: InFilesDetector): void {
   if (options.verbose) {
     detector.registerSubscriber(new VerboseSubscriber(options));
   }
 
-  if (!options.silent && !options.reporters?.includes('ai')) {
+  const reporterPrintsClones = options.reporters?.some((reporter: string) =>
+    REPORTERS_PRINTING_CLONES.includes(reporter),
+  );
+
+  if (!options.silent && !reporterPrintsClones) {
     detector.registerSubscriber(new ProgressSubscriber(options));
   }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

With `--reporters consoleFull`, every clone is announced twice: `ProgressSubscriber` prints a `Clone found (...)` header while detection runs, and `ConsoleFullReporter` prints the same header again before each code table.

```
$ jscpd -r consoleFull --skipLocal fixtures/clike/file2.c
Clone found (c):
 - fixtures/clike/file2.c [18:3 - 28:3] (10 lines, 63 tokens)
   fixtures/clike/file2.c [8:3 - 18:3]

Clone found (c):
 - fixtures/clike/file2.c [18:3 - 28:3] (10 lines, 63 tokens)
   fixtures/clike/file2.c [8:3 - 18:3]

 18 │ 8  │ ...
```

Reported in #652.

* **What is the new behavior (if this is a feature change)?**

`registerSubscribers` already skipped the progress subscriber for the `ai` reporter, because that reporter prints the clones itself. `consoleFull` is in the same category, so it joins that list and each clone is announced once.

`--reporters console` and the other reporters are unaffected — they do not print per-clone output, so the progress subscriber still streams the headers for them. Combining `--reporters console,consoleFull` now yields the code tables plus the summary table, with no duplicated headers.

* **Other information**:

Tests: added two cases to `apps/jscpd/__tests__/reporters.test.ts` — one asserting `consoleFull` announces each clone once (fails on `master` with `2 !== 1`), one asserting `console` still announces it.

The full `apps/jscpd` reporter suite does not pass on my Windows machine even on a clean `master`: the tests compare against POSIX paths (`report/jscpd-report.json`, `../../fixtures/...`) that come out with backslashes here. The three `Console Full` cases pass, and I also verified the change end to end against the CLI: `jscpd -r consoleFull --skipLocal fixtures/clike/file2.c` prints 2 `Clone found` headers before this change and 1 after, while `-r console` prints 1 in both.

Fixes #652

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/900)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate clone announcements in console-based reports.
  * Improved progress display behavior when using full console reporting.
  * Added coverage to ensure clone announcements are emitted exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->