### PR TITLE
feat(sarif): expand rule information

### DIFF
--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -198,8 +198,20 @@ impl Reporter for SarifReporter {
                     "informationUri": "https://github.com/kucherenko/jscpd/",
                     "rules": [{
                         "id": "jscpd/duplicate-code",
+                        "name": "jscpd/duplicate-code",
                         "shortDescription": { "text": "Duplicated code detected" },
+                        "fullDescription": {
+                            "text": "Duplicate sections of code increase the risk of development errors, especially if fixes are made to one code block but not the other. Duplicates that share the same abstractions should be refactored into reusable helper methods as an application of the Don't Repeat Yourself principle."
+                        },
+                        "defaultConfiguration": {
+                            "enabled": true,
+                            "level": "warning"
+                        },
                         "helpUri": "https://github.com/kucherenko/jscpd/",
+                        "properties": {
+                            "tags": [ "quality" ],
+                            "problem.severity": "warning"
+                        }
                     }]
                 }
             },


### PR DESCRIPTION
Provide more details for the jscpd/duplicate-code rule. These will improve the appearance of rules in consumers like SARIF browsers for IDEs and Azure DevOps, and are inspired by some of the properties in rules emitted by CodeQL's SARIF reporter.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

SARIF output contains a very bare-bones rule object for `jscpd/duplicate-code`.

* **What is the new behavior (if this is a feature change)?**

Adds the following rule details:
- Display name of the rule (matches ID like CodeQL does, but doesn't have to)
- Full description string matching the tone of other tools' rules
- Default configuration properties for the rule (warning level, rule is enabled)
- Tags and property-bag expression of the warning level / severity

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/914)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced SARIF reports with clearer rule names and descriptions.
  * Added warning severity and enabled-warning details.
  * Included a quality classification tag for improved report context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->