### PR TITLE
feat(rust): opt-in --summary codebase report — top files/folders by tokens, lines, size, complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ jscpd v5 is a ground-up Rust rewrite that ships as [`jscpd@5`](https://www.npmjs
 - **`--workers`** — control parallelism for file tokenization and detection (default: auto, uses all CPU cores; not available in v4)
 - **13 reporters**: `console`, `console-full`, `json`, `xml`, `csv`, `html`, `markdown`, `badge`, `sarif`, `ai`, `xcode`, `threshold`, `silent`
 - **AI reporter** — token-efficient output for LLM pipelines (~79% fewer tokens than console)
+- **`--summary`** — codebase summary: top files and folders by tokens, lines, size, and a complexity estimate — refactoring hotspots straight from the scan (see [docs](docs/rust.md#summary))
 - **Self-contained binary** — prebuilt for 6 platforms (macOS arm64/x64, Linux arm64/x64, Windows x64)
 
 **Not yet in v5** (use v4 for these):
@@ -159,8 +160,9 @@ jscpd integrates into AI-powered workflows through three mechanisms:
 Token-efficient output for LLM pipelines (~79% fewer tokens than the default console reporter):
 
 ```bash
-jscpd --reporters ai /path/to/source   # v4
-cpd --reporters ai /path/to/source      # v5
+jscpd --reporters ai /path/to/source              # v4
+cpd --reporters ai /path/to/source                # v5
+cpd --reporters ai --summary /path/to/source      # v5: + compact codebase summary
 ```
 
 ### Agent Skills

--- a/docs/ai-ready.md
+++ b/docs/ai-ready.md
@@ -39,6 +39,26 @@ Benchmarked on the `fixtures/` directory (212 clones, 347 files):
 
 ~79% fewer tokens than the default console reporter.
 
+### Codebase Summary (v5)
+
+Add `--summary` for a compact refactoring-hotspot overview — top files and folders by tokens, lines, size, and a complexity estimate. In the `ai` reporter each entry is one line with all metrics inline, so an agent gets the full picture for a handful of tokens:
+
+```
+Summary by tokens (321 files, 129 folders):
+files (tokens/lines/size/cx/dup%):
+src/core/files.ts 2052/363/11.4K/80/0.0%
+...
+folders (files/tokens/lines/size):
+src/core 8/5264/843/26.5K
+...
+```
+
+```bash
+cpd --reporters ai --summary --no-tips /path/to/source
+```
+
+See [rust.md](rust.md#summary) for the metric definitions and `--summary-top` / `--summary-by` options.
+
 ## Agent Skills
 
 jscpd ships two AI agent skills that teach coding assistants how to use jscpd and refactor detected duplications.

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -79,6 +79,9 @@ cpd [OPTIONS] [PATH]...
 | `--skip-local` | | Skip clones where both fragments are in the same directory | off |
 | `--sarif-error-tokens` | | Report SARIF results as `error` for clones with at least this many tokens (smaller clones stay `warning`). When overall duplication exceeds `--threshold`, all SARIF results become `error` regardless of size. | — (all `warning`) |
 | `--min-duplicated-lines` | | Minimum percentage of duplication to report (0-100) | 0 |
+| `--summary` | | Print a codebase summary: top files and folders by tokens, lines, size, and a complexity estimate. See [Summary](#summary) | off |
+| `--summary-top` | | Number of entries in each summary top list | 10 |
+| `--summary-by` | | Summary sort metric: `tokens`, `lines`, `size`, `complexity` | `tokens` |
 | `--silent` | `-s` | Suppress console output | off |
 | `--no-tips` | | Suppress tips and promotional messages | off |
 | `--version` | `-V` | Print version | — |
@@ -105,6 +108,46 @@ cpd [OPTIONS] [PATH]...
 | `silent` | No console output |
 
 Output file names differ from v4: v5 uses `jscpd-report.*` prefix (e.g. `jscpd-report.json`, `jscpd-report.sarif`) while v4 uses `jscpd-report.json`, `html/` directory, etc.
+
+### Summary
+
+`--summary` appends a codebase summary to the run output — the statistics jscpd already collects while scanning, aggregated to answer "where should I refactor first":
+
+```
+Summary (by tokens; 321 files, 129 folders analyzed)
+Top files:
+  TOKENS  LINES   SIZE  CX  DUP%  PATH
+    2052    363  11.4K  80   0.0  files.ts
+    ...
+Top folders:
+  FILES  TOKENS  LINES   SIZE  CX  PATH
+      8    5264    843  26.5K  15  src/core
+      ...
+```
+
+- **Top files** lists the top `--summary-top` files ranked by the `--summary-by` metric. Every row carries all metrics, so re-ranking by another lens is a `--summary-by size` (or `lines`, `complexity`) away.
+- **Top folders** aggregates files into their direct parent directory (each file counted exactly once; no cumulative ancestor totals).
+- **CX** is a language-agnostic cyclomatic-complexity estimate computed from the token stream: 1 + the number of decision-point tokens (`if`, `elif`/`elsif`/`elseif`, `unless`, `for`, `foreach`, `while`, `until`, `case`, `cond`, `when`, `catch`, `rescue`, `except`, `and`, `or`, `andalso`, `orelse`, `&&`, `||`, `?`, `??`). Matching is case-insensitive, so uppercase-keyword languages (SQL, PL/SQL, Fortran, COBOL, BASIC) count too. For folders it is the per-file mean. Languages that branch without such keywords (Smalltalk `ifTrue:` messages, Prolog clauses) stay at 1 — treat CX as a ranking signal, not an exact metric.
+- **DUP%** is the share of the file's lines covered by detected clone fragments (both fragments of a clone count toward their files; display is capped at 100%).
+
+The summary is fully opt-in and computed after detection from data already in memory, so runs without `--summary` are unaffected. It integrates with:
+
+- `console` / `console-full` — the block shown above
+- `ai` — a compact, LLM-token-efficient variant (one line per file/folder)
+- `json` — an additive `summary` key in `jscpd-report.json` (absent when the flag is off, so the schema is unchanged for existing consumers)
+
+Config file equivalents: `"summary": true`, `"summaryTop": 10`, `"summaryBy": "tokens"`.
+
+```bash
+# Refactoring hotspots: biggest files by tokens plus duplication share
+cpd ./src --summary
+
+# Agent-friendly: compact clone list + compact summary
+cpd ./src --summary --reporters ai --no-tips
+
+# Focus on the most complex files, top 5 lists, machine-readable
+cpd ./src --summary --summary-by complexity --summary-top 5 --reporters json
+```
 
 ### Blame Output
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **cpd (Rust)** are documented here. Releases follow [Sema
 
 ## 5.0.16
 
+### New Features
+
+- **Codebase summary (`--summary`)** — opt-in refactoring-hotspot overview appended to the run output: top files and folders ranked by tokens, lines, size, or a token-based cyclomatic-complexity estimate, with each file's duplication share. `--summary-top <n>` sets the list length, `--summary-by tokens|lines|size|complexity` picks the ranking metric (config file: `summary`, `summaryTop`, `summaryBy`). Renders in `console`/`console-full`, as a compact one-line-per-entry block in the `ai` reporter, and as an additive `summary` key in the JSON report (absent when the flag is off, so the schema is unchanged for existing consumers). Computed after detection from data already in memory — runs without `--summary` are unaffected. ([#934](https://github.com/kucherenko/jscpd/issues/934))
+
 ### Security
 
 - **Supply-chain hardening (OpenSSF Scorecard)** — every GitHub Action in the release and CI pipelines is pinned to a full commit SHA (kept fresh by Dependabot), workflow tokens follow least privilege (top-level `contents: read`, write grants scoped to the jobs that need them), and the repository now has a `SECURITY.md` with private disclosure channels, private vulnerability reporting, and a protected `master` branch

--- a/rust/crates/cpd-core/src/detect.rs
+++ b/rust/crates/cpd-core/src/detect.rs
@@ -902,6 +902,7 @@ mod tests {
 
     fn make_file(id: &str, format: &str, tokens: Vec<Token>) -> SourceFile {
         SourceFile {
+            bytes: 0,
             id: id.to_string(),
             format: format.to_string(),
             tokens,

--- a/rust/crates/cpd-core/src/lib.rs
+++ b/rust/crates/cpd-core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod detect;
 pub mod hash;
 pub mod models;
 pub mod paths;
+pub mod summary;

--- a/rust/crates/cpd-core/src/models.rs
+++ b/rust/crates/cpd-core/src/models.rs
@@ -97,6 +97,10 @@ pub struct SourceFile {
     pub id: String,
     pub format: String,
     pub tokens: Vec<Token>,
+    /// File size in bytes. Zero for synthetic sub-format sources
+    /// (embedded code blocks) whose bytes are counted by the parent file.
+    #[serde(default)]
+    pub bytes: u64,
 }
 
 /// Per-format or total statistics row.

--- a/rust/crates/cpd-core/src/summary.rs
+++ b/rust/crates/cpd-core/src/summary.rs
@@ -1,0 +1,535 @@
+// summary.rs — opt-in codebase summary: per-file metrics, folder rollup, top-N lists.
+//
+// Everything in this module runs only when `--summary` is enabled, after
+// detection has finished, over data already held in memory (SourceFile tokens
+// and detected clones). Nothing in the detection hot path calls into it.
+
+use crate::models::{CpdClone, SourceFile};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Metric used to rank files and folders in the summary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SummaryMetric {
+    #[default]
+    Tokens,
+    Lines,
+    Size,
+    Complexity,
+}
+
+impl std::str::FromStr for SummaryMetric {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tokens" => Ok(Self::Tokens),
+            "lines" => Ok(Self::Lines),
+            "size" => Ok(Self::Size),
+            "complexity" => Ok(Self::Complexity),
+            other => Err(format!(
+                "invalid summary metric '{other}': must be one of: tokens, lines, size, complexity"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for SummaryMetric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Tokens => "tokens",
+            Self::Lines => "lines",
+            Self::Size => "size",
+            Self::Complexity => "complexity",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Per-file summary row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileSummary {
+    pub path: String,
+    pub format: String,
+    pub lines: u64,
+    pub tokens: u64,
+    pub bytes: u64,
+    pub duplicated_lines: u64,
+    pub duplicated_tokens: u64,
+    /// Cyclomatic-complexity estimate: 1 + count of decision-point tokens
+    /// (`if`, `for`, `while`, `case`, `catch`, `&&`, `||`, `?`, …).
+    pub complexity: u64,
+}
+
+/// Per-folder rollup. Files are counted in their direct parent directory only
+/// (no cumulative ancestor totals), so every file contributes to exactly one
+/// folder row and rows are directly comparable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderSummary {
+    pub path: String,
+    pub files: u64,
+    pub lines: u64,
+    pub tokens: u64,
+    pub bytes: u64,
+    pub duplicated_lines: u64,
+    /// Sum of per-file complexity estimates (divide by `files` for the mean).
+    pub complexity: u64,
+}
+
+/// Codebase summary: top files and folder rollup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Summary {
+    /// Primary sort metric.
+    pub by: SummaryMetric,
+    /// Top-N files by `by`, descending. Every row carries all metrics
+    /// (tokens, lines, bytes, complexity, duplication) so one list serves
+    /// every lens; re-run with a different `--summary-by` to re-rank.
+    pub files: Vec<FileSummary>,
+    /// Top-N folders by `by`, direct-parent aggregation.
+    pub folders: Vec<FolderSummary>,
+    /// Total number of files analyzed (before top-N truncation).
+    pub total_files: u64,
+    /// Total number of folders (before top-N truncation).
+    pub total_folders: u64,
+}
+
+/// Decision-point tokens counted by the complexity estimate. Conservative,
+/// language-agnostic list: branch/loop keywords and short-circuit operators
+/// that appear as standalone tokens across supported languages.
+///
+/// Matching is ASCII-case-insensitive so case-insensitive and
+/// uppercase-keyword languages (SQL, PL/SQL, Fortran, COBOL, BASIC, Pascal)
+/// count too. The occasional identifier spelled like a keyword slightly
+/// inflates an estimate that is only used for ranking.
+fn is_decision_token(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() || bytes.len() > 7 {
+        return false;
+    }
+    let mut lower = [0u8; 7];
+    for (dst, b) in lower.iter_mut().zip(bytes) {
+        *dst = b.to_ascii_lowercase();
+    }
+    matches!(
+        &lower[..bytes.len()],
+        b"if"
+            | b"elif"
+            | b"elsif"
+            | b"elseif"
+            | b"unless"
+            | b"for"
+            | b"foreach"
+            | b"while"
+            | b"until"
+            | b"case"
+            | b"cond"
+            | b"when"
+            | b"catch"
+            | b"rescue"
+            | b"except"
+            | b"andalso"
+            | b"orelse"
+            | b"&&"
+            | b"||"
+            | b"and"
+            | b"or"
+            | b"?"
+            | b"??"
+    )
+}
+
+/// A synthetic source is the per-sub-format shadow of a multi-format file
+/// (markdown/vue/svelte embedded code); its id is `<parent-id>:<format>` and
+/// its metrics are already covered by the parent entry.
+fn is_synthetic(source: &SourceFile) -> bool {
+    source
+        .id
+        .strip_suffix(source.format.as_str())
+        .is_some_and(|prefix| prefix.ends_with(':'))
+}
+
+fn metric_of(file: &FileSummary, by: SummaryMetric) -> u64 {
+    match by {
+        SummaryMetric::Tokens => file.tokens,
+        SummaryMetric::Lines => file.lines,
+        SummaryMetric::Size => file.bytes,
+        SummaryMetric::Complexity => file.complexity,
+    }
+}
+
+fn folder_metric_of(folder: &FolderSummary, by: SummaryMetric) -> u64 {
+    match by {
+        SummaryMetric::Tokens => folder.tokens,
+        SummaryMetric::Lines => folder.lines,
+        SummaryMetric::Size => folder.bytes,
+        SummaryMetric::Complexity => folder.complexity,
+    }
+}
+
+/// Parent directory of a path, with separators normalized to `/`.
+/// Files at the scan root map to `"."`.
+fn parent_dir(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    match normalized.rfind('/') {
+        Some(0) => "/".to_string(),
+        Some(idx) => normalized[..idx].to_string(),
+        None => ".".to_string(),
+    }
+}
+
+/// Compute the summary from detection results.
+///
+/// `display_path` maps a source id (canonical absolute path) to the path shown
+/// in reports — the same relativization applied to clone fragments, so
+/// per-file duplication matching works on identical strings.
+pub fn compute_summary(
+    sources: &[SourceFile],
+    clones: &[CpdClone],
+    top: usize,
+    by: SummaryMetric,
+    display_path: impl Fn(&str) -> String,
+) -> Summary {
+    // Per-file duplication, keyed by display path. Both fragments of a clone
+    // count toward their file: the question here is "where does duplicated
+    // code live", not the de-duplicated total that Statistics reports.
+    let mut dup: HashMap<String, (u64, u64)> = HashMap::new();
+    for clone in clones {
+        for fragment in [&clone.fragment_a, &clone.fragment_b] {
+            // Sub-format fragments carry a `<path>:<format>` id; fold them
+            // into the parent file.
+            let path = fragment
+                .source_id
+                .strip_suffix(&format!(":{}", clone.format))
+                .unwrap_or(&fragment.source_id);
+            let entry = dup.entry(path.to_string()).or_default();
+            entry.0 += fragment.end.line.saturating_sub(fragment.start.line) as u64;
+            entry.1 += clone.token_count as u64;
+        }
+    }
+
+    let mut files: Vec<FileSummary> = sources
+        .iter()
+        .filter(|s| !is_synthetic(s))
+        .map(|source| {
+            let path = display_path(&source.id);
+            // Same line metric as Statistics: max token start line.
+            let lines = source
+                .tokens
+                .iter()
+                .map(|t| t.start.line)
+                .max()
+                .unwrap_or(0) as u64;
+            let decisions = source
+                .tokens
+                .iter()
+                .filter(|t| is_decision_token(&t.value))
+                .count() as u64;
+            let (duplicated_lines, duplicated_tokens) = dup.get(&path).copied().unwrap_or_default();
+            FileSummary {
+                lines,
+                tokens: source.tokens.len() as u64,
+                bytes: source.bytes,
+                duplicated_lines,
+                duplicated_tokens,
+                complexity: 1 + decisions,
+                format: source.format.clone(),
+                path,
+            }
+        })
+        .collect();
+
+    let total_files = files.len() as u64;
+
+    // Folder rollup over ALL files (before top-N truncation).
+    let mut folder_map: HashMap<String, FolderSummary> = HashMap::new();
+    for file in &files {
+        let dir = parent_dir(&file.path);
+        let entry = folder_map
+            .entry(dir.clone())
+            .or_insert_with(|| FolderSummary {
+                path: dir,
+                files: 0,
+                lines: 0,
+                tokens: 0,
+                bytes: 0,
+                duplicated_lines: 0,
+                complexity: 0,
+            });
+        entry.files += 1;
+        entry.lines += file.lines;
+        entry.tokens += file.tokens;
+        entry.bytes += file.bytes;
+        entry.duplicated_lines += file.duplicated_lines;
+        entry.complexity += file.complexity;
+    }
+    let total_folders = folder_map.len() as u64;
+
+    // Top-N files by the primary metric: `--summary-top N` always yields at
+    // most N rows (least surprise). Other lenses are one `--summary-by` away;
+    // every row still carries all metrics.
+    files.sort_by(|a, b| {
+        metric_of(b, by)
+            .cmp(&metric_of(a, by))
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    files.truncate(top);
+
+    let mut folders: Vec<FolderSummary> = folder_map.into_values().collect();
+    folders.sort_by(|a, b| {
+        folder_metric_of(b, by)
+            .cmp(&folder_metric_of(a, by))
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    folders.truncate(top);
+
+    Summary {
+        by,
+        files,
+        folders,
+        total_files,
+        total_folders,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{CpdClone, Fragment, Location, Token, TokenKind};
+
+    fn loc(line: u32) -> Location {
+        Location {
+            line,
+            column: 0,
+            offset: 0,
+        }
+    }
+
+    fn token(value: &str, line: u32) -> Token {
+        Token {
+            kind: TokenKind::Keyword,
+            value: value.to_string(),
+            start: loc(line),
+            end: loc(line),
+        }
+    }
+
+    fn source(id: &str, format: &str, values: &[&str], bytes: u64) -> SourceFile {
+        SourceFile {
+            id: id.to_string(),
+            format: format.to_string(),
+            tokens: values
+                .iter()
+                .enumerate()
+                .map(|(i, v)| token(v, i as u32 + 1))
+                .collect(),
+            bytes,
+        }
+    }
+
+    fn clone_between(format: &str, a: &str, b: &str, lines: u32, tokens: u32) -> CpdClone {
+        let fragment = |id: &str| Fragment {
+            source_id: id.to_string(),
+            source_root: None,
+            start: loc(1),
+            end: loc(1 + lines),
+            range: [0, tokens],
+            blame: None,
+        };
+        CpdClone {
+            format: format.to_string(),
+            fragment_a: fragment(a),
+            fragment_b: fragment(b),
+            token_count: tokens,
+        }
+    }
+
+    fn identity(path: &str) -> String {
+        path.to_string()
+    }
+
+    #[test]
+    fn empty_input_produces_empty_summary() {
+        let summary = compute_summary(&[], &[], 10, SummaryMetric::Tokens, identity);
+        assert!(summary.files.is_empty());
+        assert!(summary.folders.is_empty());
+        assert_eq!(summary.total_files, 0);
+        assert_eq!(summary.total_folders, 0);
+    }
+
+    #[test]
+    fn files_sorted_by_primary_metric() {
+        let sources = vec![
+            source("src/small.js", "javascript", &["a", "b"], 10),
+            source("src/big.js", "javascript", &["a", "b", "c", "d"], 20),
+        ];
+        let summary = compute_summary(&sources, &[], 10, SummaryMetric::Tokens, identity);
+        assert_eq!(summary.files[0].path, "src/big.js");
+        assert_eq!(summary.files[0].tokens, 4);
+        assert_eq!(summary.total_files, 2);
+    }
+
+    #[test]
+    fn top_n_is_exact_row_count_by_primary_metric() {
+        // huge.js wins on tokens, fat.js wins on size — top=1 by tokens must
+        // yield exactly one row: huge.js. `--summary-top N` never surprises
+        // with more than N rows; other metrics are served by --summary-by.
+        let sources = vec![
+            source("huge.js", "javascript", &["a", "b", "c", "d", "e"], 1),
+            source("fat.js", "javascript", &["a"], 9999),
+        ];
+        let summary = compute_summary(&sources, &[], 1, SummaryMetric::Tokens, identity);
+        assert_eq!(summary.files.len(), 1);
+        assert_eq!(summary.files[0].path, "huge.js");
+        assert_eq!(summary.total_files, 2, "truncation stays visible");
+
+        let by_size = compute_summary(&sources, &[], 1, SummaryMetric::Size, identity);
+        assert_eq!(by_size.files[0].path, "fat.js");
+    }
+
+    #[test]
+    fn complexity_counts_decision_tokens() {
+        let sources = vec![source(
+            "a.js",
+            "javascript",
+            &["if", "x", "&&", "y", "for", "z", "else"],
+            10,
+        )];
+        let summary = compute_summary(&sources, &[], 10, SummaryMetric::Complexity, identity);
+        // 1 + (if, &&, for) = 4; "else" is not a decision point.
+        assert_eq!(summary.files[0].complexity, 4);
+    }
+
+    #[test]
+    fn complexity_is_case_insensitive() {
+        // SQL / PL/SQL / Fortran style uppercase keywords.
+        let sources = vec![source(
+            "a.sql",
+            "sql",
+            &["IF", "x", "OR", "y", "WHEN", "THEN", "If"],
+            10,
+        )];
+        let summary = compute_summary(&sources, &[], 10, SummaryMetric::Complexity, identity);
+        // 1 + (IF, OR, WHEN, If) = 5; THEN is not a decision point.
+        assert_eq!(summary.files[0].complexity, 5);
+    }
+
+    #[test]
+    fn decision_token_edge_cases() {
+        assert!(is_decision_token("unless"));
+        assert!(is_decision_token("ELSEIF"));
+        assert!(is_decision_token("andalso"));
+        assert!(!is_decision_token(""));
+        assert!(!is_decision_token("iffy"));
+        assert!(!is_decision_token("conditionally"), "length-capped");
+        assert!(!is_decision_token("форматирование"), "non-ASCII ignored");
+    }
+
+    #[test]
+    fn folder_rollup_uses_direct_parent() {
+        let sources = vec![
+            source("src/app/a.js", "javascript", &["x"], 5),
+            source("src/app/b.js", "javascript", &["x", "y"], 5),
+            source("src/c.js", "javascript", &["x"], 5),
+            source("root.js", "javascript", &["x"], 5),
+        ];
+        let summary = compute_summary(&sources, &[], 10, SummaryMetric::Tokens, identity);
+        assert_eq!(summary.total_folders, 3);
+        let app = summary
+            .folders
+            .iter()
+            .find(|f| f.path == "src/app")
+            .expect("src/app folder");
+        assert_eq!(app.files, 2);
+        assert_eq!(app.tokens, 3);
+        let root = summary.folders.iter().find(|f| f.path == ".");
+        assert!(root.is_some(), "root files grouped under '.'");
+    }
+
+    #[test]
+    fn duplication_attributed_to_both_fragments() {
+        let sources = vec![
+            source("a.js", "javascript", &["x", "y", "z"], 5),
+            source("b.js", "javascript", &["x", "y", "z"], 5),
+        ];
+        let clones = vec![clone_between("javascript", "a.js", "b.js", 9, 30)];
+        let summary = compute_summary(&sources, &clones, 10, SummaryMetric::Tokens, identity);
+        for path in ["a.js", "b.js"] {
+            let file = summary.files.iter().find(|f| f.path == path).unwrap();
+            assert_eq!(file.duplicated_lines, 9, "{path} duplicated lines");
+            assert_eq!(file.duplicated_tokens, 30, "{path} duplicated tokens");
+        }
+    }
+
+    #[test]
+    fn synthetic_sub_format_sources_are_skipped() {
+        let sources = vec![
+            source("doc.md", "markdown", &["x", "y"], 100),
+            source("doc.md:javascript", "javascript", &["x"], 0),
+        ];
+        let summary = compute_summary(&sources, &[], 10, SummaryMetric::Tokens, identity);
+        assert_eq!(summary.total_files, 1);
+        assert_eq!(summary.files[0].path, "doc.md");
+    }
+
+    #[test]
+    fn sub_format_clone_folds_into_parent_file() {
+        let sources = vec![source("doc.md", "markdown", &["x", "y"], 100)];
+        let clones = vec![clone_between(
+            "javascript",
+            "doc.md:javascript",
+            "doc.md:javascript",
+            4,
+            20,
+        )];
+        let summary = compute_summary(&sources, &clones, 10, SummaryMetric::Tokens, identity);
+        assert_eq!(
+            summary.files[0].duplicated_lines, 8,
+            "both fragments fold in"
+        );
+    }
+
+    #[test]
+    fn display_path_applied_before_dup_matching() {
+        let sources = vec![source("/abs/root/a.js", "javascript", &["x"], 5)];
+        let clones = vec![clone_between("javascript", "a.js", "a.js", 2, 10)];
+        let summary = compute_summary(&sources, &clones, 10, SummaryMetric::Tokens, |p| {
+            p.strip_prefix("/abs/root/").unwrap_or(p).to_string()
+        });
+        assert_eq!(summary.files[0].path, "a.js");
+        assert_eq!(summary.files[0].duplicated_lines, 4);
+    }
+
+    #[test]
+    fn folders_truncated_to_top_n_but_total_reported() {
+        let sources: Vec<SourceFile> = (0..5)
+            .map(|i| source(&format!("dir{i}/f.js"), "javascript", &["x"], 1))
+            .collect();
+        let summary = compute_summary(&sources, &[], 2, SummaryMetric::Tokens, identity);
+        assert_eq!(summary.folders.len(), 2);
+        assert_eq!(summary.total_folders, 5);
+    }
+
+    #[test]
+    fn metric_parses_from_str() {
+        assert_eq!(
+            "complexity".parse::<SummaryMetric>().unwrap(),
+            SummaryMetric::Complexity
+        );
+        assert!("bogus".parse::<SummaryMetric>().is_err());
+    }
+
+    #[test]
+    fn summary_serializes_camel_case() {
+        let sources = vec![source("a.js", "javascript", &["x"], 5)];
+        let summary = compute_summary(&sources, &[], 10, SummaryMetric::Size, identity);
+        let json = serde_json::to_string(&summary).unwrap();
+        assert!(json.contains("\"totalFiles\""));
+        assert!(json.contains("\"duplicatedLines\""));
+        assert!(json.contains("\"by\":\"size\""));
+        assert!(!json.contains("total_files"));
+    }
+}

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -185,6 +185,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
                     }
                 }
 
+                let file_bytes = map.len() as u64;
                 let content = str::from_utf8(&map).ok()?;
                 let id = file
                     .path
@@ -223,6 +224,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
                         id: id.clone(),
                         format: file.format.clone(),
                         tokens,
+                        bytes: file_bytes,
                     }];
 
                     let mut prepared = Vec::new();
@@ -249,6 +251,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
                                 id: map_id.clone(),
                                 format: map.format.clone(),
                                 tokens: synth_tokens,
+                                bytes: 0,
                             });
                         }
                         prepared.push(PreparedSource::from_detection_tokens(
@@ -272,6 +275,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
                         id: id.clone(),
                         format: file.format.clone(),
                         tokens,
+                        bytes: file_bytes,
                     };
 
                     let opts = TokenizeOptions {

--- a/rust/crates/cpd-finder/src/statistics.rs
+++ b/rust/crates/cpd-finder/src/statistics.rs
@@ -125,6 +125,7 @@ mod tests {
             id: id.to_string(),
             format: format.to_string(),
             tokens,
+            bytes: 0,
         }
     }
 

--- a/rust/crates/cpd-reporter/src/ai.rs
+++ b/rust/crates/cpd-reporter/src/ai.rs
@@ -82,6 +82,10 @@ impl Reporter for AiReporter {
             self.style
                 .bold(&format!("{:.1}%", ctx.stats.total.percentage)),
         );
+        if let Some(summary) = ctx.summary {
+            println!("---");
+            crate::summary_render::print_summary_compact(summary);
+        }
         Ok(())
     }
 }

--- a/rust/crates/cpd-reporter/src/badge.rs
+++ b/rust/crates/cpd-reporter/src/badge.rs
@@ -119,6 +119,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &stats_with_pct(5.0, 10),
             duration: Duration::ZERO,
+            summary: None,
         };
         reporter.report(&[], &ctx, &dir).unwrap();
         let content = std::fs::read_to_string(dir.join("jscpd-badge.svg")).unwrap();
@@ -136,6 +137,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &stats_with_pct(pct, duplicated_lines),
             duration: Duration::ZERO,
+            summary: None,
         };
         reporter.report(&[], &ctx, &dir).unwrap();
         (dir.clone(), dir.join("jscpd-badge.svg"))

--- a/rust/crates/cpd-reporter/src/console.rs
+++ b/rust/crates/cpd-reporter/src/console.rs
@@ -55,6 +55,9 @@ impl Reporter for ConsoleReporter {
                 )
             );
         });
+        if let Some(summary) = ctx.summary {
+            crate::summary_render::print_summary(summary, &self.style);
+        }
         Ok(())
     }
 }
@@ -78,6 +81,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &one_clone_stats(),
             duration: Duration::ZERO,
+            summary: None,
         };
         assert!(
             reporter

--- a/rust/crates/cpd-reporter/src/console_full.rs
+++ b/rust/crates/cpd-reporter/src/console_full.rs
@@ -151,6 +151,9 @@ impl Reporter for ConsoleFullReporter {
                 println!();
             },
         );
+        if let Some(summary) = ctx.summary {
+            crate::summary_render::print_summary(summary, &self.style);
+        }
         Ok(())
     }
 }
@@ -224,6 +227,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &one_clone_stats(),
             duration: Duration::ZERO,
+            summary: None,
         };
         let result = reporter.report(&[make_clone_no_blame()], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok());
@@ -236,6 +240,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &one_clone_stats(),
             duration: Duration::ZERO,
+            summary: None,
         };
         let result = reporter.report(&[make_clone_with_blame()], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok());

--- a/rust/crates/cpd-reporter/src/context.rs
+++ b/rust/crates/cpd-reporter/src/context.rs
@@ -1,4 +1,5 @@
 use cpd_core::models::Statistics;
+use cpd_core::summary::Summary;
 use std::time::Duration;
 
 /// Context for reporting that includes statistics and timing information.
@@ -11,12 +12,24 @@ pub struct ReportContext<'a> {
     pub stats: &'a Statistics,
     /// Time taken for clone detection
     pub duration: Duration,
+    /// Opt-in codebase summary (`--summary`); None when disabled.
+    pub summary: Option<&'a Summary>,
 }
 
 impl<'a> ReportContext<'a> {
     /// Creates a new ReportContext with the given statistics and duration.
     pub fn new(stats: &'a Statistics, duration: Duration) -> Self {
-        Self { stats, duration }
+        Self {
+            stats,
+            duration,
+            summary: None,
+        }
+    }
+
+    /// Attach an opt-in codebase summary.
+    pub fn with_summary(mut self, summary: Option<&'a Summary>) -> Self {
+        self.summary = summary;
+        self
     }
 }
 

--- a/rust/crates/cpd-reporter/src/html.rs
+++ b/rust/crates/cpd-reporter/src/html.rs
@@ -170,6 +170,7 @@ mod tests {
         let ctx = ReportContext {
             stats,
             duration: Duration::ZERO,
+            summary: None,
         };
         reporter.report(clones, &ctx, &dir).unwrap();
         std::fs::read_to_string(dir.join("jscpd-report.html")).unwrap()

--- a/rust/crates/cpd-reporter/src/json_reporter.rs
+++ b/rust/crates/cpd-reporter/src/json_reporter.rs
@@ -104,10 +104,16 @@ impl Reporter for JsonReporter {
             .map(|c| clone_to_dup(c, self.blame, &mut file_cache))
             .collect();
 
-        let value = json!({
+        let mut value = json!({
             "statistics": ctx.stats,
             "duplicates": duplicates,
         });
+        // Additive only: the key is absent unless --summary was requested,
+        // so the report schema is unchanged for existing consumers.
+        if let Some(summary) = ctx.summary {
+            value["summary"] =
+                serde_json::to_value(summary).map_err(|e| ReporterError::Format(e.to_string()))?;
+        }
 
         let content = serde_json::to_string_pretty(&value)
             .map_err(|e| ReporterError::Format(e.to_string()))?;
@@ -212,6 +218,7 @@ mod tests {
         let ctx = ReportContext {
             stats,
             duration: Duration::ZERO,
+            summary: None,
         };
         reporter.report(clones, &ctx, &dir).unwrap();
         std::fs::read_to_string(dir.join("jscpd-report.json")).unwrap()

--- a/rust/crates/cpd-reporter/src/lib.rs
+++ b/rust/crates/cpd-reporter/src/lib.rs
@@ -11,6 +11,7 @@ pub mod reporter;
 pub mod sarif;
 pub mod shared;
 pub mod silent;
+pub mod summary_render;
 pub mod threshold;
 pub mod xcode;
 pub mod xml_reporter;

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -478,6 +478,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &stats,
             duration: Duration::ZERO,
+            summary: None,
         };
         reporter.report(clones, &ctx, &dir).unwrap();
         let content = std::fs::read_to_string(dir.join("jscpd-report.sarif")).unwrap();

--- a/rust/crates/cpd-reporter/src/silent.rs
+++ b/rust/crates/cpd-reporter/src/silent.rs
@@ -73,6 +73,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &any_stats(),
             duration: Duration::ZERO,
+            summary: None,
         };
         let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok());
@@ -101,6 +102,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &stats,
             duration: Duration::ZERO,
+            summary: None,
         };
         let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok());

--- a/rust/crates/cpd-reporter/src/summary_render.rs
+++ b/rust/crates/cpd-reporter/src/summary_render.rs
@@ -1,0 +1,222 @@
+// summary_render.rs — console rendering for the opt-in `--summary` block.
+
+use crate::shared::Style;
+use cpd_core::summary::{FileSummary, FolderSummary, Summary};
+
+/// Human-readable byte size: 999 → "999", 12_345 → "12.1K", 3_400_000 → "3.2M".
+pub fn human_size(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    let b = bytes as f64;
+    if b < KB {
+        format!("{bytes}")
+    } else if b < KB * KB {
+        format!("{:.1}K", b / KB)
+    } else {
+        format!("{:.1}M", b / (KB * KB))
+    }
+}
+
+/// Duplication percentage for display, clamped to 100: overlapping clones can
+/// push the raw fragment-line sum past the file's line count.
+fn dup_percent(duplicated_lines: u64, lines: u64) -> String {
+    if lines == 0 {
+        "0.0".to_string()
+    } else {
+        let pct = duplicated_lines as f64 / lines as f64 * 100.0;
+        format!("{:.1}", pct.min(100.0))
+    }
+}
+
+fn file_row(f: &FileSummary) -> [String; 6] {
+    [
+        f.tokens.to_string(),
+        f.lines.to_string(),
+        human_size(f.bytes),
+        f.complexity.to_string(),
+        dup_percent(f.duplicated_lines, f.lines),
+        f.path.clone(),
+    ]
+}
+
+fn folder_row(f: &FolderSummary) -> [String; 6] {
+    let mean_cx = if f.files > 0 {
+        f.complexity / f.files
+    } else {
+        0
+    };
+    [
+        f.files.to_string(),
+        f.tokens.to_string(),
+        f.lines.to_string(),
+        human_size(f.bytes),
+        mean_cx.to_string(),
+        f.path.clone(),
+    ]
+}
+
+/// Print rows with right-aligned numeric columns and the path last.
+fn print_aligned(headers: [&str; 6], rows: &[[String; 6]], style: &Style) {
+    let mut widths: [usize; 6] = headers.map(str::len);
+    for row in rows {
+        for (w, cell) in widths.iter_mut().zip(row.iter()) {
+            *w = (*w).max(cell.len());
+        }
+    }
+    let header_line = headers
+        .iter()
+        .enumerate()
+        .map(|(i, h)| {
+            if i == 5 {
+                h.to_string()
+            } else {
+                format!("{h:>width$}", width = widths[i])
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("  ");
+    println!("  {}", style.dim(&header_line));
+    for row in rows {
+        let line = row
+            .iter()
+            .enumerate()
+            .map(|(i, cell)| {
+                if i == 5 {
+                    cell.clone()
+                } else {
+                    format!("{cell:>width$}", width = widths[i])
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("  ");
+        println!("  {line}");
+    }
+}
+
+/// Full console rendering, appended after the normal reporter output.
+pub fn print_summary(summary: &Summary, style: &Style) {
+    println!();
+    println!(
+        "{} {}",
+        style.bold("Summary"),
+        style.dim(&format!(
+            "(by {}; {} files, {} folders analyzed)",
+            summary.by, summary.total_files, summary.total_folders
+        ))
+    );
+    if !summary.files.is_empty() {
+        println!("{}", style.bold("Top files:"));
+        let rows: Vec<[String; 6]> = summary.files.iter().map(file_row).collect();
+        print_aligned(
+            ["TOKENS", "LINES", "SIZE", "CX", "DUP%", "PATH"],
+            &rows,
+            style,
+        );
+    }
+    if !summary.folders.is_empty() {
+        println!("{}", style.bold("Top folders:"));
+        let rows: Vec<[String; 6]> = summary.folders.iter().map(folder_row).collect();
+        print_aligned(
+            ["FILES", "TOKENS", "LINES", "SIZE", "CX", "PATH"],
+            &rows,
+            style,
+        );
+    }
+}
+
+/// Compact rendering for the `ai` reporter: one line per entry, no table
+/// padding, minimal punctuation — designed to cost as few LLM tokens as
+/// possible while keeping every metric available.
+pub fn print_summary_compact(summary: &Summary) {
+    println!(
+        "Summary by {} ({} files, {} folders):",
+        summary.by, summary.total_files, summary.total_folders
+    );
+    println!("files (tokens/lines/size/cx/dup%):");
+    for f in &summary.files {
+        println!(
+            "{} {}/{}/{}/{}/{}%",
+            f.path,
+            f.tokens,
+            f.lines,
+            human_size(f.bytes),
+            f.complexity,
+            dup_percent(f.duplicated_lines, f.lines),
+        );
+    }
+    println!("folders (files/tokens/lines/size):");
+    for f in &summary.folders {
+        println!(
+            "{} {}/{}/{}/{}",
+            f.path,
+            f.files,
+            f.tokens,
+            f.lines,
+            human_size(f.bytes),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cpd_core::summary::SummaryMetric;
+
+    #[test]
+    fn human_size_units() {
+        assert_eq!(human_size(999), "999");
+        assert_eq!(human_size(2048), "2.0K");
+        assert_eq!(human_size(3 * 1024 * 1024), "3.0M");
+    }
+
+    #[test]
+    fn dup_percent_handles_zero_lines() {
+        assert_eq!(dup_percent(5, 0), "0.0");
+        assert_eq!(dup_percent(25, 100), "25.0");
+        assert_eq!(dup_percent(150, 100), "100.0", "clamped at 100");
+    }
+
+    fn sample_summary() -> Summary {
+        Summary {
+            by: SummaryMetric::Tokens,
+            files: vec![FileSummary {
+                path: "src/a.js".to_string(),
+                format: "javascript".to_string(),
+                lines: 100,
+                tokens: 500,
+                bytes: 2048,
+                duplicated_lines: 10,
+                duplicated_tokens: 50,
+                complexity: 7,
+            }],
+            folders: vec![FolderSummary {
+                path: "src".to_string(),
+                files: 1,
+                lines: 100,
+                tokens: 500,
+                bytes: 2048,
+                duplicated_lines: 10,
+                complexity: 7,
+            }],
+            total_files: 1,
+            total_folders: 1,
+        }
+    }
+
+    #[test]
+    fn print_summary_does_not_panic() {
+        print_summary(&sample_summary(), &Style::new(true));
+    }
+
+    #[test]
+    fn print_summary_compact_does_not_panic() {
+        print_summary_compact(&sample_summary());
+    }
+
+    #[test]
+    fn folder_row_uses_mean_complexity() {
+        let mut folder = sample_summary().folders.remove(0);
+        folder.files = 2;
+        folder.complexity = 9;
+        assert_eq!(folder_row(&folder)[4], "4");
+    }
+}

--- a/rust/crates/cpd-reporter/src/threshold.rs
+++ b/rust/crates/cpd-reporter/src/threshold.rs
@@ -55,6 +55,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &stats_with_pct(pct, pct as u64),
             duration: Duration::ZERO,
+            summary: None,
         };
         reporter.report(&[], &ctx, &PathBuf::from("/tmp"))
     }
@@ -95,6 +96,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &stats_with_pct(99.9, 99),
             duration: Duration::ZERO,
+            summary: None,
         };
         let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok(), "no threshold must always return Ok");
@@ -108,6 +110,7 @@ mod tests {
         let ctx = ReportContext {
             stats: &stats_with_pct(100.0, 100),
             duration: Duration::ZERO,
+            summary: None,
         };
         let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok(), "silent reporter must always return Ok");

--- a/rust/crates/cpd-reporter/tests/blame_integration.rs
+++ b/rust/crates/cpd-reporter/tests/blame_integration.rs
@@ -107,6 +107,7 @@ fn run_blame_reporter(
     let ctx = ReportContext {
         stats: &make_stats(),
         duration: Duration::ZERO,
+        summary: None,
     };
     reporter.report(&[clone], &ctx, &dir).unwrap();
     (dir, reporter)

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -269,6 +269,18 @@ pub struct Cli {
     #[arg(long, default_value = "0")]
     pub min_duplicated_lines: f64,
 
+    /// Print a codebase summary: top files and folders by tokens, lines, size, complexity
+    #[arg(long)]
+    pub summary: bool,
+
+    /// Number of entries in each summary top list (default: 10)
+    #[arg(long, value_name = "N")]
+    pub summary_top: Option<usize>,
+
+    /// Summary sort metric: tokens, lines, size, complexity (default: tokens)
+    #[arg(long, value_name = "METRIC")]
+    pub summary_by: Option<String>,
+
     /// Do not write detection progress and result to console
     #[arg(long, short = 's')]
     pub silent: bool,
@@ -330,6 +342,11 @@ pub struct ConfigFile {
     #[serde(alias = "no-tips")]
     pub no_tips: Option<bool>,
     pub silent: Option<bool>,
+    pub summary: Option<bool>,
+    #[serde(alias = "summary-top")]
+    pub summary_top: Option<usize>,
+    #[serde(alias = "summary-by")]
+    pub summary_by: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -53,6 +53,9 @@ struct MergedConfig {
     no_tips: bool,
     silent: bool,
     pattern: Option<String>,
+    summary: bool,
+    summary_top: usize,
+    summary_by: String,
 }
 
 impl MergedConfig {
@@ -89,6 +92,9 @@ impl MergedConfig {
             no_tips: opts.no_tips,
             silent: opts.silent,
             pattern: opts.pattern.clone(),
+            summary: opts.summary,
+            summary_top: opts.summary_top,
+            summary_by: opts.summary_by.to_string(),
         }
     }
 }
@@ -153,6 +159,13 @@ fn main() {
                     mode_str
                 );
             }
+        }
+    }
+
+    // CLI summary-by validation: warn on invalid value (parallels --mode)
+    if let Some(metric) = cli.summary_by.as_deref() {
+        if let Err(e) = metric.parse::<cpd_core::summary::SummaryMetric>() {
+            eprintln!("Warning: --summary-by: {} (defaulting to tokens)", e);
         }
     }
 
@@ -281,6 +294,21 @@ fn main() {
     // Capture elapsed time (after blame so it's included)
     let elapsed = timer.elapsed();
 
+    // Opt-in codebase summary. Computed after detection from data already in
+    // memory; when --summary is off this is a no-op and detection output is
+    // byte-identical to previous releases.
+    let summary = if opts.summary {
+        Some(cpd_core::summary::compute_summary(
+            &run_result.sources,
+            &clones,
+            opts.summary_top,
+            opts.summary_by,
+            |id| display_source_path(id, opts.absolute, &canonical_roots),
+        ))
+    } else {
+        None
+    };
+
     // Reporter options
     let reporter_opts = ReporterOptions {
         output_dir: opts.output_dir.clone(),
@@ -340,7 +368,7 @@ fn main() {
                     }
                 };
 
-            let ctx = ReportContext::new(&statistics, elapsed);
+            let ctx = ReportContext::new(&statistics, elapsed).with_summary(summary.as_ref());
             match reporter.report(&clones, &ctx, &opts.output_dir) {
                 Ok(()) => {}
                 Err(cpd_reporter::reporter::ReporterError::ThresholdExceeded {
@@ -422,6 +450,22 @@ fn make_path_absolute(source_id: &mut String) {
             *source_id = abs.to_string_lossy().into_owned();
         }
     }
+}
+
+/// Display path for a summary entry: the same relativization applied to clone
+/// fragments in `relativize_to_scan_root`, so per-file duplication matching
+/// works on identical strings.
+fn display_source_path(id: &str, absolute: bool, canonical_roots: &[std::path::PathBuf]) -> String {
+    if absolute {
+        return id.to_string();
+    }
+    let path = std::path::Path::new(id);
+    for root in canonical_roots {
+        if let Ok(stripped) = path.strip_prefix(root) {
+            return strip_dot_prefix(&stripped.to_string_lossy());
+        }
+    }
+    strip_dot_prefix(id)
 }
 
 /// Strip a leading `./` or `.\` component so paths are not dot-prefixed.

--- a/rust/crates/cpd/src/options.rs
+++ b/rust/crates/cpd/src/options.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use cpd_core::summary::SummaryMetric;
 use cpd_tokenizer::tokenizer::Mode;
 
 #[derive(Debug, Clone)]
@@ -34,6 +35,9 @@ pub struct Options {
     pub skip_local: bool,
     pub no_tips: bool,
     pub silent: bool,
+    pub summary: bool,
+    pub summary_top: usize,
+    pub summary_by: SummaryMetric,
     pub pattern: Option<String>,
     #[allow(dead_code)]
     pub list: bool,
@@ -144,6 +148,15 @@ impl Options {
             skip_local: cli.skip_local || config.skip_local.unwrap_or(false),
             no_tips: cli.no_tips || config.no_tips.unwrap_or(false) || std::env::var("CI").is_ok(),
             silent: cli.silent || config.silent.unwrap_or(false),
+            summary: cli.summary || config.summary.unwrap_or(false),
+            summary_top: cli.summary_top.or(config.summary_top).unwrap_or(10),
+            // Invalid metric values are warned about in main() (like --mode).
+            summary_by: cli
+                .summary_by
+                .as_deref()
+                .or(config.summary_by.as_deref())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_default(),
             pattern: cli.pattern.clone().or(config.pattern.clone()),
             list: cli.list,
         }

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -860,3 +860,140 @@ fn cross_formats_shown_in_debug_output() {
         "--debug must show the configured group, got: {stdout}"
     );
 }
+
+// --- --summary ---
+
+fn run_summary(extra_args: &[&str]) -> Output {
+    let dir = cross_formats_fixture_dir();
+    let mut args: Vec<&str> = vec![
+        "--min-tokens",
+        "20",
+        "--min-lines",
+        "1",
+        "--no-colors",
+        "--no-tips",
+    ];
+    args.extend_from_slice(extra_args);
+    let dir_str = dir.to_str().unwrap();
+    args.push(dir_str);
+    run_cpd(args).expect("cpd binary must exist")
+}
+
+#[test]
+fn summary_flag_prints_summary_block() {
+    let output = run_summary(&["--summary", "--reporters", "console"]);
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("Summary") && stdout.contains("Top files:"),
+        "--summary must print the summary block, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Top folders:"),
+        "--summary must print the folder rollup, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("a.ts"),
+        "summary must list scanned files, got: {stdout}"
+    );
+}
+
+#[test]
+fn summary_absent_by_default() {
+    let output = run_summary(&["--reporters", "console"]);
+    let stdout = stdout_of(&output);
+    assert!(
+        !stdout.contains("Top files:"),
+        "summary must be opt-in; default output changed: {stdout}"
+    );
+}
+
+#[test]
+fn summary_ai_reporter_prints_compact_block() {
+    let output = run_summary(&["--summary", "--reporters", "ai"]);
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("files (tokens/lines/size/cx/dup%):"),
+        "ai reporter must print the compact summary, got: {stdout}"
+    );
+}
+
+#[test]
+fn summary_json_key_present_only_when_enabled() {
+    let out_on = std::env::temp_dir().join("cpd-summary-json-on");
+    let _ = std::fs::remove_dir_all(&out_on);
+    run_summary(&[
+        "--summary",
+        "--reporters",
+        "json",
+        "--output",
+        out_on.to_str().unwrap(),
+    ]);
+    let report = std::fs::read_to_string(out_on.join("jscpd-report.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    let summary = parsed
+        .get("summary")
+        .expect("--summary must add a summary key to the JSON report");
+    assert!(summary.get("files").is_some(), "summary.files expected");
+    assert!(summary.get("folders").is_some(), "summary.folders expected");
+    assert!(
+        summary.get("totalFiles").is_some(),
+        "summary.totalFiles expected (camelCase)"
+    );
+
+    let out_off = std::env::temp_dir().join("cpd-summary-json-off");
+    let _ = std::fs::remove_dir_all(&out_off);
+    run_summary(&["--reporters", "json", "--output", out_off.to_str().unwrap()]);
+    let report = std::fs::read_to_string(out_off.join("jscpd-report.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert!(
+        parsed.get("summary").is_none(),
+        "without --summary the JSON schema must be unchanged"
+    );
+}
+
+#[test]
+fn summary_by_invalid_value_warns_and_defaults() {
+    let output = run_summary(&[
+        "--summary",
+        "--summary-by",
+        "bogus",
+        "--reporters",
+        "console",
+    ]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("summary-by") && stderr.contains("bogus"),
+        "invalid --summary-by must warn, got: {stderr}"
+    );
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("(by tokens;"),
+        "invalid metric must fall back to tokens, got: {stdout}"
+    );
+}
+
+#[test]
+fn summary_top_limits_file_and_folder_lists() {
+    let output = run_summary(&["--summary", "--summary-top", "1", "--reporters", "console"]);
+    let stdout = stdout_of(&output);
+    let rows_after = |heading: &str| {
+        stdout
+            .split(heading)
+            .nth(1)
+            .unwrap_or("")
+            .lines()
+            .skip(2) // empty remainder of the heading line, then the column header
+            .take_while(|l| l.starts_with("  "))
+            .count()
+    };
+    assert_eq!(
+        rows_after("Top files:"),
+        1,
+        "--summary-top 1 must list exactly one file, got: {stdout}"
+    );
+    assert_eq!(
+        rows_after("Top folders:"),
+        1,
+        "--summary-top 1 must list exactly one folder, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Implements the Rust part of #934.

## What

New opt-in codebase summary appended to the run output — a refactoring-hotspot overview built from statistics the detector already collects:

- `--summary` — enable the block (`"summary": true` in `.jscpd.json`)
- `--summary-top <n>` — entries per list, default 10 (`summaryTop`)
- `--summary-by tokens|lines|size|complexity` — ranking metric, default tokens (`summaryBy`; invalid values warn and fall back, like `--mode`)

```
Summary (by tokens; 321 files, 129 folders analyzed)
Top files:
  TOKENS  LINES   SIZE  CX   DUP%  PATH
    7688    233  10.3K   2   96.1  clike/file2.java
    7376    221   9.8K   2  100.0  clike/file1.java
    3020    416  12.3K  26   90.6  rust/file1.rs
Top folders:
  FILES  TOKENS  LINES   SIZE  CX  PATH
     16   22639   1426  50.6K   3  clike
     18   11680   2522  72.7K  12  javascript
      2    5128    717  21.0K  21  rust
```

- **Top files**: strictly top-N by the chosen metric; every row carries all metrics, so other lenses are one `--summary-by` away.
- **Top folders**: direct-parent aggregation — each file counted exactly once, rows directly comparable. `totalFiles`/`totalFolders` always expose pre-truncation counts (no silent truncation).
- **CX**: language-agnostic cyclomatic estimate — 1 + decision-point tokens (`if`, `elif`/`elsif`/`elseif`, `unless`, `for`, `foreach`, `while`, `until`, `case`, `cond`, `when`, `catch`, `rescue`, `except`, `and`, `or`, `andalso`, `orelse`, `&&`, `||`, `?`, `??`), matched case-insensitively so SQL/PL/SQL/Fortran/COBOL/BASIC count. Verified across all 157 fixture languages.
- **DUP%**: share of the file's lines covered by clone fragments (both fragments attributed; display capped at 100%).

## Reporter integration

- `console` / `console-full` — aligned tables after the normal output
- `ai` — compact one-line-per-entry variant for LLM/agent pipelines
- `json` — additive `summary` key; **absent when the flag is off**, so the report schema is unchanged for existing consumers

## Performance

Zero hot-path cost: the only unconditional change is storing the file's byte size (already known from the mmap). All summary computation runs post-detection, only when `--summary` is set, over `RunResult.sources` already in memory.

hyperfine A/B vs a master-built baseline binary (packages/ + rust/crates, 8 runs): **39.8ms ± 1.5 (this PR, no flag) vs 40.2ms ± 1.6 (baseline)** — identical within noise; `--summary` adds ~2ms. Confirmed on the full repo tree as well.

## Implementation

- `cpd-core/src/summary.rs` (new) — `Summary`/`FileSummary`/`FolderSummary` models + `compute_summary` (camelCase serde), 14 unit tests
- `cpd-reporter/src/summary_render.rs` (new) — table + compact renderers
- `ReportContext` gains an optional `summary` reference; `ReportContext::new` is source-compatible, `with_summary` added
- `SourceFile` gains a serde-defaulted `bytes` field
- CLI flags + config fields + `--debug` output in the `cpd` crate; 6 new integration tests

Full workspace suite green locally (Rust tests are not in PR CI): `cargo test`, `cargo clippy` (no new warnings), `cargo fmt`.

## Docs

`docs/rust.md` (options table + Summary section), `docs/ai-ready.md`, root `README.md`, `rust/CHANGELOG.md` under 5.0.16.

## Follow-ups (tracked in #934)

- Summary section in the HTML report (askama template)
- TypeScript parity port

Refs #934

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/935)
<!-- Reviewable:end -->
