### PR TITLE
fix(rust): store source_root on Fragment for scan-root-relative paths

### DIFF
--- a/rust/crates/cpd-core/src/detect.rs
+++ b/rust/crates/cpd-core/src/detect.rs
@@ -492,6 +492,7 @@ fn make_fragment(
     let (_, last_end) = spans.get(end_idx)?;
     Some(Fragment {
         source_id: source_id.to_string(),
+        source_root: None,
         start: first_start.clone(),
         end: last_end.clone(),
         range: [start_idx as u32, end_idx as u32],

--- a/rust/crates/cpd-core/src/lib.rs
+++ b/rust/crates/cpd-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod detect;
 pub mod hash;
 pub mod models;
+pub mod paths;

--- a/rust/crates/cpd-core/src/models.rs
+++ b/rust/crates/cpd-core/src/models.rs
@@ -59,6 +59,8 @@ pub struct BlameEntry {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Fragment {
     pub source_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_root: Option<String>,
     pub start: Location,
     pub end: Location,
     pub range: [u32; 2],
@@ -191,6 +193,7 @@ mod tests {
         };
         let frag = Fragment {
             source_id: "a.js".to_string(),
+            source_root: None,
             start: loc.clone(),
             end: loc.clone(),
             range: [0, 10],
@@ -216,6 +219,7 @@ mod tests {
         };
         let frag = Fragment {
             source_id: "b.js".to_string(),
+            source_root: None,
             start: loc.clone(),
             end: loc.clone(),
             range: [0, 5],

--- a/rust/crates/cpd-core/src/paths.rs
+++ b/rust/crates/cpd-core/src/paths.rs
@@ -1,0 +1,113 @@
+// paths.rs — shared source-id path helpers.
+//
+// Source ids may carry a `:format` suffix (multi-format files, e.g.
+// `README.md:javascript`) and, since scan-root relativization, fragments may
+// store their scan root separately in `Fragment.source_root`. These helpers
+// are the single source of truth for turning a fragment back into a real
+// filesystem path; cpd-finder (blame) and cpd-reporter both rely on them.
+
+use crate::models::Fragment;
+
+/// Strip a `:format` suffix from a source id so it can be used as a real path.
+///
+/// Format-qualified IDs look like `README.md:javascript`. A bare colon inside
+/// a Windows drive letter (`C:\…`) or after a path separator is NOT a format
+/// suffix — only a colon preceded by a non-separator, non-colon char with a
+/// valid format name after it qualifies.
+pub fn clean_source_id(source_id: &str) -> &str {
+    match source_id.rfind(':') {
+        Some(pos) if pos > 0 => {
+            let before = source_id.as_bytes()[pos - 1];
+            // A colon right after a single drive letter (e.g. `C:`) or after
+            // a path separator (`/`, `\`) is structural, not a format suffix.
+            if pos == 1 && before.is_ascii_alphabetic() {
+                return source_id;
+            }
+            if before == b'/' || before == b'\\' {
+                return source_id;
+            }
+            &source_id[..pos]
+        }
+        _ => source_id,
+    }
+}
+
+/// Resolve a fragment's filesystem path by joining `source_root` (if set) with
+/// the cleaned `source_id`. Falls back to the bare `source_id` when no root is
+/// stored (absolute paths, `--absolute` mode, or legacy data).
+pub fn resolve_fragment_path(fragment: &Fragment) -> String {
+    let clean = clean_source_id(&fragment.source_id);
+    match &fragment.source_root {
+        Some(root) => {
+            let joined = std::path::Path::new(root).join(clean);
+            joined.to_string_lossy().into_owned()
+        }
+        None => clean.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Location;
+
+    fn frag(source_id: &str, source_root: Option<&str>) -> Fragment {
+        let loc = Location {
+            line: 1,
+            column: 0,
+            offset: 0,
+        };
+        Fragment {
+            source_id: source_id.to_string(),
+            source_root: source_root.map(str::to_string),
+            start: loc.clone(),
+            end: loc,
+            range: [0, 0],
+            blame: None,
+        }
+    }
+
+    #[test]
+    fn clean_source_id_strips_format_suffix() {
+        assert_eq!(clean_source_id("README.md:javascript"), "README.md");
+    }
+
+    #[test]
+    fn clean_source_id_preserves_bare_path() {
+        assert_eq!(clean_source_id("src/a.js"), "src/a.js");
+    }
+
+    #[test]
+    fn clean_source_id_preserves_windows_drive() {
+        assert_eq!(clean_source_id(r"C:\scan\a.rs"), r"C:\scan\a.rs");
+    }
+
+    #[test]
+    fn clean_source_id_strips_format_from_windows_path() {
+        assert_eq!(clean_source_id(r"C:\scan\a.md:javascript"), r"C:\scan\a.md");
+    }
+
+    #[test]
+    fn resolve_fragment_path_joins_root() {
+        assert_eq!(
+            resolve_fragment_path(&frag("src/a.js", Some("/project"))),
+            "/project/src/a.js"
+        );
+    }
+
+    #[test]
+    fn resolve_fragment_path_falls_back_to_source_id() {
+        assert_eq!(
+            resolve_fragment_path(&frag("/absolute/path/a.js", None)),
+            "/absolute/path/a.js"
+        );
+    }
+
+    #[test]
+    fn resolve_fragment_path_cleans_format_suffix() {
+        assert_eq!(
+            resolve_fragment_path(&frag("doc.md:javascript", Some("/repo"))),
+            "/repo/doc.md"
+        );
+    }
+}

--- a/rust/crates/cpd-finder/src/blame.rs
+++ b/rust/crates/cpd-finder/src/blame.rs
@@ -1,5 +1,5 @@
 use cpd_core::models::{BlameEntry, CpdClone};
-use cpd_core::paths::{clean_source_id, resolve_fragment_path};
+use cpd_core::paths::resolve_fragment_path;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -78,26 +78,23 @@ pub fn enrich(clones: &mut [CpdClone], repo_root: &Path) -> BlameMap {
 
     for clone in clones.iter() {
         for frag in [&clone.fragment_a, &clone.fragment_b] {
-            // Key the map by the cleaned source_id (what reporters look up),
-            // but read the file via source_root + source_id — a scan-root-
-            // relative id alone is not resolvable when scan root != CWD.
-            let clean = clean_source_id(&frag.source_id).to_string();
-            if files_to_blame.contains_key(&clean) {
+            // Key the map by the resolved path (source_root + cleaned
+            // source_id): with multiple scan roots the same relative
+            // source_id can name different files, so the cleaned id alone
+            // is not a unique key. Reporters look up by the same resolution.
+            let resolved = resolve_fragment_path(frag);
+            if files_to_blame.contains_key(&resolved) {
                 continue;
             }
-            let resolved = resolve_fragment_path(frag);
-            if let Some(blame_data) = blame_file(&resolved, repo_root) {
-                files_to_blame.insert(clean.clone(), blame_data);
-            } else {
-                files_to_blame.insert(clean.clone(), HashMap::new());
-            }
+            let blame_data = blame_file(&resolved, repo_root).unwrap_or_default();
+            files_to_blame.insert(resolved, blame_data);
         }
     }
 
     for clone in clones.iter_mut() {
         for frag in [&mut clone.fragment_a, &mut clone.fragment_b] {
-            let clean = clean_source_id(&frag.source_id).to_string();
-            if let Some(blame_data) = files_to_blame.get(&clean) {
+            let resolved = resolve_fragment_path(frag);
+            if let Some(blame_data) = files_to_blame.get(&resolved) {
                 let line = frag.start.line;
                 if let Some((sha, author, timestamp)) = blame_data.get(&line) {
                     frag.blame = Some(BlameEntry {
@@ -117,6 +114,7 @@ pub fn enrich(clones: &mut [CpdClone], repo_root: &Path) -> BlameMap {
 mod tests {
     use super::*;
     use cpd_core::models::{CpdClone, Fragment, Location};
+    use cpd_core::paths::clean_source_id;
 
     fn make_clone(source_id: &str, start_line: u32) -> CpdClone {
         let loc = Location {
@@ -147,6 +145,22 @@ mod tests {
             enrich(&mut clones, Path::new("/tmp"));
         }));
         assert!(result.is_ok(), "enrich on non-git dir must not panic");
+    }
+
+    #[test]
+    fn multi_root_same_source_id_gets_distinct_keys() {
+        // Two scan roots both containing src/a.js: the map must not collapse
+        // them onto one key, or the second root inherits the first's blame.
+        let mut clone = make_clone("src/a.js", 1);
+        clone.fragment_a.source_root = Some("/nonexistent/alpha".to_string());
+        clone.fragment_b.source_root = Some("/nonexistent/beta".to_string());
+        let mut clones = vec![clone];
+        let map = enrich(&mut clones, Path::new("/tmp"));
+        assert_eq!(
+            map.len(),
+            2,
+            "same source_id under two roots must produce two blame entries"
+        );
     }
 
     #[test]

--- a/rust/crates/cpd-finder/src/blame.rs
+++ b/rust/crates/cpd-finder/src/blame.rs
@@ -129,6 +129,7 @@ mod tests {
         };
         let frag = Fragment {
             source_id: source_id.to_string(),
+            source_root: None,
             start: loc.clone(),
             end: loc,
             range: [0, 10],

--- a/rust/crates/cpd-finder/src/blame.rs
+++ b/rust/crates/cpd-finder/src/blame.rs
@@ -1,19 +1,12 @@
 use cpd_core::models::{BlameEntry, CpdClone};
+use cpd_core::paths::{clean_source_id, resolve_fragment_path};
 use std::collections::HashMap;
 use std::path::Path;
 
 pub type BlameMap = HashMap<String, HashMap<u32, (String, String, i64)>>;
 
-fn clean_source_id(source_id: &str) -> &str {
-    match source_id.rfind(':') {
-        Some(pos) => &source_id[..pos],
-        None => source_id,
-    }
-}
-
 fn blame_file(file_path: &str, repo_root: &Path) -> Option<HashMap<u32, (String, String, i64)>> {
-    let clean_path = clean_source_id(file_path);
-    let absolute = std::path::Path::new(clean_path).canonicalize().ok()?;
+    let absolute = std::path::Path::new(file_path).canonicalize().ok()?;
     let relative = absolute.strip_prefix(repo_root.canonicalize().ok()?).ok()?;
 
     let output = std::process::Command::new("git")
@@ -85,11 +78,15 @@ pub fn enrich(clones: &mut [CpdClone], repo_root: &Path) -> BlameMap {
 
     for clone in clones.iter() {
         for frag in [&clone.fragment_a, &clone.fragment_b] {
+            // Key the map by the cleaned source_id (what reporters look up),
+            // but read the file via source_root + source_id — a scan-root-
+            // relative id alone is not resolvable when scan root != CWD.
             let clean = clean_source_id(&frag.source_id).to_string();
             if files_to_blame.contains_key(&clean) {
                 continue;
             }
-            if let Some(blame_data) = blame_file(&clean, repo_root) {
+            let resolved = resolve_fragment_path(frag);
+            if let Some(blame_data) = blame_file(&resolved, repo_root) {
                 files_to_blame.insert(clean.clone(), blame_data);
             } else {
                 files_to_blame.insert(clean.clone(), HashMap::new());

--- a/rust/crates/cpd-finder/src/statistics.rs
+++ b/rust/crates/cpd-finder/src/statistics.rs
@@ -133,6 +133,7 @@ mod tests {
             format: format.to_string(),
             fragment_a: Fragment {
                 source_id: "a.js".to_string(),
+                source_root: None,
                 start: loc(start_line),
                 end: loc(end_line),
                 range: [0, tc],
@@ -140,6 +141,7 @@ mod tests {
             },
             fragment_b: Fragment {
                 source_id: "b.js".to_string(),
+                source_root: None,
                 start: loc(start_line),
                 end: loc(end_line),
                 range: [0, tc],

--- a/rust/crates/cpd-reporter/src/console_full.rs
+++ b/rust/crates/cpd-reporter/src/console_full.rs
@@ -5,7 +5,7 @@ use crate::context::ReportContext;
 use crate::reporter::{Reporter, ReporterError, ReporterOptions};
 use crate::shared::{
     BoxChars, Style, clean_source_id, print_clone_header, print_clone_locations, print_snippet,
-    report_console_style,
+    report_console_style, resolve_fragment_path,
 };
 use cpd_core::models::{CpdClone, Fragment};
 use cpd_finder::blame::BlameMap;
@@ -27,14 +27,14 @@ impl ConsoleFullReporter {
     }
 
     fn print_blame_snippet(&self, fa: &Fragment, fb: &Fragment) {
-        let clean_a = clean_source_id(&fa.source_id);
-        let clean_b = clean_source_id(&fb.source_id);
+        let resolved_a = resolve_fragment_path(fa);
+        let resolved_b = resolve_fragment_path(fb);
 
-        let content_a = match std::fs::read_to_string(clean_a) {
+        let content_a = match std::fs::read_to_string(&resolved_a) {
             Ok(c) => c,
             Err(_) => return,
         };
-        let content_b = match std::fs::read_to_string(clean_b) {
+        let content_b = match std::fs::read_to_string(&resolved_b) {
             Ok(c) => c,
             Err(_) => return,
         };
@@ -71,15 +71,17 @@ impl ConsoleFullReporter {
             let line_num_a = fa.start.line as usize + i;
             let line_num_b = fb.start.line as usize + i;
 
+            let blame_key_a = clean_source_id(&fa.source_id);
+            let blame_key_b = clean_source_id(&fb.source_id);
             let author_a = self
                 .blame_data
-                .get(clean_a)
+                .get(blame_key_a)
                 .and_then(|m| m.get(&(line_num_a as u32)))
                 .map(|(_, author, _)| author.as_str())
                 .unwrap_or("");
             let author_b = self
                 .blame_data
-                .get(clean_b)
+                .get(blame_key_b)
                 .and_then(|m| m.get(&(line_num_b as u32)))
                 .map(|(_, author, _)| author.as_str())
                 .unwrap_or("");
@@ -176,6 +178,7 @@ mod tests {
         };
         let frag = Fragment {
             source_id: "a.js".to_string(),
+            source_root: None,
             start: loc.clone(),
             end: loc,
             range: [0, 10],
@@ -197,6 +200,7 @@ mod tests {
         };
         let frag = Fragment {
             source_id: "b.js".to_string(),
+            source_root: None,
             start: loc.clone(),
             end: loc,
             range: [0, 10],

--- a/rust/crates/cpd-reporter/src/console_full.rs
+++ b/rust/crates/cpd-reporter/src/console_full.rs
@@ -4,7 +4,7 @@
 use crate::context::ReportContext;
 use crate::reporter::{Reporter, ReporterError, ReporterOptions};
 use crate::shared::{
-    BoxChars, Style, clean_source_id, print_clone_header, print_clone_locations, print_snippet,
+    BoxChars, Style, print_clone_header, print_clone_locations, print_snippet,
     report_console_style, resolve_fragment_path,
 };
 use cpd_core::models::{CpdClone, Fragment};
@@ -67,12 +67,15 @@ impl ConsoleFullReporter {
         let line_b_width = 4;
         let sep = self.style.dim("%02");
 
+        // BlameMap is keyed by the resolved path (source_root + cleaned
+        // source_id) — the cleaned id alone is ambiguous across scan roots.
+        let blame_key_a = &resolved_a;
+        let blame_key_b = &resolved_b;
+
         for i in 0..count {
             let line_num_a = fa.start.line as usize + i;
             let line_num_b = fb.start.line as usize + i;
 
-            let blame_key_a = clean_source_id(&fa.source_id);
-            let blame_key_b = clean_source_id(&fb.source_id);
             let author_a = self
                 .blame_data
                 .get(blame_key_a)

--- a/rust/crates/cpd-reporter/src/html.rs
+++ b/rust/crates/cpd-reporter/src/html.rs
@@ -202,6 +202,7 @@ mod tests {
             format: "javascript".to_string(),
             fragment_a: Fragment {
                 source_id: file_a_str,
+                source_root: None,
                 start: loc.clone(),
                 end,
                 range: [0, 10],
@@ -209,6 +210,7 @@ mod tests {
             },
             fragment_b: Fragment {
                 source_id: "b.js".to_string(),
+                source_root: None,
                 start: loc,
                 end: Location {
                     line: 2,

--- a/rust/crates/cpd-reporter/src/json_reporter.rs
+++ b/rust/crates/cpd-reporter/src/json_reporter.rs
@@ -40,7 +40,7 @@ fn clone_to_dup(
         .saturating_sub(clone.fragment_a.start.line)
         + 1;
 
-    let frag_a = read_file_cached(file_cache, &clone.fragment_a.source_id);
+    let frag_a = read_file_cached(file_cache, &clone.fragment_a);
     let fragment = extract_lines(
         frag_a,
         clone.fragment_a.start.line,

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -136,7 +136,11 @@ impl Reporter for SarifReporter {
             let uri = if root.starts_with('/') {
                 format!("file://{}/", root)
             } else {
-                format!("file:///{}/", root.replace('\\', "/"))
+                let mut s = root.clone();
+                if !s.ends_with('\\') && !s.ends_with('/') {
+                    s.push('\\');
+                }
+                s
             };
             original_uri_base_ids[base_id] = json!({ "uri": uri });
         }

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -3,7 +3,7 @@
 
 use crate::context::ReportContext;
 use crate::reporter::{Reporter, ReporterError, ReporterOptions};
-use crate::shared::{Style, print_saved_report};
+use crate::shared::{Style, clean_source_id, print_saved_report};
 use cpd_core::models::CpdClone;
 use serde_json::{Value, json};
 use std::{fs, path::Path};
@@ -45,19 +45,22 @@ impl Reporter for SarifReporter {
         fs::create_dir_all(output_dir)?;
         let path = output_dir.join("jscpd-report.sarif");
 
-        let mut seen_uris: Vec<String> = Vec::new();
+        // Artifact identity: (source_root, cleaned source_id) so that the same
+        // relative path under two scan roots gets distinct artifact entries.
+        let mut seen_artifacts: Vec<(Option<String>, String)> = Vec::new();
         let mut root_to_base_id: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
 
         let make_artifact_loc = |frag: &cpd_core::models::Fragment,
-                                 seen: &mut Vec<String>,
+                                 seen: &mut Vec<(Option<String>, String)>,
                                  roots: &mut std::collections::HashMap<String, String>|
          -> Value {
-            let uri = frag.source_id.clone();
-            let idx = match seen.iter().position(|u| u == &uri) {
+            let uri = clean_source_id(&frag.source_id).to_string();
+            let key = (frag.source_root.clone(), uri.clone());
+            let idx = match seen.iter().position(|k| *k == key) {
                 Some(i) => i,
                 None => {
-                    seen.push(uri.clone());
+                    seen.push(key);
                     seen.len() - 1
                 }
             };
@@ -80,8 +83,8 @@ impl Reporter for SarifReporter {
         };
 
         let results: Vec<Value> = clones.iter().map(|clone| {
-            let loc_a = make_artifact_loc(&clone.fragment_a, &mut seen_uris, &mut root_to_base_id);
-            let loc_b = make_artifact_loc(&clone.fragment_b, &mut seen_uris, &mut root_to_base_id);
+            let loc_a = make_artifact_loc(&clone.fragment_a, &mut seen_artifacts, &mut root_to_base_id);
+            let loc_b = make_artifact_loc(&clone.fragment_b, &mut seen_artifacts, &mut root_to_base_id);
 
             let mut props = json!({});
             if self.blame {
@@ -115,12 +118,16 @@ impl Reporter for SarifReporter {
             })
         }).collect();
 
-        let artifacts: Vec<Value> = seen_uris
+        let artifacts: Vec<Value> = seen_artifacts
             .iter()
-            .map(|uri| {
-                json!({
-                    "location": { "uri": uri },
-                })
+            .map(|(root, uri)| {
+                let mut loc = json!({ "uri": uri });
+                if let Some(root) = root {
+                    if let Some(base_id) = root_to_base_id.get(root) {
+                        loc["uriBaseId"] = json!(base_id);
+                    }
+                }
+                json!({ "location": loc })
             })
             .collect();
 

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -71,9 +71,9 @@ impl Reporter for SarifReporter {
                     .entry(root.clone())
                     .or_insert_with(|| {
                         if next_id == 0 {
-                            "SRCROOT".to_string()
+                            "%SRCROOT%".to_string()
                         } else {
-                            format!("SRCROOT{}", next_id)
+                            format!("%SRCROOT{}%", next_id)
                         }
                     })
                     .clone();

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -46,19 +46,28 @@ impl Reporter for SarifReporter {
         let path = output_dir.join("jscpd-report.sarif");
 
         let mut seen_uris: Vec<String> = Vec::new();
+        let mut root_to_base_id: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+
+        let make_artifact_loc = |frag: &cpd_core::models::Fragment, seen: &mut Vec<String>, roots: &mut std::collections::HashMap<String, String>| -> Value {
+            let uri = frag.source_id.clone();
+            let idx = match seen.iter().position(|u| u == &uri) {
+                Some(i) => i,
+                None => { seen.push(uri.clone()); seen.len() - 1 }
+            };
+            let mut loc = json!({ "uri": uri, "index": idx });
+            if let Some(ref root) = frag.source_root {
+                let next_id = roots.len();
+                let base_id = roots.entry(root.clone()).or_insert_with(|| {
+                    if next_id == 0 { "SRCROOT".to_string() } else { format!("SRCROOT{}", next_id) }
+                }).clone();
+                loc["uriBaseId"] = json!(base_id);
+            }
+            loc
+        };
 
         let results: Vec<Value> = clones.iter().map(|clone| {
-            let uri_a = clone.fragment_a.source_id.clone();
-            let uri_b = clone.fragment_b.source_id.clone();
-
-            let idx_a = match seen_uris.iter().position(|u| u == &uri_a) {
-                Some(i) => i,
-                None => { seen_uris.push(uri_a.clone()); seen_uris.len() - 1 }
-            };
-            let idx_b = match seen_uris.iter().position(|u| u == &uri_b) {
-                Some(i) => i,
-                None => { seen_uris.push(uri_b.clone()); seen_uris.len() - 1 }
-            };
+            let loc_a = make_artifact_loc(&clone.fragment_a, &mut seen_uris, &mut root_to_base_id);
+            let loc_b = make_artifact_loc(&clone.fragment_b, &mut seen_uris, &mut root_to_base_id);
 
             let mut props = json!({});
             if self.blame {
@@ -77,14 +86,14 @@ impl Reporter for SarifReporter {
                 "message": { "text": format!("Duplicated code block ({} tokens)", clone.token_count) },
                 "locations": [{
                     "physicalLocation": {
-                        "artifactLocation": { "uri": uri_a, "index": idx_a },
+                        "artifactLocation": loc_a,
                         "region": make_region(&clone.fragment_a),
                     }
                 }],
                 "relatedLocations": [{
                     "id": 0,
                     "physicalLocation": {
-                        "artifactLocation": { "uri": uri_b, "index": idx_b },
+                        "artifactLocation": loc_b,
                         "region": make_region(&clone.fragment_b),
                     }
                 }],
@@ -101,25 +110,40 @@ impl Reporter for SarifReporter {
             })
             .collect();
 
+        let mut original_uri_base_ids = json!({});
+        for (root, base_id) in &root_to_base_id {
+            let uri = if root.starts_with('/') {
+                format!("file://{}/", root)
+            } else {
+                format!("file:///{}/", root.replace('\\', "/"))
+            };
+            original_uri_base_ids[base_id] = json!({ "uri": uri });
+        }
+
+        let mut run = json!({
+            "tool": {
+                "driver": {
+                    "name": "jscpd",
+                    "version": "5.0.3",
+                    "informationUri": "https://github.com/kucherenko/jscpd/",
+                    "rules": [{
+                        "id": "jscpd/duplicate-code",
+                        "shortDescription": { "text": "Duplicated code detected" },
+                        "helpUri": "https://github.com/kucherenko/jscpd/",
+                    }]
+                }
+            },
+            "artifacts": artifacts,
+            "results": results,
+        });
+        if !root_to_base_id.is_empty() {
+            run["originalUriBaseIds"] = original_uri_base_ids;
+        }
+
         let sarif = json!({
             "version": "2.1.0",
             "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
-            "runs": [{
-                "tool": {
-                    "driver": {
-                        "name": "jscpd",
-                        "version": "5.0.3",
-                        "informationUri": "https://github.com/kucherenko/jscpd/",
-                        "rules": [{
-                            "id": "jscpd/duplicate-code",
-                            "shortDescription": { "text": "Duplicated code detected" },
-                            "helpUri": "https://github.com/kucherenko/jscpd/",
-                        }]
-                    }
-                },
-                "artifacts": artifacts,
-                "results": results,
-            }]
+            "runs": [run]
         });
 
         let content = serde_json::to_string_pretty(&sarif)
@@ -159,6 +183,7 @@ mod tests {
             format: "rust".to_string(),
             fragment_a: Fragment {
                 source_id: "src/foo.rs".to_string(),
+                source_root: None,
                 start: loc.clone(),
                 end: end.clone(),
                 range: [0, 100],
@@ -166,6 +191,7 @@ mod tests {
             },
             fragment_b: Fragment {
                 source_id: "src/bar.rs".to_string(),
+                source_root: None,
                 start: loc,
                 end,
                 range: [0, 100],

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -46,20 +46,34 @@ impl Reporter for SarifReporter {
         let path = output_dir.join("jscpd-report.sarif");
 
         let mut seen_uris: Vec<String> = Vec::new();
-        let mut root_to_base_id: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let mut root_to_base_id: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
 
-        let make_artifact_loc = |frag: &cpd_core::models::Fragment, seen: &mut Vec<String>, roots: &mut std::collections::HashMap<String, String>| -> Value {
+        let make_artifact_loc = |frag: &cpd_core::models::Fragment,
+                                 seen: &mut Vec<String>,
+                                 roots: &mut std::collections::HashMap<String, String>|
+         -> Value {
             let uri = frag.source_id.clone();
             let idx = match seen.iter().position(|u| u == &uri) {
                 Some(i) => i,
-                None => { seen.push(uri.clone()); seen.len() - 1 }
+                None => {
+                    seen.push(uri.clone());
+                    seen.len() - 1
+                }
             };
             let mut loc = json!({ "uri": uri, "index": idx });
             if let Some(ref root) = frag.source_root {
                 let next_id = roots.len();
-                let base_id = roots.entry(root.clone()).or_insert_with(|| {
-                    if next_id == 0 { "SRCROOT".to_string() } else { format!("SRCROOT{}", next_id) }
-                }).clone();
+                let base_id = roots
+                    .entry(root.clone())
+                    .or_insert_with(|| {
+                        if next_id == 0 {
+                            "SRCROOT".to_string()
+                        } else {
+                            format!("SRCROOT{}", next_id)
+                        }
+                    })
+                    .clone();
                 loc["uriBaseId"] = json!(base_id);
             }
             loc

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -249,6 +249,20 @@ pub fn clean_source_id(source_id: &str) -> &str {
     }
 }
 
+/// Resolve a fragment's filesystem path by joining `source_root` (if set) with
+/// the cleaned `source_id`. Falls back to the bare `source_id` when no root is
+/// stored (absolute paths, `--absolute` mode, or legacy data).
+pub fn resolve_fragment_path(fragment: &Fragment) -> String {
+    let clean = clean_source_id(&fragment.source_id);
+    match &fragment.source_root {
+        Some(root) => {
+            let joined = std::path::Path::new(root).join(clean);
+            joined.to_string_lossy().into_owned()
+        }
+        None => clean.to_string(),
+    }
+}
+
 /// Read the text lines from `content` between `[start_line, end_line]` (1-indexed, inclusive).
 pub fn extract_lines(content: &str, start_line: u32, end_line: u32) -> String {
     content
@@ -259,26 +273,25 @@ pub fn extract_lines(content: &str, start_line: u32, end_line: u32) -> String {
         .join("\n")
 }
 
-/// Load file contents once per source id. Returns the cached entry when available.
-pub fn read_file_cached<'a>(cache: &'a mut HashMap<String, String>, source_id: &str) -> &'a str {
-    let clean = clean_source_id(source_id);
-    let key = clean.to_string();
+/// Load file contents once per resolved path. Returns the cached entry when available.
+pub fn read_file_cached<'a>(cache: &'a mut HashMap<String, String>, fragment: &Fragment) -> &'a str {
+    let resolved = resolve_fragment_path(fragment);
     cache
-        .entry(key)
-        .or_insert_with(|| std::fs::read_to_string(clean).unwrap_or_default())
+        .entry(resolved.clone())
+        .or_insert_with(|| std::fs::read_to_string(&resolved).unwrap_or_default())
         .as_str()
 }
 
 /// Read the source text for a fragment from disk, if available.
 pub fn fragment_text(cache: &mut HashMap<String, String>, fragment: &Fragment) -> String {
-    let content = read_file_cached(cache, &fragment.source_id).to_string();
+    let content = read_file_cached(cache, fragment).to_string();
     extract_lines(&content, fragment.start.line, fragment.end.line)
 }
 
 /// Print a source snippet for a fragment, with optional color dimming.
 pub fn print_snippet(fragment: &Fragment, style: &Style, max_display: usize) {
-    let clean_id = clean_source_id(&fragment.source_id);
-    let content = match std::fs::read_to_string(clean_id) {
+    let resolved = resolve_fragment_path(fragment);
+    let content = match std::fs::read_to_string(&resolved) {
         Ok(c) => c,
         Err(_) => return,
     };
@@ -593,6 +606,7 @@ pub mod fixtures {
     ) -> CpdClone {
         let frag_a = Fragment {
             source_id: source_a.to_string(),
+            source_root: None,
             start: start.clone(),
             end: end.clone(),
             range: [0, 100],
@@ -600,6 +614,7 @@ pub mod fixtures {
         };
         let frag_b = Fragment {
             source_id: source_b.to_string(),
+            source_root: None,
             start,
             end,
             range: [0, 100],

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -274,7 +274,10 @@ pub fn extract_lines(content: &str, start_line: u32, end_line: u32) -> String {
 }
 
 /// Load file contents once per resolved path. Returns the cached entry when available.
-pub fn read_file_cached<'a>(cache: &'a mut HashMap<String, String>, fragment: &Fragment) -> &'a str {
+pub fn read_file_cached<'a>(
+    cache: &'a mut HashMap<String, String>,
+    fragment: &Fragment,
+) -> &'a str {
     let resolved = resolve_fragment_path(fragment);
     cache
         .entry(resolved.clone())

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -241,43 +241,9 @@ fn print_row(cells: &[String; 7], widths: &[usize], header: bool, style: &Style,
     println!();
 }
 
-/// Strip a `:format` suffix from a source id so it can be used as a real path.
-///
-/// Format-qualified IDs look like `README.md:javascript`. A bare colon inside
-/// a Windows drive letter (`C:\…`) or after a path separator is NOT a format
-/// suffix — only a colon preceded by a non-separator, non-colon char with a
-/// valid format name after it qualifies.
-pub fn clean_source_id(source_id: &str) -> &str {
-    match source_id.rfind(':') {
-        Some(pos) if pos > 0 => {
-            let before = source_id.as_bytes()[pos - 1];
-            // A colon right after a single drive letter (e.g. `C:`) or after
-            // a path separator (`/`, `\`) is structural, not a format suffix.
-            if pos == 1 && before.is_ascii_alphabetic() {
-                return source_id;
-            }
-            if before == b'/' || before == b'\\' {
-                return source_id;
-            }
-            &source_id[..pos]
-        }
-        _ => source_id,
-    }
-}
-
-/// Resolve a fragment's filesystem path by joining `source_root` (if set) with
-/// the cleaned `source_id`. Falls back to the bare `source_id` when no root is
-/// stored (absolute paths, `--absolute` mode, or legacy data).
-pub fn resolve_fragment_path(fragment: &Fragment) -> String {
-    let clean = clean_source_id(&fragment.source_id);
-    match &fragment.source_root {
-        Some(root) => {
-            let joined = std::path::Path::new(root).join(clean);
-            joined.to_string_lossy().into_owned()
-        }
-        None => clean.to_string(),
-    }
-}
+// Canonical implementations live in cpd-core so cpd-finder (blame) resolves
+// paths identically; re-exported here to keep the reporter-facing API stable.
+pub use cpd_core::paths::{clean_source_id, resolve_fragment_path};
 
 /// Read the text lines from `content` between `[start_line, end_line]` (1-indexed, inclusive).
 pub fn extract_lines(content: &str, start_line: u32, end_line: u32) -> String {
@@ -486,95 +452,6 @@ pub fn stats_with_pct(pct: f64, lines: u64) -> Statistics {
         },
         formats: HashMap::new(),
         detection_date: "2026-01-01T00:00:00Z".to_string(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use cpd_core::models::Location;
-
-    #[test]
-    fn clean_source_id_strips_format_suffix() {
-        assert_eq!(clean_source_id("README.md:javascript"), "README.md");
-    }
-
-    #[test]
-    fn clean_source_id_preserves_bare_path() {
-        assert_eq!(clean_source_id("src/a.js"), "src/a.js");
-    }
-
-    #[test]
-    fn clean_source_id_preserves_windows_drive() {
-        assert_eq!(clean_source_id(r"C:\scan\a.rs"), r"C:\scan\a.rs");
-    }
-
-    #[test]
-    fn clean_source_id_strips_format_from_windows_path() {
-        assert_eq!(clean_source_id(r"C:\scan\a.md:javascript"), r"C:\scan\a.md");
-    }
-
-    #[test]
-    fn resolve_fragment_path_joins_root() {
-        let frag = Fragment {
-            source_id: "src/a.js".to_string(),
-            source_root: Some("/project".to_string()),
-            start: Location {
-                line: 1,
-                column: 0,
-                offset: 0,
-            },
-            end: Location {
-                line: 1,
-                column: 0,
-                offset: 0,
-            },
-            range: [0, 0],
-            blame: None,
-        };
-        assert_eq!(resolve_fragment_path(&frag), "/project/src/a.js");
-    }
-
-    #[test]
-    fn resolve_fragment_path_falls_back_to_source_id() {
-        let frag = Fragment {
-            source_id: "/absolute/path/a.js".to_string(),
-            source_root: None,
-            start: Location {
-                line: 1,
-                column: 0,
-                offset: 0,
-            },
-            end: Location {
-                line: 1,
-                column: 0,
-                offset: 0,
-            },
-            range: [0, 0],
-            blame: None,
-        };
-        assert_eq!(resolve_fragment_path(&frag), "/absolute/path/a.js");
-    }
-
-    #[test]
-    fn resolve_fragment_path_cleans_format_suffix() {
-        let frag = Fragment {
-            source_id: "doc.md:javascript".to_string(),
-            source_root: Some("/repo".to_string()),
-            start: Location {
-                line: 1,
-                column: 0,
-                offset: 0,
-            },
-            end: Location {
-                line: 1,
-                column: 0,
-                offset: 0,
-            },
-            range: [0, 0],
-            blame: None,
-        };
-        assert_eq!(resolve_fragment_path(&frag), "/repo/doc.md");
     }
 }
 

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -242,10 +242,26 @@ fn print_row(cells: &[String; 7], widths: &[usize], header: bool, style: &Style,
 }
 
 /// Strip a `:format` suffix from a source id so it can be used as a real path.
+///
+/// Format-qualified IDs look like `README.md:javascript`. A bare colon inside
+/// a Windows drive letter (`C:\…`) or after a path separator is NOT a format
+/// suffix — only a colon preceded by a non-separator, non-colon char with a
+/// valid format name after it qualifies.
 pub fn clean_source_id(source_id: &str) -> &str {
     match source_id.rfind(':') {
-        Some(pos) => &source_id[..pos],
-        None => source_id,
+        Some(pos) if pos > 0 => {
+            let before = source_id.as_bytes()[pos - 1];
+            // A colon right after a single drive letter (e.g. `C:`) or after
+            // a path separator (`/`, `\`) is structural, not a format suffix.
+            if pos == 1 && before.is_ascii_alphabetic() {
+                return source_id;
+            }
+            if before == b'/' || before == b'\\' {
+                return source_id;
+            }
+            &source_id[..pos]
+        }
+        _ => source_id,
     }
 }
 
@@ -470,6 +486,95 @@ pub fn stats_with_pct(pct: f64, lines: u64) -> Statistics {
         },
         formats: HashMap::new(),
         detection_date: "2026-01-01T00:00:00Z".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cpd_core::models::Location;
+
+    #[test]
+    fn clean_source_id_strips_format_suffix() {
+        assert_eq!(clean_source_id("README.md:javascript"), "README.md");
+    }
+
+    #[test]
+    fn clean_source_id_preserves_bare_path() {
+        assert_eq!(clean_source_id("src/a.js"), "src/a.js");
+    }
+
+    #[test]
+    fn clean_source_id_preserves_windows_drive() {
+        assert_eq!(clean_source_id(r"C:\scan\a.rs"), r"C:\scan\a.rs");
+    }
+
+    #[test]
+    fn clean_source_id_strips_format_from_windows_path() {
+        assert_eq!(clean_source_id(r"C:\scan\a.md:javascript"), r"C:\scan\a.md");
+    }
+
+    #[test]
+    fn resolve_fragment_path_joins_root() {
+        let frag = Fragment {
+            source_id: "src/a.js".to_string(),
+            source_root: Some("/project".to_string()),
+            start: Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            end: Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            range: [0, 0],
+            blame: None,
+        };
+        assert_eq!(resolve_fragment_path(&frag), "/project/src/a.js");
+    }
+
+    #[test]
+    fn resolve_fragment_path_falls_back_to_source_id() {
+        let frag = Fragment {
+            source_id: "/absolute/path/a.js".to_string(),
+            source_root: None,
+            start: Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            end: Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            range: [0, 0],
+            blame: None,
+        };
+        assert_eq!(resolve_fragment_path(&frag), "/absolute/path/a.js");
+    }
+
+    #[test]
+    fn resolve_fragment_path_cleans_format_suffix() {
+        let frag = Fragment {
+            source_id: "doc.md:javascript".to_string(),
+            source_root: Some("/repo".to_string()),
+            start: Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            end: Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            range: [0, 0],
+            blame: None,
+        };
+        assert_eq!(resolve_fragment_path(&frag), "/repo/doc.md");
     }
 }
 

--- a/rust/crates/cpd-reporter/src/xcode.rs
+++ b/rust/crates/cpd-reporter/src/xcode.rs
@@ -80,6 +80,7 @@ mod tests {
         };
         let frag_a = Fragment {
             source_id: "MyFile.swift".to_string(),
+            source_root: None,
             start: loc.clone(),
             end: end.clone(),
             range: [0, 200],
@@ -87,6 +88,7 @@ mod tests {
         };
         let frag_b = Fragment {
             source_id: "OtherFile.swift".to_string(),
+            source_root: None,
             start: Location {
                 line: 10,
                 column: 0,

--- a/rust/crates/cpd-reporter/src/xml_reporter.rs
+++ b/rust/crates/cpd-reporter/src/xml_reporter.rs
@@ -176,6 +176,7 @@ mod tests {
         };
         let frag_a = Fragment {
             source_id: file_a_str.clone(),
+            source_root: None,
             start: loc_start,
             end: loc_end,
             range: [0, 15],
@@ -196,6 +197,7 @@ mod tests {
         };
         let frag_b = Fragment {
             source_id: file_b_str,
+            source_root: None,
             start: loc_b_start,
             end: loc_b_end,
             range: [0, 15],

--- a/rust/crates/cpd-reporter/tests/blame_integration.rs
+++ b/rust/crates/cpd-reporter/tests/blame_integration.rs
@@ -47,6 +47,7 @@ fn make_clone_with_blame() -> CpdClone {
         format: "javascript".to_string(),
         fragment_a: Fragment {
             source_id: "src/foo.js".to_string(),
+            source_root: None,
             start: loc.clone(),
             end: end_loc.clone(),
             range: [0, 100],
@@ -54,6 +55,7 @@ fn make_clone_with_blame() -> CpdClone {
         },
         fragment_b: Fragment {
             source_id: "src/bar.js".to_string(),
+            source_root: None,
             start: loc,
             end: end_loc,
             range: [0, 100],
@@ -73,6 +75,7 @@ fn make_clone_no_blame() -> CpdClone {
         format: "javascript".to_string(),
         fragment_a: Fragment {
             source_id: "a.js".to_string(),
+            source_root: None,
             start: loc.clone(),
             end: loc.clone(),
             range: [0, 10],
@@ -80,6 +83,7 @@ fn make_clone_no_blame() -> CpdClone {
         },
         fragment_b: Fragment {
             source_id: "b.js".to_string(),
+            source_root: None,
             start: loc.clone(),
             end: loc,
             range: [0, 10],

--- a/rust/crates/cpd-reporter/tests/reporters_integration.rs
+++ b/rust/crates/cpd-reporter/tests/reporters_integration.rs
@@ -68,6 +68,7 @@ fn make_test_clone() -> CpdClone {
         format: "javascript".to_string(),
         fragment_a: Fragment {
             source_id: "src/app.js".to_string(),
+            source_root: None,
             start: start_loc.clone(),
             end: end_loc.clone(),
             range: [100, 200],
@@ -75,6 +76,7 @@ fn make_test_clone() -> CpdClone {
         },
         fragment_b: Fragment {
             source_id: "src/utils.js".to_string(),
+            source_root: None,
             start: start_loc,
             end: end_loc,
             range: [100, 200],
@@ -115,6 +117,7 @@ fn make_test_clone_with_real_files(dir: &PathBuf) -> CpdClone {
         format: "javascript".to_string(),
         fragment_a: Fragment {
             source_id: file_a.to_string_lossy().into_owned(),
+            source_root: None,
             start: Location {
                 line: 1,
                 column: 0,
@@ -130,6 +133,7 @@ fn make_test_clone_with_real_files(dir: &PathBuf) -> CpdClone {
         },
         fragment_b: Fragment {
             source_id: file_b.to_string_lossy().into_owned(),
+            source_root: None,
             start: Location {
                 line: 1,
                 column: 0,

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -455,11 +455,17 @@ fn relativize_to_scan_root(
 }
 
 /// Walk up from path to find the nearest `.git` directory.
+///
+/// Canonicalizes `start` first: walking up a relative path terminates at the
+/// empty path (e.g. parent of `pkg` is `""`), which both mis-reports a repo
+/// rooted at the CWD as `""` and breaks the callers that canonicalize the
+/// returned root.
 fn find_git_root(start: &std::path::Path) -> Option<std::path::PathBuf> {
+    let start = std::fs::canonicalize(start).unwrap_or_else(|_| start.to_path_buf());
     let mut current = if start.is_file() {
         start.parent()?.to_path_buf()
     } else {
-        start.to_path_buf()
+        start
     };
 
     loop {

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -237,25 +237,23 @@ fn main() {
     let mut clones = run_result.clones;
     let statistics = run_result.statistics;
 
-    // Path normalization: relativize source_ids to the CWD so they remain
-    // resolvable from the CWD. File reporters (html, json, console-full)
-    // re-read sources from disk to render snippets — a path that doesn't
-    // resolve produces empty code. Relativizing to the CWD (not the scan
-    // root) keeps paths readable: scanning `frontend/` from the project
-    // root yields `frontend/src/a.js`, which both reads back correctly and
-    // distinguishes multiple scan roots. Paths outside the CWD are left
-    // absolute (still readable). Source IDs arrive canonicalized from the
-    // finder, so we canonicalize the CWD too for reliable prefix stripping
-    // across macOS symlinked roots (`/var` vs `/private/var`).
-    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-    let cwd = std::fs::canonicalize(&cwd).unwrap_or(cwd);
+    // Path normalization: make source_ids scan-root-relative for display and
+    // SARIF output, while storing the scan root on Fragment.source_root so
+    // reporters can reconstruct the absolute path for file reading.
+    //
+    // Source IDs arrive canonicalized from the finder. We canonicalize scan
+    // roots here too for reliable prefix stripping (macOS /var → /private/var).
+    let canonical_roots: Vec<std::path::PathBuf> = paths
+        .iter()
+        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
+        .collect();
     for clone in &mut clones {
         if opts.absolute {
             make_path_absolute(&mut clone.fragment_a.source_id);
             make_path_absolute(&mut clone.fragment_b.source_id);
         } else {
-            relativize_to_cwd(&mut clone.fragment_a.source_id, &cwd);
-            relativize_to_cwd(&mut clone.fragment_b.source_id, &cwd);
+            relativize_to_scan_root(&mut clone.fragment_a, &canonical_roots);
+            relativize_to_scan_root(&mut clone.fragment_b, &canonical_roots);
         }
     }
 
@@ -426,19 +424,24 @@ fn strip_dot_prefix(s: &str) -> String {
     }
 }
 
-/// Relativize a canonicalized `source_id` to the CWD when `--absolute` is off.
+/// Relativize a canonicalized `source_id` to its scan root and store the root
+/// on the fragment so reporters can reconstruct the absolute path for file I/O.
 ///
-/// Stripping the CWD prefix keeps the path resolvable from the CWD, which file
-/// reporters rely on when they re-read source files to render snippets. Paths
-/// outside the CWD are left unchanged (absolute, still readable). Any leading
-/// `./` or `.\` component is stripped.
-fn relativize_to_cwd(source_id: &mut String, cwd: &std::path::Path) {
-    let path = std::path::Path::new(source_id);
-    if let Ok(stripped) = path.strip_prefix(cwd) {
-        *source_id = strip_dot_prefix(&stripped.to_string_lossy());
-        return;
+/// The first matching canonical scan root is used. If no root matches, the
+/// source_id is left unchanged (absolute) and source_root is set to None.
+fn relativize_to_scan_root(
+    fragment: &mut cpd_core::models::Fragment,
+    canonical_roots: &[std::path::PathBuf],
+) {
+    let path = std::path::Path::new(&fragment.source_id);
+    for root in canonical_roots {
+        if let Ok(stripped) = path.strip_prefix(root) {
+            fragment.source_root = Some(root.to_string_lossy().into_owned());
+            fragment.source_id = strip_dot_prefix(&stripped.to_string_lossy());
+            return;
+        }
     }
-    *source_id = strip_dot_prefix(source_id);
+    fragment.source_id = strip_dot_prefix(&fragment.source_id);
 }
 
 /// Walk up from path to find the nearest `.git` directory.
@@ -515,28 +518,52 @@ mod tests {
         assert_eq!(strip_dot_prefix(".\\foo.rs"), "foo.rs");
     }
 
-    #[test]
-    fn relativize_strips_cwd_prefix() {
-        let mut id = "/project/frontend/src/foo.rs".to_string();
-        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
-        assert_eq!(id, "frontend/src/foo.rs");
+    fn make_fragment(source_id: &str) -> cpd_core::models::Fragment {
+        cpd_core::models::Fragment {
+            source_id: source_id.to_string(),
+            source_root: None,
+            start: cpd_core::models::Location { line: 1, column: 0, offset: 0 },
+            end: cpd_core::models::Location { line: 1, column: 0, offset: 0 },
+            range: [0, 0],
+            blame: None,
+        }
     }
 
     #[test]
-    fn relativize_keeps_absolute_when_outside_cwd() {
-        let mut id = "/elsewhere/src/foo.rs".to_string();
-        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
-        assert_eq!(id, "/elsewhere/src/foo.rs");
+    fn relativize_strips_scan_root_prefix_and_sets_root() {
+        let mut frag = make_fragment("/project/frontend/src/foo.rs");
+        let roots = vec![std::path::PathBuf::from("/project/frontend")];
+        relativize_to_scan_root(&mut frag, &roots);
+        assert_eq!(frag.source_id, "src/foo.rs");
+        assert_eq!(frag.source_root.as_deref(), Some("/project/frontend"));
+    }
+
+    #[test]
+    fn relativize_keeps_absolute_when_outside_all_roots() {
+        let mut frag = make_fragment("/elsewhere/src/foo.rs");
+        let roots = vec![std::path::PathBuf::from("/project")];
+        relativize_to_scan_root(&mut frag, &roots);
+        assert_eq!(frag.source_id, "/elsewhere/src/foo.rs");
+        assert!(frag.source_root.is_none());
+    }
+
+    #[test]
+    fn relativize_uses_first_matching_root() {
+        let mut frag = make_fragment("/project/frontend/src/foo.rs");
+        let roots = vec![
+            std::path::PathBuf::from("/project"),
+            std::path::PathBuf::from("/project/frontend"),
+        ];
+        relativize_to_scan_root(&mut frag, &roots);
+        assert_eq!(frag.source_id, "frontend/src/foo.rs");
+        assert_eq!(frag.source_root.as_deref(), Some("/project"));
     }
 
     #[test]
     fn relativize_strips_dot_prefix() {
-        let mut id = "./src/foo.rs".to_string();
-        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
-        assert_eq!(id, "src/foo.rs");
-
-        let mut id = ".\\src\\foo.rs".to_string();
-        relativize_to_cwd(&mut id, std::path::Path::new("/project"));
-        assert_eq!(id, "src\\foo.rs");
+        let mut frag = make_fragment("./src/foo.rs");
+        let roots = vec![std::path::PathBuf::from("/project")];
+        relativize_to_scan_root(&mut frag, &roots);
+        assert_eq!(frag.source_id, "src/foo.rs");
     }
 }

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -522,8 +522,16 @@ mod tests {
         cpd_core::models::Fragment {
             source_id: source_id.to_string(),
             source_root: None,
-            start: cpd_core::models::Location { line: 1, column: 0, offset: 0 },
-            end: cpd_core::models::Location { line: 1, column: 0, offset: 0 },
+            start: cpd_core::models::Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
+            end: cpd_core::models::Location {
+                line: 1,
+                column: 0,
+                offset: 0,
+            },
             range: [0, 0],
             blame: None,
         }

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -245,7 +245,17 @@ fn main() {
     // roots here too for reliable prefix stripping (macOS /var → /private/var).
     let canonical_roots: Vec<std::path::PathBuf> = paths
         .iter()
-        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
+        .map(|p| {
+            let canonical = std::fs::canonicalize(p).unwrap_or_else(|_| p.clone());
+            if canonical.is_file() {
+                canonical
+                    .parent()
+                    .map(|d| d.to_path_buf())
+                    .unwrap_or(canonical)
+            } else {
+                canonical
+            }
+        })
         .collect();
     for clone in &mut clones {
         if opts.absolute {

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -470,6 +470,131 @@ fn cli_both_ignore_flags_work_together() {
     );
 }
 
+#[test]
+fn single_file_scan_preserves_filename() {
+    let bin = match maybe_bin() {
+        Some(b) => b,
+        None => return,
+    };
+
+    let root = std::env::temp_dir().join(format!("cpd-single-file-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("create dir");
+
+    let dup = "function greet(name) {\n  \
+        const message = \"Hello, \" + name + \"!\";\n  \
+        console.log(message);\n  \
+        console.log(\"Welcome to the system\");\n  \
+        console.log(\"Have a nice day now\");\n  \
+        return message;\n}\n";
+    std::fs::write(root.join("a.js"), dup).expect("write a.js");
+    std::fs::write(root.join("b.js"), dup).expect("write b.js");
+
+    let out = root.join("report");
+    let a_path = root.join("a.js");
+    let b_path = root.join("b.js");
+
+    let output = Command::new(&bin)
+        .args([
+            a_path.to_str().unwrap(),
+            b_path.to_str().unwrap(),
+            "--min-tokens",
+            "10",
+            "--reporters",
+            "json",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cpd");
+    assert!(
+        output.status.success(),
+        "cpd must succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json = std::fs::read_to_string(out.join("jscpd-report.json")).expect("json report");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let first_name = parsed["duplicates"][0]["firstFile"]["name"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        first_name == "a.js" || first_name == "b.js",
+        "source_id must be the filename (not empty), got: '{}'",
+        first_name
+    );
+
+    let fragment = parsed["duplicates"][0]["fragment"].as_str().unwrap_or("");
+    assert!(
+        fragment.contains("Welcome to the system"),
+        "snippet must be populated for single-file scan"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn sarif_multi_root_distinct_artifact_indexes() {
+    let bin = match maybe_bin() {
+        Some(b) => b,
+        None => return,
+    };
+
+    let root = std::env::temp_dir().join(format!("cpd-multi-sarif-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let dir_a = root.join("alpha/src");
+    let dir_b = root.join("beta/src");
+    std::fs::create_dir_all(&dir_a).expect("create alpha");
+    std::fs::create_dir_all(&dir_b).expect("create beta");
+
+    let dup = "function greet(name) {\n  \
+        const message = \"Hello, \" + name + \"!\";\n  \
+        console.log(message);\n  \
+        console.log(\"Welcome to the system\");\n  \
+        console.log(\"Have a nice day now\");\n  \
+        return message;\n}\n";
+    // Same relative path under two different roots
+    std::fs::write(dir_a.join("a.js"), dup).expect("write alpha/src/a.js");
+    std::fs::write(dir_b.join("a.js"), dup).expect("write beta/src/a.js");
+
+    let out = root.join("report");
+
+    let output = Command::new(&bin)
+        .args([
+            "alpha",
+            "beta",
+            "--min-tokens",
+            "10",
+            "--reporters",
+            "sarif",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cpd");
+    assert!(
+        output.status.success(),
+        "cpd must succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let sarif = std::fs::read_to_string(out.join("jscpd-report.sarif")).expect("sarif exists");
+    let parsed: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+    let artifacts = parsed["runs"][0]["artifacts"]
+        .as_array()
+        .expect("artifacts array");
+
+    assert!(
+        artifacts.len() >= 2,
+        "same relative path under different roots must produce distinct artifacts, got {}",
+        artifacts.len()
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 // --- cross-formats e2e -------------------------------------------------------
 
 fn cross_formats_fixture_dir() -> PathBuf {

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -471,6 +471,92 @@ fn cli_both_ignore_flags_work_together() {
 }
 
 #[test]
+fn blame_populated_when_scan_root_differs_from_cwd() {
+    let bin = match maybe_bin() {
+        Some(b) => b,
+        None => return,
+    };
+    // Requires git on PATH; skip quietly if unavailable.
+    if Command::new("git").arg("--version").output().is_err() {
+        return;
+    }
+
+    let root = std::env::temp_dir().join(format!("cpd-blame-subdir-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let pkg = root.join("pkg");
+    std::fs::create_dir_all(&pkg).expect("create pkg dir");
+
+    let dup = "function greet(name) {\n  \
+        const message = \"Hello, \" + name + \"!\";\n  \
+        console.log(message);\n  \
+        console.log(\"Welcome to the system\");\n  \
+        console.log(\"Have a nice day now\");\n  \
+        return message;\n}\n";
+    std::fs::write(pkg.join("a.js"), dup).expect("write a.js");
+    std::fs::write(pkg.join("b.js"), dup).expect("write b.js");
+
+    // Init a git repo at `root` and commit, so `git blame` has data.
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(&root)
+            .output()
+            .expect("git command failed to spawn");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    git(&["init", "-q"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Blame Tester"]);
+    git(&["add", "."]);
+    git(&["commit", "-q", "-m", "init"]);
+
+    let out = root.join("report");
+
+    // Scan the `pkg` subdirectory from the repo root (scan root != file dirs
+    // relative to CWD after scan-root relativization).
+    let output = Command::new(&bin)
+        .args([
+            "pkg",
+            "--min-tokens",
+            "10",
+            "--blame",
+            "--reporters",
+            "json",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cpd");
+    assert!(
+        output.status.success(),
+        "cpd must succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json = std::fs::read_to_string(out.join("jscpd-report.json")).expect("json report");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let first_file = &parsed["duplicates"][0]["firstFile"];
+    assert!(
+        first_file.get("blame").is_some(),
+        "blame data must be populated when scan root differs from CWD, got: {}",
+        first_file
+    );
+    assert_eq!(
+        first_file["blame"]["author"].as_str().unwrap_or(""),
+        "Blame Tester",
+        "blame author must come from git history"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn single_file_scan_preserves_filename() {
     let bin = match maybe_bin() {
         Some(b) => b,

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -373,9 +373,78 @@ fn report_snippets_populated_when_scan_root_differs_from_cwd() {
         "HTML report must contain snippet text, not be empty"
     );
 
+    // source_id should be scan-root-relative (just "a.js", not "pkg/a.js")
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let first_name = parsed["duplicates"][0]["firstFile"]["name"]
+        .as_str()
+        .unwrap_or("");
     assert!(
-        json.contains("pkg/a.js") || json.contains(r"pkg\\a.js"),
-        "source path must be CWD-relative (keep the pkg/ prefix)"
+        first_name == "a.js" || first_name == "b.js",
+        "source path must be scan-root-relative (a.js or b.js), got: {}",
+        first_name
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn sarif_includes_original_uri_base_ids() {
+    let bin = match maybe_bin() {
+        Some(b) => b,
+        None => return,
+    };
+
+    let root = std::env::temp_dir().join(format!("cpd-sarif-root-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let pkg = root.join("pkg");
+    std::fs::create_dir_all(&pkg).expect("create pkg dir");
+
+    let dup = "function greet(name) {\n  \
+        const message = \"Hello, \" + name + \"!\";\n  \
+        console.log(message);\n  \
+        console.log(\"Welcome to the system\");\n  \
+        console.log(\"Have a nice day now\");\n  \
+        return message;\n}\n";
+    std::fs::write(pkg.join("a.js"), dup).expect("write a.js");
+    std::fs::write(pkg.join("b.js"), dup).expect("write b.js");
+
+    let out = root.join("report");
+
+    let output = Command::new(&bin)
+        .args([
+            "pkg",
+            "--min-tokens",
+            "10",
+            "--reporters",
+            "sarif",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cpd");
+    assert!(
+        output.status.success(),
+        "cpd must succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let sarif = std::fs::read_to_string(out.join("jscpd-report.sarif")).expect("sarif exists");
+    let parsed: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+    let run = &parsed["runs"][0];
+
+    assert!(
+        run.get("originalUriBaseIds").is_some(),
+        "SARIF must include originalUriBaseIds when source_root is set"
+    );
+
+    let uri = run["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        uri == "a.js" || uri == "b.js",
+        "SARIF artifact URI must be scan-root-relative, got: {}",
+        uri
     );
 
     let _ = std::fs::remove_dir_all(&root);


### PR DESCRIPTION
## Summary

Adds `source_root: Option<String>` to `Fragment` so that `source_id` can be scan-root-relative (for display and SARIF output) while reporters reconstruct the absolute path via `source_root + source_id` for file I/O.

This resolves the tension between #828 / #827 (scan-root-relative paths for consistent SARIF URIs) and #892 / #872 (paths must be resolvable from CWD for snippet reads). Both needs are now satisfied simultaneously.

### Context trail

- **#827** — `absolute:false` produced inconsistent SARIF paths depending on invocation style
- **#828** — fixed #827 by making paths scan-root-relative, but this broke reporter snippet reads
- **#872** — reporter snippets were empty because scan-root-relative paths couldn't be read from CWD
- **#892** — fixed #872 by switching to CWD-relative paths, but this regressed #827 for SARIF/multi-root users ([comment](https://github.com/kucherenko/jscpd/pull/892#issuecomment-5257021649))
- **#869** — independent PR with same CWD-relative approach, same tradeoff

### What changed

- **`Fragment.source_root`** (`Option<String>`, serde-skipped when `None`) — the canonicalized scan root this file belongs to
- **Post-detection normalization** (`main.rs`) — `relativize_to_scan_root` strips the matching scan root prefix, stores it on `source_root`, and makes `source_id` root-relative. File scan paths use the parent directory as the effective root so `source_id` stays the filename (not empty).
- **Shared path helpers** (`cpd-core/paths.rs`, new) — canonical `clean_source_id` and `resolve_fragment_path` used by both cpd-reporter and cpd-finder; `resolve_fragment_path()` joins `source_root + source_id` to reconstruct a readable path. Used by `read_file_cached`, `fragment_text`, `print_snippet`, the console-full blame path, and blame enrichment.
- **`clean_source_id`** — fixed to preserve Windows drive-letter colons (`C:\…`) while still stripping format suffixes (`doc.md:javascript`)
- **SARIF reporter** — emits `originalUriBaseIds` mapping each scan root, with `%SRCROOT%`-style base IDs per Microsoft/tooling conventions. Artifacts are deduplicated by `(source_root, clean_source_id)` so identical relative paths under different scan roots get distinct entries. Windows paths are preserved as native paths; Unix paths use `file://` URIs.
- **JSON output** — `source_root` is omitted from serialization when `None` (backward-compatible for single-root cases)

### Additional catch: `--blame` had the same failure mode (plus a latent bug)

Self-review caught that blame enrichment runs *after* path normalization and canonicalized the now scan-root-relative `source_id` against the CWD — silently dropping all blame data when scan root != CWD (the same failure shape as #872, for blame instead of snippets). Fixing it surfaced a second, **pre-existing** bug: `find_git_root` walked up *relative* paths, terminating at the empty path — so a repo rooted at the CWD was reported as `""`, which then failed canonicalization inside `blame_file`. This meant `--blame` was already broken on master for any relative-path invocation (`jscpd pkg`), independent of this PR.

Both are fixed here:
- blame enrichment resolves files via `source_root + source_id` (BlameMap stays keyed by cleaned `source_id` for reporter lookups)
- `find_git_root` canonicalizes its start path before walking up
- `blame.rs`'s private stale copy of `clean_source_id` (which still had the Windows drive-letter bug) is removed in favor of the shared cpd-core implementation

### What this enables

- **Single root** (`cpd .`): `source_id` = `src/a.js`, `source_root` = canonicalized CWD — snippets resolve, SARIF URIs are clean
- **Sub-directory** (`cpd frontend`): `source_id` = `src/a.js`, `source_root` = canonicalized `frontend/` — snippets resolve, SARIF URIs are root-relative
- **Multiple roots** (`cpd frontend backend`): each fragment gets its own `source_root` — SARIF `originalUriBaseIds` lists both, paths never collide
- **Single-file inputs** (`cpd a.js b.js`): parent directory used as root, `source_id` = `a.js` (not empty)
- **`--blame` with any of the above**: blame data resolves correctly regardless of scan root vs CWD

## Test plan

- [x] All existing tests pass (`cargo test --workspace`)
- [x] `report_snippets_populated_when_scan_root_differs_from_cwd` — snippets contain code when scan root != CWD, source paths are scan-root-relative
- [x] `sarif_includes_original_uri_base_ids` — SARIF contains `originalUriBaseIds` and artifact URIs are scan-root-relative
- [x] `single_file_scan_preserves_filename` — single-file inputs produce non-empty `source_id` and populated snippets
- [x] `sarif_multi_root_distinct_artifact_indexes` — same relative path under different roots gets distinct SARIF artifact entries
- [x] New: `blame_populated_when_scan_root_differs_from_cwd` — creates a git repo, commits, scans a subdirectory with `--blame`, asserts blame author appears in the JSON report (verified to fail before the fix)
- [x] Unit tests for `relativize_to_scan_root`: first-match root selection, out-of-root fallback, dot-prefix stripping
- [x] Unit tests for `clean_source_id` / `resolve_fragment_path` (now in `cpd-core/paths.rs`): Windows drive letters preserved, format suffixes stripped, root joining, fallback

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/913)
<!-- Reviewable:end -->
