### PR TITLE
fix(deps): remove duplicated entries that break pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2612,14 +2612,6 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
-    engines: {node: '>=12'}
-
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
-    engines: {node: '>=12'}
-
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -4624,14 +4616,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fdir@6.5.0(picomatch@4.0.5):
-    optionalDependencies:
-      picomatch: 4.0.5
-
-  fdir@6.5.0(picomatch@4.0.5):
-    optionalDependencies:
-      picomatch: 4.0.5
-
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -5341,10 +5325,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.5: {}
-
-  picomatch@4.0.5: {}
 
   picomatch@4.0.5: {}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Bug fix (repository tooling — no runtime code changed).

* **What is the current behavior?**

`pnpm-lock.yaml` on `master` contains duplicated mapping keys, which makes it invalid YAML:

```
 ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ".../pnpm-lock.yaml" is broken:
 duplicated mapping key (2615:3)

 2615 |   picomatch@4.0.5:
----------^
```

Three entries are triplicated, byte-for-byte identical each time:

- `packages:` → `picomatch@4.0.5` (3×)
- `snapshots:` → `fdir@6.5.0(picomatch@4.0.5)` (3×)
- `snapshots:` → `picomatch@4.0.5` (3×)

Consequences:

- `pnpm install --frozen-lockfile` fails outright, so the lockfile cannot be used in a reproducible/CI-verified install.
- Plain `pnpm install` (what `.github/workflows/nodejs.yml` runs) only prints `WARN Ignoring broken lockfile` and then re-resolves the whole dependency graph from the registry. CI stays green, but it is no longer installing the pinned versions — the lockfile is effectively inert.

* **What is the new behavior (if this is a feature change)?**

The duplicate entries are removed, keeping one copy of each. The diff is 20 deleted lines and nothing else; no version is added, removed, or changed.

After the fix:

```
$ pnpm install --frozen-lockfile
Done in 8.3s using pnpm v10.28.0
```

The lockfile is left untouched by that install, confirming it is in sync with the `package.json` files.

* **Other information**:

Verified locally on Windows with pnpm 10.28.0 / Node 22:

- `pnpm install --frozen-lockfile` succeeds and does not modify `pnpm-lock.yaml`.
- `packages/core` test suite passes against the resulting `node_modules` (7 files, 65 tests).

I did not regenerate the lockfile, deliberately — a regeneration would produce a large unrelated version-bump diff. This is the minimal change that makes the existing lockfile parseable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/901)
<!-- Reviewable:end -->
