### PR TITLE
test: pin test fixture line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Test fixtures are byte-sensitive: their line endings are part of what is under
+# test, so git must not rewrite them per platform. Without these rules a Windows
+# checkout (core.autocrlf=true, the Git for Windows default) converts every LF
+# fixture to CRLF in the working tree, which breaks the tokenizer's CRLF-vs-LF
+# regression tests.
+fixtures/** text=auto eol=lf
+packages/*/__tests__/fixtures/** text=auto eol=lf
+
+# ...except this fixture, which must keep its CRLF endings on every platform: it
+# is the CRLF half of the astro CRLF-vs-LF comparison. Marking it -text stops git
+# from normalizing it to LF on commit (under core.autocrlf=input, or on
+# `git add --renormalize`), which would silently reduce it to a copy of
+# basic.astro and make the comparison vacuous.
+packages/tokenizer/__tests__/fixtures/astro/crlf.astro -text


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Bug fix (test infrastructure) — adds a `.gitattributes` so test fixtures keep the line endings the tests assert.

* **What is the current behavior?**

The repo has no `.gitattributes`. Every test fixture is stored LF in git except `packages/tokenizer/__tests__/fixtures/astro/crlf.astro`, which is deliberately stored CRLF.

On a Windows clone with `core.autocrlf=true` (the Git for Windows default) git rewrites all the LF fixtures to CRLF on checkout, and three tokenizer tests fail:

```
FAIL  __tests__/astro.test.ts  > crlf.astro > basic.astro does not contain CRLF sequences
FAIL  __tests__/svelte.test.ts > CRLF normalization > LF source does not contain CRLF sequences
FAIL  __tests__/svelte.test.ts > CRLF normalization > CRLF and LF sources produce the same token count per format
    AssertionError: expected 99 to be 84
```

Two distinct problems, both invisible in CI because `.github/workflows/nodejs.yml` only runs on `ubuntu-latest`:

1. **The LF fixtures stop being LF.** `astro.test.ts` compares `basic.astro` against `crlf.astro`; once the checkout converts `basic.astro` to CRLF the two files are byte-identical, so the CRLF-vs-LF comparison is comparing a file with itself. `svelte.test.ts` builds its CRLF input as `fixture('basic.svelte').replace(/\n/g, '\r\n')` — if the fixture is already CRLF that yields `\r\r\n`, hence the 99-vs-84 token count.
2. **`crlf.astro` is not protected from normalization.** It carries CRLF in the blob but has no attribute, so under `core.autocrlf=input` or a `git add --renormalize` git would normalize it to LF on commit — silently reducing it to a copy of `basic.astro` and making the astro comparison vacuous on every platform.

* **What is the new behavior (if this is a feature change)?**

A root `.gitattributes` pins both fixture trees to `text=auto eol=lf`, and marks `crlf.astro` as `-text` so its CRLF endings survive everywhere.

After the change, on Windows:

| package | before | after |
| --- | --- | --- |
| `@jscpd/tokenizer` | 3 failed / 276 passed | **279 passed** |
| `@jscpd/core` | 65 passed | 65 passed |

* **Other information**:

- **No blob churn.** `git add --renormalize .` stages nothing — the committed fixtures already match the new policy, so this is purely a checkout-time fix. On Linux nothing changes and CI behaviour is unaffected; the value is that Windows checkouts stop diverging and `crlf.astro` can no longer be normalized away.
- Existing clones keep their stale CRLF working-tree copies until the files are re-checked-out (`git rm --cached -r . && git reset --hard`, or a fresh clone). That is inherent to `.gitattributes` and not something the file can fix retroactively.
- `text=auto` rather than a bare `text` so git still auto-detects binary; I verified none of the 574 fixture files contain NUL bytes and none besides `crlf.astro` carry CRLF in the blob, so the rules are a no-op for everything else.
- `packages/finder` has 5 unrelated pre-existing failures on Windows in the shebang-detection suite (`fs.chmodSync` exec bits are meaningless on NTFS, and `fs.symlinkSync` needs elevation). Those are untouched here — identical before and after — and would need a separate `describe.skipIf(process.platform === 'win32')` style change if you want them addressed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/940)
<!-- Reviewable:end -->
