### PR TITLE
fix(finder): align clone fragments with the reported line numbers

### DIFF
--- a/packages/finder/__tests__/hooks.test.ts
+++ b/packages/finder/__tests__/hooks.test.ts
@@ -38,6 +38,35 @@ describe('FragmentsHook', () => {
       expect(typeof clone.duplicationB.fragment).toBe('string');
     });
   });
+
+  // The mocked file content is 'file content line1\nline2\nline3'.
+  it('addFragments expands a range starting mid-line to the whole line', async () => {
+    const { FragmentsHook } = await import('../src/hooks/fragment');
+    const clone = buildClone({ duplicationA: { range: [5, 24] } as any });
+    const result = FragmentsHook.addFragments(clone);
+    expect(result.duplicationA.fragment).toBe('file content line1\nline2');
+  });
+
+  it('addFragments does not pull in the next line for a range ending after a newline', async () => {
+    const { FragmentsHook } = await import('../src/hooks/fragment');
+    const clone = buildClone({ duplicationA: { range: [19, 25] } as any });
+    const result = FragmentsHook.addFragments(clone);
+    expect(result.duplicationA.fragment).toBe('line2');
+  });
+
+  it('addFragments expands a range ending mid-line to the end of that line', async () => {
+    const { FragmentsHook } = await import('../src/hooks/fragment');
+    const clone = buildClone({ duplicationA: { range: [0, 21] } as any });
+    const result = FragmentsHook.addFragments(clone);
+    expect(result.duplicationA.fragment).toBe('file content line1\nline2');
+  });
+
+  it('addFragments keeps a fragment that already covers whole lines', async () => {
+    const { FragmentsHook } = await import('../src/hooks/fragment');
+    const clone = buildClone({ duplicationA: { range: [0, 30] } as any });
+    const result = FragmentsHook.addFragments(clone);
+    expect(result.duplicationA.fragment).toBe('file content line1\nline2\nline3');
+  });
 });
 
 describe('BlamerHook', () => {

--- a/packages/finder/src/hooks/fragment.ts
+++ b/packages/finder/src/hooks/fragment.ts
@@ -2,6 +2,29 @@ import {IClone} from '@jscpd/core';
 import {readFileSync} from "fs";
 import {IHook} from '..';
 
+/**
+ * Reporters print a clone fragment next to the line numbers taken from the
+ * clone location, so the fragment has to start and end on line boundaries.
+ * A clone range, however, starts at the first duplicated *token*, which is not
+ * necessarily the first token of its line, and may end just after the newline
+ * that terminates the last line. Snapping the range to whole lines keeps the
+ * printed code in step with the printed line numbers.
+ */
+function readWholeLines(code: string, [from, to]: [number, number]): string {
+	// Beginning of the line containing `from` (0 when there is no newline before it).
+	const start = code.lastIndexOf('\n', from - 1) + 1;
+
+	// A range that ends right after a line terminator already covers whole
+	// lines; without stepping back, the next line would be pulled in.
+	let end = to;
+	if (end > start && code[end - 1] === '\n') {
+		end--;
+	}
+
+	const lineEnd = code.indexOf('\n', end);
+	return code.substring(start, lineEnd === -1 ? code.length : lineEnd);
+}
+
 export class FragmentsHook implements IHook {
 
 	process(clones: IClone[]): Promise<IClone[]> {
@@ -13,8 +36,8 @@ export class FragmentsHook implements IHook {
 	static addFragments(clone: IClone): IClone {
 		const codeA = readFileSync(clone.duplicationA.sourceId).toString();
 		const codeB = readFileSync(clone.duplicationB.sourceId).toString();
-		clone.duplicationA.fragment = codeA.substring(clone.duplicationA.range[0], clone.duplicationA.range[1]);
-		clone.duplicationB.fragment = codeB.substring(clone.duplicationB.range[0], clone.duplicationB.range[1]);
+		clone.duplicationA.fragment = readWholeLines(codeA, clone.duplicationA.range);
+		clone.duplicationB.fragment = readWholeLines(codeB, clone.duplicationB.range);
 		return clone;
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

Related to #612 (`consoleFull`/html reporter shows a code block that does not match the line numbers).

`FragmentsHook` stores the fragment as the raw `code.substring(range[0], range[1])` of the clone's **token** range. The reporters then print that string line by line next to line numbers derived from `duplicationX.start.line`, which produces two mismatches:

1. A clone whose first duplicated token is not the first token of its line renders a truncated first line, still labelled with the full line number.
2. A range that ends just after the newline terminating the last line renders a trailing empty row.

Both show up in `consoleFull`, and the html reporter has the same mismatch since it prints the fragment under a `Line <start> - Line <end>` header.

Before, on a clone starting mid-line (note the truncated line 1, and 8 rows for a header that reports 7 lines):

```
Clone found (javascript):
 - m\one.js [1:30 - 8:2] (7 lines, 86 tokens)
   m\two.js [3:27 - 10:2]

 1 │ 3  │ ; function sharedHelper(input) {
 2 │ 4  │   const parts = String(input).split(',');
 ...
```

and on a clone whose range ends on a line terminator (row 16 is empty, while the header reports 15 lines):

```
 14 │ 37 │         return uts_ns;
 15 │ 38 │ }
 16 │ 39 │
```

* **What is the new behavior (if this is a feature change)?**

The fragment is snapped to whole lines when it is read, so the printed code lines up with the printed line numbers:

```
 1 │ 3  │ const unrelatedPrefixHere = 1; function sharedHelper(input) {
 2 │ 4  │   const parts = String(input).split(',');
 ...
```

```
 14 │ 37 │         return uts_ns;
 15 │ 38 │ }
```

Only the displayed fragment changes. The token `range`, the clone locations and the statistics are untouched, so detection results and `--threshold` behaviour are unaffected.

* **Other information**:

- Four unit tests added in `packages/finder/__tests__/hooks.test.ts` covering a mid-line start, a range ending on a newline, a range ending mid-line, and an already line-aligned range.
- `pnpm run typecheck` passes for `@jscpd/finder`.
- On the test suites: `packages/finder` and `apps/jscpd` both have pre-existing failures on my Windows machine (`getFilesToDetect` returns no files — path/glob related, unrelated to this change). The counts are identical before and after this commit; only the 4 new tests differ (`20 failed | 80 passed` → `20 failed | 84 passed` in `packages/finder`). I have not been able to verify against a green baseline locally, so CI is the real check here.
- I have not changed the `lines` figure in the clone header (`end.line - start.line`), which is why the mid-line example still reports 7 lines for 8 rows. That count also feeds the duplication statistics and `--threshold`, so it felt out of scope for this fix — happy to look at it separately if you would like.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/916)
<!-- Reviewable:end -->

<!-- brian settings start --><!--{}--><!-- brian settings end -->