### PR TITLE
fix(finder): normalize native path separators before globbing

### DIFF
--- a/.changeset/windows-native-path-separators.md
+++ b/.changeset/windows-native-path-separators.md
@@ -1,0 +1,5 @@
+---
+"@jscpd/finder": patch
+---
+
+Fix file discovery on Windows when paths use native separators. `fast-glob` treats a backslash as an escape character, so a scan path or ignore pattern containing `\` — whether typed by the user (`D:\project\src`) or produced by `path.join()` / `path.resolve()` — silently matched nothing and jscpd reported no files. Separators are now normalized to `/` before patterns reach `fast-glob`; POSIX behaviour is unchanged, since a backslash is a legal filename character there. ([#602](https://github.com/kucherenko/jscpd/issues/602))

--- a/packages/finder/__tests__/files.test.ts
+++ b/packages/finder/__tests__/files.test.ts
@@ -134,6 +134,69 @@ describe('getFilesToDetect — shebang detection', () => {
   });
 });
 
+describe('getFilesToDetect — native path separators (issue #602)', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'jscpd-sep-test-')));
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'vendor'), { recursive: true });
+    const content = Array.from({ length: 10 }, (_, i) => `const v${i} = ${i};`).join('\n');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.js'), content);
+    fs.writeFileSync(path.join(tmpDir, 'vendor', 'lib.js'), content);
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const makeOptions = (scanPath: string, ignore: string[] = []): any => ({
+    path: [scanPath],
+    format: ['javascript'],
+    pattern: '**/*',
+    minLines: 1,
+    maxLines: 10000,
+    maxSize: '100mb',
+    ignore,
+    noSymlinks: false,
+    absolute: false,
+  });
+
+  // On Windows path.join()/path.resolve() emit backslashes, which fast-glob
+  // treats as escape characters — the resulting pattern matches nothing. These
+  // cases are no-ops on POSIX and only regress on Windows.
+  it('scans a directory given as a native absolute path', () => {
+    const files = getFilesToDetect(makeOptions(path.join(tmpDir, 'src')));
+    expect(files.map(f => f.path).some(p => p.includes('main.js'))).toBe(true);
+  });
+
+  it('scans a single file given as a native absolute path', () => {
+    const files = getFilesToDetect(makeOptions(path.join(tmpDir, 'src', 'main.js')));
+    expect(files).toHaveLength(1);
+    expect(files[0].content.length).toBeGreaterThan(0);
+  });
+
+  it('applies a native absolute ignore pattern', () => {
+    const files = getFilesToDetect(
+      makeOptions(tmpDir, [path.join(tmpDir, 'vendor', '**')]),
+    );
+    const paths = files.map(f => f.path);
+    expect(paths.some(p => p.includes('vendor'))).toBe(false);
+    expect(paths.some(p => p.includes('main.js'))).toBe(true);
+  });
+
+  it('applies a relative ignore pattern when the scan path is native absolute', () => {
+    const files = getFilesToDetect(makeOptions(tmpDir, ['vendor/**']));
+    const paths = files.map(f => f.path);
+    expect(paths.some(p => p.includes('vendor'))).toBe(false);
+    expect(paths.some(p => p.includes('main.js'))).toBe(true);
+  });
+});
+
 describe('getFilesToDetect — ignore patterns with relative paths (issue #611)', () => {
   let tmpDir: string;
   let originalCwd: string;

--- a/packages/finder/src/files.ts
+++ b/packages/finder/src/files.ts
@@ -70,6 +70,19 @@ function readShebangFormat(filePath: string): string | undefined {
 }
 
 
+/**
+ * fast-glob only understands forward slashes. On Windows a backslash is an
+ * escape character, so a native path — whether typed by the user
+ * (`D:\project\src`), produced by `path.join()`, or produced by
+ * `path.resolve()` — silently matches nothing when handed to fast-glob.
+ *
+ * Normalize separators on Windows only: on POSIX a backslash is a legal
+ * filename character and must be preserved.
+ */
+function toGlobPattern(value: string): string {
+  return path.sep === '\\' ? value.replace(/\\/g, '/') : value;
+}
+
 function isFile(path: string): boolean {
   try {
     const stat: Stats = lstatSync(path);
@@ -307,12 +320,13 @@ export function getFilesToDetect(options: IOptions): EntryWithContent[] {
 
   patterns = patterns!==undefined ? patterns.map((inputPath: string) => {
     const currentPath = realpathSync(inputPath);
+    const globPath = toGlobPattern(inputPath);
 
     if (isFile(currentPath)) {
-      return inputPath;
+      return globPath;
     }
 
-    return inputPath.endsWith('/') ? `${inputPath}${pattern}` : `${inputPath}/${pattern}`;
+    return globPath.endsWith('/') ? `${globPath}${pattern}` : `${globPath}/${pattern}`;
   }): [];
 
   // Normalize ignore patterns so they work regardless of whether the scan path
@@ -330,12 +344,12 @@ export function getFilesToDetect(options: IOptions): EntryWithContent[] {
   // Patterns already starting with "**/" already work and are left unchanged.
   const normalizedIgnore = (options.ignore || []).flatMap((ignorePattern: string) => {
     if (path.isAbsolute(ignorePattern) || ignorePattern.startsWith('**/')) {
-      return [ignorePattern];
+      return [toGlobPattern(ignorePattern)];
     }
     const variants = new Set<string>([ignorePattern]);
     for (const scanDir of [...scanDirs, '.']) {
-      variants.add(path.join(scanDir, ignorePattern));
-      variants.add(path.resolve(cwd, scanDir, ignorePattern));
+      variants.add(toGlobPattern(path.join(scanDir, ignorePattern)));
+      variants.add(toGlobPattern(path.resolve(cwd, scanDir, ignorePattern)));
     }
     return [...variants];
   });


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

On Windows, `getFilesToDetect` finds no files when the scan path uses native separators. `fast-glob` treats a backslash as an escape character, so a pattern like `D:\project\src/**/*` matches nothing and jscpd silently reports zero files instead of erroring.

This is what #602 describes: the reporter's workaround there — `path.join(directory, './src').replace(/\/g, '/')` — is exactly the normalization that is missing inside jscpd.

It affects both paths the user supplies and patterns this module builds itself: the relative-ignore variants added for #611 go through `path.join()` / `path.resolve()`, which emit backslashes on Windows.

The breakage is invisible upstream because `.github/workflows/nodejs.yml` only runs on `ubuntu-latest`. On a clean `master` on Windows, 17 of the 26 `packages/finder/__tests__/files.test.ts` tests fail — including the basic `single file path returns array with exactly 1 entry with content` — because the fixture path is built with `path.join(__dirname, '../../../fixtures')`.

* **What is the new behavior (if this is a feature change)?**

Separators are normalized to `/` before patterns reach `fast-glob`, via a small `toGlobPattern()` helper applied to the scan patterns and to the generated ignore-pattern variants.

The helper is a no-op unless `path.sep === '\'`, so POSIX behaviour is byte-for-byte unchanged — a backslash is a legal filename character there and must be preserved. `collectGitignorePatterns()` already did this for `baseDir`; this extends the same treatment to the remaining call sites.

Four regression tests are added under `getFilesToDetect — native path separators (issue #602)`, covering a native absolute directory path, a native absolute single-file path, a native absolute ignore pattern, and a relative ignore pattern against a native absolute scan path. They are trivially green on POSIX and fail on Windows without this change (verified both ways locally).

* **Other information**:

Verified on Windows 11 / Node 22:

- `packages/finder`: 5 failed | 103 passed before the new tests; 5 failed | 25 passed within `files.test.ts` after. The fix takes that file from 17 failures down to 5.
- The 5 remaining failures are a separate, pre-existing Windows gap and are untouched by this PR: they are all in the `shebang detection` group, which gates on `stats.mode & 0o111`. Windows has no exec bit, and one of them additionally needs `symlinkSync`, which requires elevation. Happy to open a follow-up (POSIX-gating those cases, or detecting shebangs by content on Windows) if you'd like — I did not want to widen this PR.
- `tsc --noEmit` is clean.
- A changeset is included (`@jscpd/finder`, patch).

Fixes #602

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/939)
<!-- Reviewable:end -->
