### PR TITLE
chore(rust): fix clippy unnecessary_sort_by in MCP snippet check

### DIFF
--- a/rust/crates/cpd/src/mcp.rs
+++ b/rust/crates/cpd/src/mcp.rs
@@ -347,7 +347,7 @@ impl McpServer {
                 c.fragment_a.source_id == SNIPPET_ID || c.fragment_b.source_id == SNIPPET_ID
             })
             .collect();
-        matches.sort_by(|a, b| b.token_count.cmp(&a.token_count));
+        matches.sort_by_key(|c| std::cmp::Reverse(c.token_count));
         let total = matches.len();
 
         let duplications: Vec<Value> = matches


### PR DESCRIPTION
Fixes the red `Rust` workflow on master ([run 32048358618](https://github.com/kucherenko/jscpd/actions/runs/32048358618)).

#936 branched before the Rust 1.97 toolchain bump (#937) landed, so the new `clippy::unnecessary_sort_by` lint never ran against the MCP code before merge. CI runs `cargo clippy --workspace -- -D warnings`, so the warning fails the build.

One-line fix: `sort_by` with a reverse comparator → `sort_by_key(Reverse(...))` as clippy suggests. No behavior change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/941)
<!-- Reviewable:end -->
