### PR TITLE
chore(rust): bump toolchain to 1.97 and oxc crates to 0.144

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.97"
 
       - name: Cache Cargo registry and target
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2

--- a/.github/workflows/npm-rust-publish.yml
+++ b/.github/workflows/npm-rust-publish.yml
@@ -142,7 +142,7 @@ jobs:
         if: steps.platform-package.outputs.published != 'true'
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.97"
           targets: ${{ matrix.target.rustTarget }}
 
       - name: Cache Cargo registry and target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.97"
           components: clippy
 
       - name: Cache Cargo registry and target

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.97"
           components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -173,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,16 +264,15 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
- "rustversion",
- "ryu",
  "static_assertions",
+ "zmij",
 ]
 
 [[package]]
@@ -632,9 +637,9 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -678,35 +683,23 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc-miette"
-version = "2.7.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
+checksum = "330e07b3807046e0afa8fcc94f1fe976e93831b370d148bfe1168cb53da1b913"
 dependencies = [
- "cfg-if",
+ "bytecount",
+ "memchr",
  "owo-colors",
- "oxc-miette-derive",
  "textwrap",
- "thiserror",
  "unicode-segmentation",
  "unicode-width",
 ]
 
 [[package]]
-name = "oxc-miette-derive"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "oxc_allocator"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e900ccc598726485709ccee5caf11687db0fdce7a7f6ab5ca67ab99036347fd"
+checksum = "9262c7bbd58c8c32c2c60d1a7b6c274cd2aeaff1b726a2fb86081b75084698cb"
 dependencies = [
  "allocator-api2",
  "hashbrown",
@@ -716,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85f2b08a659b819c31ae798a4d8ed43d5d3e4b5d3c24fe244599ed602401c16"
+checksum = "e8134809b665d524d9a0ddeee87a5d3602776aa2410a10a0439fd25eeb594a5d"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -734,21 +727,21 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3baa8c4432cc17e36cb2aff37fc9e57e7defa5d0cf8fd4127d68ca474dd5edd"
+checksum = "ac120c6863a9d036c78a42a5e4d2f58bb27c5df795d61d904f6e19e48c681a37"
 dependencies = [
  "phf",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976e4c8e1874fd007c4e9a729ac0975e15cbc6b715b620cbb9616b73a30828be"
+checksum = "4a57626cd6ef87f5173110a301868e3c438fd8e0576f489d9a61540ef133f686"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -758,48 +751,50 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315b3a6c1560d176796921441fb91dc45ef3810fb2b98fedc040162f3a3a0d8"
+checksum = "2a71efea56db93d3ce9e88e1d9f74f6d50fc2b06092444cdd08579f5827fd8db"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a729e6dbb517aec94346685e769f960dbdd335523cf9c844ecca7731beb15e2c"
+checksum = "e5ff8638533094ecdcd38a63930c003c261d81650e4531c3bc805c797aec2a52"
 dependencies = [
  "cow-utils",
+ "memchr",
  "oxc-miette",
  "percent-encoding",
+ "smallvec",
 ]
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f803b86d86fd830075a6a7f7b84c59e93131367738c55b4e7526669eeb0cc70"
+checksum = "77c7a326f49f06da37affdcad2fb3ebab46ac4ada8953a428f7cbd04e5cc9e6e"
 dependencies = [
- "cow-utils",
+ "dragonbox_ecma",
+ "itoa",
  "num-bigint",
  "num-traits",
- "oxc_allocator",
  "oxc_ast",
- "oxc_regular_expression",
+ "oxc_data_structures",
  "oxc_span",
  "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_estree"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad19053743d90699386a7783562185cc88a4a240a02406e005225a9ea07e4f3a"
+checksum = "8275fcb9674a1c320f0bdbc2f534ba9bb09fcb8b1c9fe306c9595d262a06bfcb"
 
 [[package]]
 name = "oxc_index"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
 dependencies = [
  "nonmax",
  "serde",
@@ -807,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5983baba9d73d319214c3d0492987f4b47cb75b916b0e428adb3b3695a728ae"
+checksum = "d13016de81370106ea4065cfabe4a278dc09e82523cfe22bb6a8ab8e993b4c3a"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -831,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4b6c29740a9de457f498b4e07c60af2c3acdc93cdc83a87b51f9c18b34b5"
+checksum = "c375b89d88ec03301b0e62528715699551871861197aa39148e95a1422e1ae9b"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -848,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92507cc30d1b8abd38fc1368ef90a33d573e746a048adefaae7434ad1be91ff"
+checksum = "abd732008dbfb09984106925f7ff7268687c8020b89bd7ee0f0b695c5bb07950"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -862,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8413fd0d68722180b2a3568a73920330ae2674975336b35a9cceb691b6f3f2"
+checksum = "e1d2ccb0f5aa4da9fc98ef70f59553c2779e28e064a8b271fcb1e88c11a63607"
 dependencies = [
  "compact_str",
  "hashbrown",
@@ -874,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.133.0"
+version = "0.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8ca91f5e39d6db686f3a75bdf01e2a44c05d24a554d22470073dd79462877b"
+checksum = "15ff0e987ab15a71dae36fd544b9859513e76639e2cc6c5e25895081162755b1"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -900,9 +895,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -911,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -921,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -934,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -1132,6 +1127,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -232,7 +232,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
                         if map.tokens.len() < min_tokens {
                             continue;
                         }
-                        let map_id = format!("{}:{}", &id, &map.format);
+                        let map_id = format!("{}:{}", id, map.format);
                         // For sub-formats, create a synthetic SourceFile with detection
                         // tokens converted to display tokens so statistics per-format
                         // counts are correct.

--- a/rust/crates/cpd-finder/tests/cross_formats_integration.rs
+++ b/rust/crates/cpd-finder/tests/cross_formats_integration.rs
@@ -1,6 +1,9 @@
 use cpd_finder::orchestrate::{RunConfig, run};
 use cpd_tokenizer::tokenizer::Mode;
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 fn setup_temp_dir(suffix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("cpd-cross-formats-{}", suffix));
@@ -52,7 +55,7 @@ fn untyped_js() -> &'static str {
 "#
 }
 
-fn write_pair(dir: &PathBuf) {
+fn write_pair(dir: &Path) {
     fs::write(dir.join("a.ts"), typed_ts()).unwrap();
     fs::write(dir.join("b.js"), untyped_js()).unwrap();
 }

--- a/rust/crates/cpd-finder/tests/ignore_pattern_integration.rs
+++ b/rust/crates/cpd-finder/tests/ignore_pattern_integration.rs
@@ -8,7 +8,7 @@
 
 use cpd_finder::orchestrate::{RunConfig, run};
 use cpd_tokenizer::tokenizer::{Mode, TokenizeOptions, code_ignore_ranges, tokenize_to_detection};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
@@ -18,7 +18,7 @@ fn ignore_pattern_dir() -> PathBuf {
     fixtures_dir().join("ignore_pattern")
 }
 
-fn skip_if_missing(dir: &PathBuf) -> bool {
+fn skip_if_missing(dir: &Path) -> bool {
     if !dir.exists() {
         eprintln!("fixture dir not found, skipping");
         return true;

--- a/rust/crates/cpd-finder/tests/skip_local_integration.rs
+++ b/rust/crates/cpd-finder/tests/skip_local_integration.rs
@@ -1,6 +1,9 @@
 use cpd_finder::orchestrate::{RunConfig, run};
 use cpd_tokenizer::tokenizer::Mode;
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 fn setup_temp_dir(suffix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("cpd-skip-local-{}", suffix));
@@ -34,7 +37,7 @@ fn skip_local_config(paths: Vec<PathBuf>) -> RunConfig {
     }
 }
 
-fn write_pair(dir_a: &PathBuf, dir_b: &PathBuf) {
+fn write_pair(dir_a: &Path, dir_b: &Path) {
     fs::write(dir_a.join("file_a.js"), duplicate_js()).unwrap();
     fs::write(dir_b.join("file_b.js"), duplicate_js()).unwrap();
 }

--- a/rust/crates/cpd-reporter/src/html.rs
+++ b/rust/crates/cpd-reporter/src/html.rs
@@ -159,7 +159,7 @@ mod tests {
     use super::*;
     use crate::context::ReportContext;
     use crate::reporter::ReporterOptions;
-    use crate::shared::fixtures::{empty_ctx, empty_stats, make_clone_with_locations, tmp_dir};
+    use crate::shared::fixtures::{empty_stats, tmp_dir};
     use cpd_core::models::{CpdClone, Fragment, Location, Statistics};
     use std::time::Duration;
 

--- a/rust/crates/cpd-reporter/src/reporter.rs
+++ b/rust/crates/cpd-reporter/src/reporter.rs
@@ -241,9 +241,9 @@ mod tests {
         impl Reporter for TestReporter {
             fn report(
                 &self,
-                clones: &[CpdClone],
+                _clones: &[CpdClone],
                 ctx: &ReportContext,
-                output_dir: &Path,
+                _output_dir: &Path,
             ) -> Result<(), ReporterError> {
                 // Verify we can access timing data from context
                 let _duration = ctx.duration;
@@ -256,7 +256,6 @@ mod tests {
             }
         }
 
-        let opts = ReporterOptions::new(PathBuf::from("/tmp"));
         let reporter = TestReporter;
         let stats = empty_stats();
         let ctx = ReportContext::new(&stats, Duration::from_millis(100));

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -265,7 +265,7 @@ mod tests {
     use super::*;
     use crate::context::ReportContext;
     use crate::reporter::ReporterOptions;
-    use crate::shared::fixtures::{empty_ctx, empty_stats, stats_with_pct, tmp_dir};
+    use crate::shared::fixtures::{empty_ctx, stats_with_pct, tmp_dir};
     use cpd_core::models::{BlameEntry, CpdClone, Fragment, Location};
     use std::time::Duration;
 

--- a/rust/crates/cpd-reporter/src/summary_render.rs
+++ b/rust/crates/cpd-reporter/src/summary_render.rs
@@ -39,11 +39,7 @@ fn file_row(f: &FileSummary) -> [String; 6] {
 }
 
 fn folder_row(f: &FolderSummary) -> [String; 6] {
-    let mean_cx = if f.files > 0 {
-        f.complexity / f.files
-    } else {
-        0
-    };
+    let mean_cx = f.complexity.checked_div(f.files).unwrap_or(0);
     [
         f.files.to_string(),
         f.tokens.to_string(),

--- a/rust/crates/cpd-reporter/src/xcode.rs
+++ b/rust/crates/cpd-reporter/src/xcode.rs
@@ -48,21 +48,11 @@ impl Reporter for XcodeReporter {
 mod tests {
     use super::*;
     use crate::assert_empty_report_ok;
-    use crate::context::ReportContext;
+
     use crate::reporter::ReporterOptions;
     use crate::shared::fixtures::empty_ctx;
-    use cpd_core::models::{CpdClone, Fragment, Location, StatRow, Statistics};
-    use std::collections::HashMap;
+    use cpd_core::models::{CpdClone, Fragment, Location};
     use std::path::PathBuf;
-    use std::time::Duration;
-
-    fn empty_stats() -> Statistics {
-        Statistics {
-            total: StatRow::default(),
-            formats: HashMap::new(),
-            detection_date: "2026-01-01".to_string(),
-        }
-    }
 
     assert_empty_report_ok!(xcode_returns_ok_on_empty_clones, XcodeReporter);
 

--- a/rust/crates/cpd-reporter/src/xml_reporter.rs
+++ b/rust/crates/cpd-reporter/src/xml_reporter.rs
@@ -150,11 +150,10 @@ impl Reporter for XmlReporter {
 mod tests {
     use super::*;
     use crate::assert_empty_report_ok;
-    use crate::context::ReportContext;
+
     use crate::reporter::ReporterOptions;
-    use crate::shared::fixtures::{empty_ctx, empty_stats, tmp_dir};
+    use crate::shared::fixtures::{empty_ctx, tmp_dir};
     use cpd_core::models::{CpdClone, Fragment, Location};
-    use std::time::Duration;
 
     assert_empty_report_ok!(empty_clones_produces_valid_xml, XmlReporter);
 

--- a/rust/crates/cpd-reporter/tests/reporters_integration.rs
+++ b/rust/crates/cpd-reporter/tests/reporters_integration.rs
@@ -12,7 +12,11 @@
 use cpd_core::models::{CpdClone, Fragment, Location, StatRow, Statistics};
 use cpd_reporter::context::ReportContext;
 use cpd_reporter::reporter::{Reporter, ReporterOptions, create_reporter};
-use std::{collections::HashMap, path::PathBuf, time::Duration};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 // ============================================================================
 // Fixture Data - Sample clone detection results
@@ -103,7 +107,7 @@ fn create_test_output_dir(test_name: &str) -> PathBuf {
 }
 
 /// Create a clone backed by real files on disk so reporters can read snippets.
-fn make_test_clone_with_real_files(dir: &PathBuf) -> CpdClone {
+fn make_test_clone_with_real_files(dir: &Path) -> CpdClone {
     let code = format!(
         "function hello() {{\n  console.log(\"{}\");\n  return 42;\n}}\n",
         SNIPPET_MARKER
@@ -151,7 +155,7 @@ fn make_test_clone_with_real_files(dir: &PathBuf) -> CpdClone {
     }
 }
 
-fn assert_file_exists(output_dir: &PathBuf, filename: &str) {
+fn assert_file_exists(output_dir: &Path, filename: &str) {
     let file_path = output_dir.join(filename);
     assert!(
         file_path.exists(),
@@ -161,7 +165,7 @@ fn assert_file_exists(output_dir: &PathBuf, filename: &str) {
     );
 }
 
-fn read_output_file(output_dir: &PathBuf, filename: &str) -> String {
+fn read_output_file(output_dir: &Path, filename: &str) -> String {
     let file_path = output_dir.join(filename);
     std::fs::read_to_string(&file_path)
         .unwrap_or_else(|_| panic!("Failed to read file {:?}", file_path))

--- a/rust/crates/cpd-tokenizer/Cargo.toml
+++ b/rust/crates/cpd-tokenizer/Cargo.toml
@@ -10,12 +10,12 @@ license.workspace = true
 
 [dependencies]
 cpd-core = { version = "0.1.8", path = "../cpd-core" }
-oxc_parser = "0.133"
-oxc_allocator = "0.133"
-oxc_span = "0.133"
-oxc_ast = "0.133"
-oxc_ast_visit = "0.133"
-oxc_syntax = "0.133"
+oxc_parser = "0.144"
+oxc_allocator = "0.144"
+oxc_span = "0.144"
+oxc_ast = "0.144"
+oxc_ast_visit = "0.144"
+oxc_syntax = "0.144"
 log = "0.4"
 regex = "1"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/rust/crates/cpd-tokenizer/src/javascript.rs
+++ b/rust/crates/cpd-tokenizer/src/javascript.rs
@@ -213,7 +213,7 @@ fn parse_with_oxc(source: &str, format: &str, strip_types: bool) -> Option<Vec<T
         .with_config(TokensParserConfig)
         .parse();
 
-    if !parser_return.errors.is_empty() {
+    if !parser_return.diagnostics.is_empty() {
         return None;
     }
 

--- a/rust/crates/cpd-tokenizer/src/razor.rs
+++ b/rust/crates/cpd-tokenizer/src/razor.rs
@@ -111,16 +111,14 @@ fn extract_razor_blocks(source: &str) -> Vec<RazorBlock> {
                     brace_depth += 1;
                     waiting_for_block_brace = false;
                 }
-                '}' => {
-                    if brace_depth > 0 {
-                        brace_depth -= 1;
-                        // Block ended, flush it
-                        if brace_depth == 0 {
-                            if let Some(block) = current_block.take() {
-                                blocks.push(block);
-                            }
-                            in_code = false;
+                '}' if brace_depth > 0 => {
+                    brace_depth -= 1;
+                    // Block ended, flush it
+                    if brace_depth == 0 {
+                        if let Some(block) = current_block.take() {
+                            blocks.push(block);
                         }
+                        in_code = false;
                     }
                 }
                 _ => {}

--- a/rust/crates/cpd-tokenizer/src/ts_strip.rs
+++ b/rust/crates/cpd-tokenizer/src/ts_strip.rs
@@ -13,10 +13,11 @@
 use oxc_ast::ast::{
     Class, ExportDefaultDeclaration, ExportDefaultDeclarationKind, ExportNamedDeclaration,
     Function, ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind, MethodDefinition,
-    Program, PropertyDefinition, TSAsExpression, TSEnumDeclaration, TSInterfaceDeclaration,
-    TSModuleDeclaration, TSNonNullExpression, TSSatisfiesExpression, TSThisParameter,
-    TSTypeAliasDeclaration, TSTypeAnnotation, TSTypeAssertion, TSTypeParameterDeclaration,
-    TSTypeParameterInstantiation, VariableDeclaration, VariableDeclarator,
+    Program, PropertyDefinition, TSAsExpression, TSEnumDeclaration, TSExternalModuleDeclaration,
+    TSInterfaceDeclaration, TSNamespaceDeclaration, TSNonNullExpression, TSSatisfiesExpression,
+    TSThisParameter, TSTypeAliasDeclaration, TSTypeAnnotation, TSTypeAssertion,
+    TSTypeParameterDeclaration, TSTypeParameterInstantiation, VariableDeclaration,
+    VariableDeclarator,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::GetSpan;
@@ -351,14 +352,22 @@ impl<'a> Visit<'a> for Collector<'_> {
         }
     }
 
-    fn visit_ts_module_declaration(&mut self, it: &TSModuleDeclaration<'a>) {
+    fn visit_ts_external_module_declaration(&mut self, it: &TSExternalModuleDeclaration<'a>) {
+        if it.declare {
+            self.push(it.span.start, it.span.end);
+            return;
+        }
+        walk::walk_ts_external_module_declaration(self, it);
+    }
+
+    fn visit_ts_namespace_declaration(&mut self, it: &TSNamespaceDeclaration<'a>) {
         if it.declare {
             self.push(it.span.start, it.span.end);
             return;
         }
         // Non-declare namespace: keep the header (runtime semantics) but
         // still strip annotations inside the body.
-        walk::walk_ts_module_declaration(self, it);
+        walk::walk_ts_namespace_declaration(self, it);
     }
 }
 

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -2363,6 +2363,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(non_snake_case)]
     fn normalize_noSymlinks_inverts_to_followSymlinks() {
         let mut value = serde_json::json!({"noSymlinks": true});
         normalize_v4_config(&mut value);
@@ -2374,6 +2375,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(non_snake_case)]
     fn normalize_noSymlinks_false_means_follow() {
         let mut value = serde_json::json!({"noSymlinks": false});
         normalize_v4_config(&mut value);
@@ -2382,6 +2384,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(non_snake_case)]
     fn normalize_noSymLinks_capital_l_inverts() {
         let mut value = serde_json::json!({"noSymLinks": true});
         normalize_v4_config(&mut value);

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -519,10 +519,7 @@ fn find_git_root(start: &std::path::Path) -> Option<std::path::PathBuf> {
         if current.join(".git").exists() {
             return Some(current);
         }
-        match current.parent() {
-            Some(parent) => current = parent.to_path_buf(),
-            None => return None,
-        }
+        current = current.parent()?.to_path_buf();
     }
 }
 

--- a/rust/crates/cpd/tests/parity_test.rs
+++ b/rust/crates/cpd/tests/parity_test.rs
@@ -25,7 +25,7 @@ fn cpd_bin() -> PathBuf {
     if let Ok(bin) = std::env::var("CARGO_BIN_EXE_cpd") {
         return PathBuf::from(bin);
     }
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
         .parent()

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93"
+channel = "1.97"


### PR DESCRIPTION
Supersedes #920.

## Why #920 couldn't merge

Dependabot's PR bumped only `oxc_parser` to 0.144 and failed CI with:

```
error: rustc 1.93.1 is not supported by the following packages:
  oxc_parser@0.144.0 requires rustc 1.95.0
  ...
```

Even with a newer toolchain it would not have compiled, since the other five oxc crates (`oxc_allocator`, `oxc_span`, `oxc_ast`, `oxc_ast_visit`, `oxc_syntax`) stayed pinned at 0.133 — oxc crates must move in lockstep.

## What this PR does

**Toolchain 1.93 → 1.97** (`rust-toolchain.toml` + all four workflows), with fixes for new clippy 1.97 lints:
- `collapsible_match` (razor.rs), `useless_borrows_in_formatting` (orchestrate.rs), `manual_checked_div` (summary_render.rs), `ptr_arg` `&PathBuf` → `&Path` in integration tests, unused imports/variables in cpd-reporter test modules, `#[allow(non_snake_case)]` on cli tests intentionally named after the JS `noSymlinks` option.

**Coordinated oxc 0.133 → 0.144 bump** (all six crates), adapting to breaking changes:
- `ParserReturn.errors` → `.diagnostics`
- `TSModuleDeclaration` split into `TSExternalModuleDeclaration` / `TSNamespaceDeclaration` (oxc-project/oxc#25284); the `ts_strip` visitor now handles both with unchanged erasure semantics (declare → strip whole span; non-declare namespace → keep header, strip annotations inside).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean on 1.97.1
- `cargo test --workspace`: 735 passed, 0 failed (includes TS-strip and parity tests)
- `cargo fmt --check` clean

MSRV (`rust-version = "1.87"`) is intentionally unchanged; note it is no longer accurate for building with oxc 0.144 (requires 1.95) — bump it separately if desired.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/937)
<!-- Reviewable:end -->
