### PR TITLE
feat(sarif): add token count and clone hash to results

### DIFF
--- a/rust/crates/cpd-core/src/hash.rs
+++ b/rust/crates/cpd-core/src/hash.rs
@@ -23,6 +23,18 @@ pub fn hash_token(kind_discriminant: u8, value: &str, ignore_case: bool) -> u64 
     }
 }
 
+/// Hash a pair of duplicated snippets independent of fragment order, so the
+/// same clone pair yields the same hash regardless of which copy the detector
+/// labels as fragment A (file discovery order varies between runs).
+pub fn snippet_pair_hash(a: &str, b: &str) -> u64 {
+    let (first, second) = if a <= b { (a, b) } else { (b, a) };
+    let mut buf = Vec::with_capacity(first.len() + second.len() + 1);
+    buf.extend_from_slice(first.as_bytes());
+    buf.push(0); // separator: keeps ("ab","c") distinct from ("a","bc")
+    buf.extend_from_slice(second.as_bytes());
+    xxh3_64(&buf)
+}
+
 /// Compute the initial polynomial hash of a window of token hashes.
 /// hash = h[0]*BASE^(n-1) + h[1]*BASE^(n-2) + ... + h[n-1]*BASE^0
 /// Uses wrapping arithmetic throughout.
@@ -77,6 +89,20 @@ mod tests {
         let h1 = token_hash(1, "x");
         let h2 = token_hash(2, "x");
         assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn snippet_pair_hash_is_order_insensitive() {
+        let h1 = snippet_pair_hash("fn a() {}", "fn b() {}");
+        let h2 = snippet_pair_hash("fn b() {}", "fn a() {}");
+        assert_eq!(h1, h2, "swapping fragments must not change the hash");
+    }
+
+    #[test]
+    fn snippet_pair_hash_separator_prevents_boundary_collisions() {
+        let h1 = snippet_pair_hash("ab", "c");
+        let h2 = snippet_pair_hash("a", "bc");
+        assert_ne!(h1, h2, "concatenation boundary must be unambiguous");
     }
 
     #[test]

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -32,9 +32,16 @@ fn make_region(frag: &cpd_core::models::Fragment) -> Value {
     })
 }
 
-fn make_clone_code_hash(clone: &CpdClone, file_cache: &mut HashMap<String, String>) -> String {
+fn make_clone_code_hash(
+    clone: &CpdClone,
+    file_cache: &mut HashMap<String, String>,
+) -> Option<String> {
     let snippet = fragment_text(file_cache, &clone.fragment_a);
-    format!("{:016x}", token_hash(0, &snippet))
+    if snippet.is_empty() {
+        None
+    } else {
+        Some(format!("{:016x}", token_hash(0, &snippet)))
+    }
 }
 
 impl Reporter for SarifReporter {
@@ -69,8 +76,10 @@ impl Reporter for SarifReporter {
 
             let mut props = json!({
                 "token_count": clone.token_count,
-                "clone_hash": make_clone_code_hash(clone, &mut file_cache),
             });
+            if let Some(hash) = make_clone_code_hash(clone, &mut file_cache) {
+                props["clone_hash"] = json!(hash);
+            }
             if self.blame {
                 if let Some(blame) = &clone.fragment_a.blame {
                     props["blame"] = json!({
@@ -185,6 +194,34 @@ mod tests {
         }
     }
 
+    fn create_test_sources(clone: &CpdClone, num_lines: u32) -> Vec<std::path::PathBuf> {
+        let lines = (1..=num_lines)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let mut paths = Vec::new();
+
+        for fragment in [&clone.fragment_a, &clone.fragment_b] {
+            let path = std::path::PathBuf::from(&fragment.source_id);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).ok();
+            }
+            fs::write(&path, &lines).ok();
+            paths.push(path);
+        }
+
+        paths
+    }
+
+    fn cleanup_test_sources(paths: &[std::path::PathBuf]) {
+        for path in paths {
+            fs::remove_file(path).ok();
+        }
+        // Clean up the src directory if it's empty
+        fs::remove_dir("src").ok();
+    }
+
     fn run_sarif_report(clones: &[CpdClone], blame: bool) -> String {
         let dir = tmp_dir("sarif");
         let mut opts = ReporterOptions::new(dir.clone());
@@ -221,16 +258,54 @@ mod tests {
 
     #[test]
     fn sarif_result_includes_clone_hash_property() {
-        let content = run_sarif_report(&[make_clone()], false);
-        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-        let hash = parsed["runs"][0]["results"][0]["properties"]["clone_hash"]
-            .as_str()
-            .unwrap();
+        let clone = make_clone();
+        let test_files = create_test_sources(&clone, 25);
 
+        let content = run_sarif_report(&[clone], false);
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let properties = &parsed["runs"][0]["results"][0]["properties"];
+        assert!(
+            properties["clone_hash"].is_string(),
+            "clone_hash must be present and be a string"
+        );
+        let hash = properties["clone_hash"].as_str().unwrap();
         assert_eq!(hash.len(), 16, "clone_hash must be 16-char hex string");
         assert!(
             hash.chars().all(|c| c.is_ascii_hexdigit()),
             "clone_hash must be hex"
+        );
+
+        cleanup_test_sources(&test_files);
+    }
+
+    #[test]
+    fn sarif_result_excludes_clone_hash_when_snippet_empty() {
+        let mut clone = make_clone();
+        clone.fragment_a.source_id = "nonexistent.rs".to_string();
+
+        let content = run_sarif_report(&[clone], false);
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let properties = &parsed["runs"][0]["results"][0]["properties"];
+        assert!(
+            properties["clone_hash"].is_null(),
+            "clone_hash must not be present when snippet is empty"
+        );
+    }
+
+    #[test]
+    fn sarif_result_includes_token_count_property() {
+        let clone = make_clone();
+        let content = run_sarif_report(&[clone], false);
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let properties = &parsed["runs"][0]["results"][0]["properties"];
+
+        assert!(
+            properties["token_count"].is_number(),
+            "token_count must be present and be a number"
+        );
+        assert_eq!(
+            properties["token_count"], 80,
+            "token_count must match clone token count"
         );
     }
 

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -3,10 +3,11 @@
 
 use crate::context::ReportContext;
 use crate::reporter::{Reporter, ReporterError, ReporterOptions};
-use crate::shared::{Style, print_saved_report};
+use crate::shared::{Style, fragment_text, print_saved_report};
+use cpd_core::hash::token_hash;
 use cpd_core::models::CpdClone;
 use serde_json::{Value, json};
-use std::{fs, path::Path};
+use std::{collections::HashMap, fs, path::Path};
 
 pub struct SarifReporter {
     blame: bool,
@@ -31,6 +32,11 @@ fn make_region(frag: &cpd_core::models::Fragment) -> Value {
     })
 }
 
+fn make_clone_code_hash(clone: &CpdClone, file_cache: &mut HashMap<String, String>) -> String {
+    let snippet = fragment_text(file_cache, &clone.fragment_a);
+    format!("{:016x}", token_hash(0, &snippet))
+}
+
 impl Reporter for SarifReporter {
     fn name(&self) -> &str {
         "sarif"
@@ -46,6 +52,7 @@ impl Reporter for SarifReporter {
         let path = output_dir.join("jscpd-report.sarif");
 
         let mut seen_uris: Vec<String> = Vec::new();
+        let mut file_cache: HashMap<String, String> = HashMap::new();
 
         let results: Vec<Value> = clones.iter().map(|clone| {
             let uri_a = clone.fragment_a.source_id.clone();
@@ -60,7 +67,10 @@ impl Reporter for SarifReporter {
                 None => { seen_uris.push(uri_b.clone()); seen_uris.len() - 1 }
             };
 
-            let mut props = json!({});
+            let mut props = json!({
+                "token_count": clone.token_count,
+                "clone_hash": make_clone_code_hash(clone, &mut file_cache),
+            });
             if self.blame {
                 if let Some(blame) = &clone.fragment_a.blame {
                     props["blame"] = json!({
@@ -206,6 +216,21 @@ mod tests {
         assert!(
             content.contains("deadbeef"),
             "SARIF must include blame SHA when blame=true"
+        );
+    }
+
+    #[test]
+    fn sarif_result_includes_clone_hash_property() {
+        let content = run_sarif_report(&[make_clone()], false);
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let hash = parsed["runs"][0]["results"][0]["properties"]["clone_hash"]
+            .as_str()
+            .unwrap();
+
+        assert_eq!(hash.len(), 16, "clone_hash must be 16-char hex string");
+        assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "clone_hash must be hex"
         );
     }
 

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -4,7 +4,7 @@
 use crate::context::ReportContext;
 use crate::reporter::{Reporter, ReporterError, ReporterOptions};
 use crate::shared::{Style, fragment_text, print_saved_report};
-use cpd_core::hash::token_hash;
+use cpd_core::hash::snippet_pair_hash;
 use cpd_core::models::CpdClone;
 use serde_json::{Value, json};
 use std::{collections::HashMap, fs, path::Path};
@@ -36,11 +36,15 @@ fn make_clone_code_hash(
     clone: &CpdClone,
     file_cache: &mut HashMap<String, String>,
 ) -> Option<String> {
-    let snippet = fragment_text(file_cache, &clone.fragment_a);
-    if snippet.is_empty() {
+    let snippet_a = fragment_text(file_cache, &clone.fragment_a);
+    let snippet_b = fragment_text(file_cache, &clone.fragment_b);
+    if snippet_a.is_empty() && snippet_b.is_empty() {
         None
     } else {
-        Some(format!("{:016x}", token_hash(0, &snippet)))
+        Some(format!(
+            "{:016x}",
+            snippet_pair_hash(&snippet_a, &snippet_b)
+        ))
     }
 }
 
@@ -74,10 +78,11 @@ impl Reporter for SarifReporter {
                 None => { seen_uris.push(uri_b.clone()); seen_uris.len() - 1 }
             };
 
+            let clone_hash = make_clone_code_hash(clone, &mut file_cache);
             let mut props = json!({
                 "token_count": clone.token_count,
             });
-            if let Some(hash) = make_clone_code_hash(clone, &mut file_cache) {
+            if let Some(hash) = &clone_hash {
                 props["clone_hash"] = json!(hash);
             }
             if self.blame {
@@ -90,7 +95,7 @@ impl Reporter for SarifReporter {
                 }
             }
 
-            json!({
+            let mut result = json!({
                 "ruleId": "jscpd/duplicate-code",
                 "level": "warning",
                 "message": { "text": format!("Duplicated code block ({} tokens)", clone.token_count) },
@@ -108,7 +113,13 @@ impl Reporter for SarifReporter {
                     }
                 }],
                 "properties": props,
-            })
+            });
+            // GitHub code scanning and other SARIF consumers use partialFingerprints
+            // for result identity across runs; the properties bag alone is opaque to them.
+            if let Some(hash) = clone_hash {
+                result["partialFingerprints"] = json!({ "jscpdCloneHash/v1": hash });
+            }
+            result
         }).collect();
 
         let artifacts: Vec<Value> = seen_uris
@@ -194,32 +205,25 @@ mod tests {
         }
     }
 
-    fn create_test_sources(clone: &CpdClone, num_lines: u32) -> Vec<std::path::PathBuf> {
+    /// Write source fixtures into a fresh temp dir and point the clone's
+    /// fragments at them via absolute paths, so tests never touch the
+    /// crate's real `src/` tree and parallel tests cannot race on files.
+    fn write_test_sources(clone: &mut CpdClone, num_lines: u32) {
+        let dir = tmp_dir("sarif-src");
         let lines = (1..=num_lines)
             .map(|i| format!("line {}", i))
             .collect::<Vec<_>>()
             .join("\n");
 
-        let mut paths = Vec::new();
-
-        for fragment in [&clone.fragment_a, &clone.fragment_b] {
-            let path = std::path::PathBuf::from(&fragment.source_id);
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).ok();
-            }
-            fs::write(&path, &lines).ok();
-            paths.push(path);
+        for fragment in [&mut clone.fragment_a, &mut clone.fragment_b] {
+            let name = std::path::Path::new(&fragment.source_id)
+                .file_name()
+                .unwrap()
+                .to_owned();
+            let path = dir.join(name);
+            fs::write(&path, &lines).unwrap();
+            fragment.source_id = path.to_string_lossy().into_owned();
         }
-
-        paths
-    }
-
-    fn cleanup_test_sources(paths: &[std::path::PathBuf]) {
-        for path in paths {
-            fs::remove_file(path).ok();
-        }
-        // Clean up the src directory if it's empty
-        fs::remove_dir("src").ok();
     }
 
     fn run_sarif_report(clones: &[CpdClone], blame: bool) -> String {
@@ -258,12 +262,13 @@ mod tests {
 
     #[test]
     fn sarif_result_includes_clone_hash_property() {
-        let clone = make_clone();
-        let test_files = create_test_sources(&clone, 25);
+        let mut clone = make_clone();
+        write_test_sources(&mut clone, 25);
 
         let content = run_sarif_report(&[clone], false);
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-        let properties = &parsed["runs"][0]["results"][0]["properties"];
+        let result = &parsed["runs"][0]["results"][0];
+        let properties = &result["properties"];
         assert!(
             properties["clone_hash"].is_string(),
             "clone_hash must be present and be a string"
@@ -274,14 +279,39 @@ mod tests {
             hash.chars().all(|c| c.is_ascii_hexdigit()),
             "clone_hash must be hex"
         );
-
-        cleanup_test_sources(&test_files);
+        assert_eq!(
+            result["partialFingerprints"]["jscpdCloneHash/v1"], *hash,
+            "partialFingerprints must carry the same hash"
+        );
     }
 
     #[test]
-    fn sarif_result_excludes_clone_hash_when_snippet_empty() {
+    fn sarif_clone_hash_is_stable_across_fragment_order() {
         let mut clone = make_clone();
-        clone.fragment_a.source_id = "nonexistent.rs".to_string();
+        write_test_sources(&mut clone, 25);
+        let mut swapped = clone.clone();
+        std::mem::swap(&mut swapped.fragment_a, &mut swapped.fragment_b);
+
+        let extract_hash = |content: &str| -> String {
+            let parsed: serde_json::Value = serde_json::from_str(content).unwrap();
+            parsed["runs"][0]["results"][0]["properties"]["clone_hash"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        };
+        let hash_ab = extract_hash(&run_sarif_report(&[clone], false));
+        let hash_ba = extract_hash(&run_sarif_report(&[swapped], false));
+        assert_eq!(
+            hash_ab, hash_ba,
+            "clone_hash must not depend on which copy is fragment A"
+        );
+    }
+
+    #[test]
+    fn sarif_result_excludes_clone_hash_when_snippets_empty() {
+        let mut clone = make_clone();
+        clone.fragment_a.source_id = "nonexistent-a.rs".to_string();
+        clone.fragment_b.source_id = "nonexistent-b.rs".to_string();
 
         let content = run_sarif_report(&[clone], false);
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -504,14 +504,14 @@ pub mod fixtures {
     }
 
     pub fn tmp_dir(prefix: &str) -> PathBuf {
+        // A process-wide counter guarantees uniqueness across parallel test
+        // threads; timestamps alone can collide and make tests share a dir.
+        static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(
             "cpd-{}-{}-{}",
             prefix,
             std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
+            NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         std::fs::create_dir_all(&dir).ok();
         dir


### PR DESCRIPTION
Useful result data for consumers not otherwise expressed in the SARIF result model.

Fixes #909

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

No extended properties for useful clone data without requiring additional "manual" checking by user.

* **What is the new behavior (if this is a feature change)?**

Adds `clone_hash` and `token_count` to a SARIF report's property bag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/910)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SARIF reports now include token counts for detected clones.
  * Reports include a deterministic 16-character hexadecimal clone hash when clone content is available; empty snippets omit the hash.
  * Clone hashes remain consistent regardless of snippet order.

* **Performance**
  * Improved report generation efficiency when processing source files.

* **Tests**
  * Added coverage for token counts, hash formatting, order stability, and empty clone snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->