### PR TITLE
feat(rust): --skip-isolated folder groups for monorepos

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -77,6 +77,7 @@ cpd [OPTIONS] [PATH]...
 | `--cross-formats` | | Detect clones across formats: `;`-separated groups of `,`-separated formats (e.g. `javascript,typescript`). Preset `js-ts` = `javascript,jsx,typescript,tsx` | — |
 | `--list` | | List all supported formats and exit | — |
 | `--skip-local` | | Skip clones where both fragments are in the same directory | off |
+| `--skip-isolated` | | Skip clones between different folders of the same isolation group: `,`-separated groups of `\|`-separated folders (e.g. `packages/a\|packages/b`). Useful in monorepos where teams own separate packages | — |
 | `--sarif-error-tokens` | | Report SARIF results as `error` for clones with at least this many tokens (smaller clones stay `warning`). When overall duplication exceeds `--threshold`, all SARIF results become `error` regardless of size. | — (all `warning`) |
 | `--min-duplicated-lines` | | Minimum percentage of duplication to report (0-100) | 0 |
 | `--mcp` | | Serve the [Model Context Protocol over stdio](ai-ready.md#stdio-transport-rust-v5): scan PATHs once, then expose `check_duplication` / `get_statistics` / `check_current_directory` tools to MCP clients | off |
@@ -184,6 +185,9 @@ cpd ./src -r console,json,sarif -o ./reports
 
 # Skip clones within the same directory
 cpd --skip-local /path/to/source
+
+# Monorepo: don't compare team-owned packages with each other
+cpd . --skip-isolated "packages/team-a|packages/team-b"
 ```
 
 ### Config File
@@ -203,6 +207,8 @@ v5 reads the same `.jscpd.json` config file format as v4:
   "mode": "mild"
 }
 ```
+
+Isolation groups use the nested-array form in the config file: `"skipIsolated": [["packages/a", "packages/b"]]`.
 
 ## Format Support
 

--- a/rust/crates/cpd-core/src/detect.rs
+++ b/rust/crates/cpd-core/src/detect.rs
@@ -69,24 +69,20 @@ impl CloneDedupKey {
 /// Files are grouped by format; each format group is processed independently.
 /// Rayon is used for outer parallelism (one task per format group).
 pub fn detect(files: &[SourceFile], min_tokens: usize) -> Vec<CpdClone> {
-    detect_with_options(files, min_tokens, false, 0, &[])
+    detect_with_options(files, min_tokens, 0, &PathFilters::default())
 }
 
 /// Detect clones with extended options.
 ///
-/// - `skip_local`: skip clone pairs where both fragments are under the same scan root.
 /// - `min_lines`: reject clones whose fragment line span is shorter than this.
 ///   The line span is `end.line - start.line`; a clone is kept only if this value
 ///   is >= `min_lines`. This mirrors jscpd's `LinesLengthCloneValidator`.
-/// - `scan_roots`: when `skip_local` is true, clone pairs where both fragments
-///   are relative to the same scan root are skipped. Mirrors jscpd's
-///   `SkipLocalValidator` which checks `path.some(dir => isRelative(fileA, dir) && isRelative(fileB, dir))`.
+/// - `filters`: path-based clone pair filters ([`PathFilters`]).
 pub fn detect_with_options(
     files: &[SourceFile],
     min_tokens: usize,
-    skip_local: bool,
     min_lines: usize,
-    scan_roots: &[PathBuf],
+    filters: &PathFilters,
 ) -> Vec<CpdClone> {
     if files.is_empty() || min_tokens == 0 {
         return vec![];
@@ -133,7 +129,7 @@ pub fn detect_with_options(
                     }
                 })
                 .collect();
-            detect_in_group(&prepared, min_tokens, skip_local, min_lines, scan_roots)
+            detect_in_group(&prepared, min_tokens, min_lines, filters)
         })
         .collect();
 
@@ -196,14 +192,12 @@ impl PreparedSource {
 /// Detect clones from pre-prepared sources grouped by format.
 ///
 /// Called by orchestrate.rs after `tokenize_to_detection` — skips re-hashing.
-/// - `scan_roots`: when `skip_local` is true, clone pairs where both fragments
-///   are relative to the same scan root are skipped.
+/// - `filters`: path-based clone pair filters ([`PathFilters`]).
 pub fn detect_prepared(
     format_groups: Vec<Vec<PreparedSource>>,
     min_tokens: usize,
-    skip_local: bool,
     min_lines: usize,
-    scan_roots: &[PathBuf],
+    filters: &PathFilters,
 ) -> Vec<CpdClone> {
     if format_groups.is_empty() || min_tokens == 0 {
         return vec![];
@@ -211,7 +205,7 @@ pub fn detect_prepared(
 
     let mut clones: Vec<CpdClone> = format_groups
         .into_par_iter()
-        .flat_map(|group| detect_in_group(&group, min_tokens, skip_local, min_lines, scan_roots))
+        .flat_map(|group| detect_in_group(&group, min_tokens, min_lines, filters))
         .collect();
 
     finalize_clones(&mut clones);
@@ -225,9 +219,8 @@ pub fn detect_prepared(
 fn detect_in_group(
     prepared: &[PreparedSource],
     min_tokens: usize,
-    skip_local: bool,
     min_lines: usize,
-    scan_roots: &[PathBuf],
+    filters: &PathFilters,
 ) -> Vec<CpdClone> {
     // Precompute window_power once for this format group.
     // If per-language min_tokens is introduced, recompute per group (it is already scoped here).
@@ -311,9 +304,8 @@ fn detect_in_group(
                         open_clone.take(),
                         file_idx,
                         prepared,
-                        skip_local,
                         min_lines,
-                        scan_roots,
+                        filters,
                         &mut clones,
                     );
                     store.insert(window_hash, current);
@@ -326,9 +318,8 @@ fn detect_in_group(
             open_clone.take(),
             file_idx,
             prepared,
-            skip_local,
             min_lines,
-            scan_roots,
+            filters,
             &mut clones,
         );
     }
@@ -337,9 +328,8 @@ fn detect_in_group(
         repeated_windows,
         prepared,
         min_tokens,
-        skip_local,
         min_lines,
-        scan_roots,
+        filters,
         &mut clones,
     );
 
@@ -350,6 +340,31 @@ fn detect_in_group(
 // Open clone state machine helpers
 // ---------------------------------------------------------------------------
 
+/// Path-based clone pair filters, applied when a clone is flushed.
+///
+/// Bundles the options that decide whether a clone pair is dropped based on
+/// where its two fragments live on disk.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PathFilters<'a> {
+    /// Skip clone pairs where both fragments are under the same scan root.
+    /// Mirrors jscpd's `SkipLocalValidator`.
+    pub skip_local: bool,
+    /// Scan roots used by `skip_local` to determine same-directory pairs.
+    pub scan_roots: &'a [PathBuf],
+    /// Isolation groups (`--skip-isolated`): skip clone pairs whose fragments
+    /// are under two *different* folders of the same group. Mirrors the
+    /// `SkipIsolatedValidator` proposed in jscpd PR #628.
+    pub isolated_groups: &'a [Vec<PathBuf>],
+}
+
+impl PathFilters<'_> {
+    /// Returns true if the clone pair (`file_a`, `file_b`) must be dropped.
+    fn should_skip(&self, file_a: &str, file_b: &str) -> bool {
+        (self.skip_local && should_skip_local(file_a, file_b, self.scan_roots))
+            || should_skip_isolated(file_a, file_b, self.isolated_groups)
+    }
+}
+
 /// Returns true if both files share a common scan root directory.
 /// Mirrors jscpd's `SkipLocalValidator.shouldSkipClone`:
 ///   `path.some(dir => isRelative(fileA, dir) && isRelative(fileB, dir))`
@@ -357,6 +372,22 @@ fn should_skip_local(file_a: &str, file_b: &str, scan_roots: &[PathBuf]) -> bool
     scan_roots
         .iter()
         .any(|root| is_relative_to(file_a, root) && is_relative_to(file_b, root))
+}
+
+/// Returns true if the two files fall under two different folders of the same
+/// isolation group. Mirrors `SkipIsolatedValidator.shouldSkipClone` from jscpd
+/// PR #628: for each group, take the first folder containing each file; the
+/// clone is skipped when both files match and their folders differ.
+fn should_skip_isolated(file_a: &str, file_b: &str, isolated_groups: &[Vec<PathBuf>]) -> bool {
+    isolated_groups.iter().any(|group| {
+        let Some(dir_a) = group.iter().find(|dir| is_relative_to(file_a, dir)) else {
+            return false;
+        };
+        group
+            .iter()
+            .find(|dir| is_relative_to(file_b, dir))
+            .is_some_and(|dir_b| dir_a != dir_b)
+    })
 }
 
 /// Returns true if `file_path` is contained within `dir`.
@@ -426,9 +457,8 @@ fn flush_clone(
     open: Option<OpenClone>,
     current_file_idx: usize,
     prepared: &[PreparedSource],
-    skip_local: bool,
     min_lines: usize,
-    scan_roots: &[PathBuf],
+    filters: &PathFilters,
     clones: &mut Vec<CpdClone>,
 ) {
     let oc = match open {
@@ -447,10 +477,9 @@ fn flush_clone(
     let ex_end = ex_start + match_len - 1;
     let cur_end = cur_start + match_len - 1;
 
-    // skip_local: drop clone pairs where both fragments are under the same scan root.
-    // Mirrors jscpd's SkipLocalValidator which checks
-    //   path.some(dir => isRelative(fileA, dir) && isRelative(fileB, dir))
-    if skip_local && should_skip_local(&existing_file.id, &current_file.id, scan_roots) {
+    // Path filters: drop clone pairs by fragment location (skip_local,
+    // skip_isolated). Mirrors jscpd's SkipLocalValidator / SkipIsolatedValidator.
+    if filters.should_skip(&existing_file.id, &current_file.id) {
         return;
     }
 
@@ -590,9 +619,8 @@ fn add_secondary_clones(
     repeated_windows: FxHashMap<u64, Vec<Occurrence>>,
     prepared: &[PreparedSource],
     min_tokens: usize,
-    skip_local: bool,
     min_lines: usize,
-    scan_roots: &[PathBuf],
+    filters: &PathFilters,
     clones: &mut Vec<CpdClone>,
 ) {
     if repeated_windows.is_empty() {
@@ -667,9 +695,8 @@ fn add_secondary_clones(
         flush_secondary_clone(
             open.take(),
             prepared,
-            skip_local,
             min_lines,
-            scan_roots,
+            filters,
             clones,
             &mut coverage,
         );
@@ -716,9 +743,8 @@ fn add_secondary_clones(
     flush_secondary_clone(
         open.take(),
         prepared,
-        skip_local,
         min_lines,
-        scan_roots,
+        filters,
         clones,
         &mut coverage,
     );
@@ -727,9 +753,8 @@ fn add_secondary_clones(
 fn flush_secondary_clone(
     open: Option<SecondaryOpen>,
     prepared: &[PreparedSource],
-    skip_local: bool,
     min_lines: usize,
-    scan_roots: &[PathBuf],
+    filters: &PathFilters,
     clones: &mut Vec<CpdClone>,
     coverage: &mut LineCoverage,
 ) {
@@ -740,14 +765,8 @@ fn flush_secondary_clone(
     let range_a = fragment_line_range(&oc.clone.fragment_a);
     let range_b = fragment_line_range(&oc.clone.fragment_b);
 
-    // skip_local: drop clone pairs where both fragments are under the same scan root.
-    if skip_local
-        && should_skip_local(
-            &prepared[oc.source_a].id,
-            &prepared[oc.source_b].id,
-            scan_roots,
-        )
-    {
+    // Path filters: drop clone pairs by fragment location (skip_local, skip_isolated).
+    if filters.should_skip(&prepared[oc.source_a].id, &prepared[oc.source_b].id) {
         return;
     }
 
@@ -998,7 +1017,7 @@ mod tests {
             to_prepared("a.js", "javascript"),
             to_prepared("a.ts", "typescript"),
         ];
-        let clones = detect_prepared(vec![group], 5, false, 0, &[]);
+        let clones = detect_prepared(vec![group], 5, 0, &PathFilters::default());
         assert_eq!(
             clones.len(),
             1,
@@ -1063,5 +1082,79 @@ mod tests {
                 "clones must be sorted"
             );
         }
+    }
+
+    fn isolated(groups: &[&[&str]]) -> Vec<Vec<PathBuf>> {
+        groups
+            .iter()
+            .map(|g| g.iter().map(PathBuf::from).collect())
+            .collect()
+    }
+
+    #[test]
+    fn skip_isolated_drops_pairs_across_group_folders() {
+        let groups = isolated(&[&["/repo/packages/a", "/repo/packages/b"]]);
+        assert!(should_skip_isolated(
+            "/repo/packages/a/src/x.js",
+            "/repo/packages/b/src/y.js",
+            &groups
+        ));
+    }
+
+    #[test]
+    fn skip_isolated_keeps_pairs_inside_one_folder() {
+        let groups = isolated(&[&["/repo/packages/a", "/repo/packages/b"]]);
+        assert!(!should_skip_isolated(
+            "/repo/packages/a/src/x.js",
+            "/repo/packages/a/lib/y.js",
+            &groups
+        ));
+    }
+
+    #[test]
+    fn skip_isolated_keeps_pairs_with_one_file_outside_group() {
+        let groups = isolated(&[&["/repo/packages/a", "/repo/packages/b"]]);
+        assert!(!should_skip_isolated(
+            "/repo/packages/a/src/x.js",
+            "/repo/globals/y.js",
+            &groups
+        ));
+        assert!(!should_skip_isolated(
+            "/repo/globals/x.js",
+            "/repo/infra/y.js",
+            &groups
+        ));
+    }
+
+    #[test]
+    fn skip_isolated_folders_in_different_groups_do_not_isolate() {
+        let groups = isolated(&[
+            &["/repo/packages/a", "/repo/packages/b"],
+            &["/repo/libs/a", "/repo/libs/b"],
+        ]);
+        assert!(!should_skip_isolated(
+            "/repo/packages/a/x.js",
+            "/repo/libs/b/y.js",
+            &groups
+        ));
+        assert!(should_skip_isolated(
+            "/repo/libs/a/x.js",
+            "/repo/libs/b/y.js",
+            &groups
+        ));
+    }
+
+    #[test]
+    fn path_filters_combine_skip_local_and_skip_isolated() {
+        let scan_roots = vec![PathBuf::from("/repo/shared")];
+        let groups = isolated(&[&["/repo/packages/a", "/repo/packages/b"]]);
+        let filters = PathFilters {
+            skip_local: true,
+            scan_roots: &scan_roots,
+            isolated_groups: &groups,
+        };
+        assert!(filters.should_skip("/repo/shared/x.js", "/repo/shared/y.js"));
+        assert!(filters.should_skip("/repo/packages/a/x.js", "/repo/packages/b/y.js"));
+        assert!(!filters.should_skip("/repo/shared/x.js", "/repo/packages/a/y.js"));
     }
 }

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -2,7 +2,7 @@
 
 use crate::statistics;
 use crate::walker::{WalkConfig, walk};
-use cpd_core::detect::{PreparedSource, detect_prepared};
+use cpd_core::detect::{PathFilters, PreparedSource, detect_prepared};
 use cpd_core::models::{CpdClone, SourceFile, Statistics};
 use cpd_tokenizer::tokenizer::{
     Mode, TokenizeOptions, code_ignore_ranges, tokenize_to_detection, tokenize_to_detection_maps,
@@ -24,6 +24,9 @@ pub struct RunConfig {
     pub no_gitignore: bool,
     pub follow_symlinks: bool,
     pub skip_local: bool,
+    /// Isolation groups (`--skip-isolated`): clones spanning two different
+    /// folders of the same group are dropped.
+    pub skip_isolated: Vec<Vec<PathBuf>>,
     pub blame: bool,
     pub workers: Option<usize>,
     pub ignore_case: bool,
@@ -50,6 +53,7 @@ impl Default for RunConfig {
             no_gitignore: false,
             follow_symlinks: false,
             skip_local: false,
+            skip_isolated: vec![],
             blame: false,
             workers: None,
             ignore_case: false,
@@ -132,24 +136,29 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
     // 3. Group prepared sources into detection pools (deterministic order).
     let format_groups = build_pools(prepared_sources, &config.cross_formats);
 
-    // 4. Detect clones — skip_local uses scan roots to determine same-directory pairs.
-    //    Both scan roots and file IDs must use the same path normalization so
-    //    that prefix comparisons work. Canonicalize scan roots once here (resolves
+    // 4. Detect clones — skip_local uses scan roots to determine same-directory
+    //    pairs; skip_isolated uses its group folders the same way.
+    //    Both these directories and file IDs must use the same path normalization
+    //    so that prefix comparisons work. Canonicalize them once here (resolves
     //    symlinks like macOS /var → /private/var), and canonicalize file paths in
     //    the parallel processing loop above. Fall back to the original path if
     //    canonicalize fails.
-    let scan_roots: Vec<std::path::PathBuf> = config
-        .paths
+    let scan_roots = canonicalize_all(&config.paths);
+    let isolated_groups: Vec<Vec<std::path::PathBuf>> = config
+        .skip_isolated
         .iter()
-        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
+        .map(|group| canonicalize_all(group))
         .collect();
     let clones = pool.install(|| {
         detect_prepared(
             format_groups,
             config.min_tokens,
-            config.skip_local,
             config.min_lines,
-            &scan_roots,
+            &PathFilters {
+                skip_local: config.skip_local,
+                scan_roots: &scan_roots,
+                isolated_groups: &isolated_groups,
+            },
         )
     });
 
@@ -161,6 +170,15 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
         statistics,
         sources: source_files,
     })
+}
+
+/// Canonicalize every path, falling back to the original on failure (e.g. a
+/// directory that does not exist).
+pub fn canonicalize_all(paths: &[std::path::PathBuf]) -> Vec<std::path::PathBuf> {
+    paths
+        .iter()
+        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
+        .collect()
 }
 
 /// Walk the configured paths and tokenize every matching file, producing both

--- a/rust/crates/cpd-finder/tests/skip_isolated_integration.rs
+++ b/rust/crates/cpd-finder/tests/skip_isolated_integration.rs
@@ -1,0 +1,108 @@
+use cpd_finder::orchestrate::{RunConfig, run};
+use cpd_tokenizer::tokenizer::Mode;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+fn setup_temp_dir(suffix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("cpd-skip-isolated-{}", suffix));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn duplicate_js() -> &'static str {
+    r#"function isDuplicate(a, b, c, d, e) {
+    const result = a + b + c;
+    if (result > d) {
+        return result * e;
+    }
+    return result;
+}
+
+function anotherFunc(x, y) {
+    return x + y;
+}
+"#
+}
+
+fn config(paths: Vec<PathBuf>, skip_isolated: Vec<Vec<PathBuf>>) -> RunConfig {
+    RunConfig {
+        paths,
+        min_tokens: 5,
+        min_lines: 1,
+        mode: Mode::Mild,
+        skip_isolated,
+        ..Default::default()
+    }
+}
+
+fn write_pair(dir_a: &Path, dir_b: &Path) {
+    fs::create_dir_all(dir_a).unwrap();
+    fs::create_dir_all(dir_b).unwrap();
+    fs::write(dir_a.join("file_a.js"), duplicate_js()).unwrap();
+    fs::write(dir_b.join("file_b.js"), duplicate_js()).unwrap();
+}
+
+#[test]
+fn clones_across_isolated_folders_are_skipped() {
+    // Group folders are passed uncanonicalized (env::temp_dir() is symlinked
+    // on macOS) while file ids are canonicalized — run() must bridge the two.
+    let dir = setup_temp_dir("cross-group");
+    let dir_a = dir.join("packages/business_a");
+    let dir_b = dir.join("packages/business_b");
+    write_pair(&dir_a, &dir_b);
+
+    let result = run(&config(
+        vec![dir.clone()],
+        vec![vec![dir_a.clone(), dir_b.clone()]],
+    ))
+    .unwrap();
+    assert!(
+        result.clones.is_empty(),
+        "clones across two folders of one isolation group must be skipped"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn clones_inside_one_isolated_folder_survive() {
+    let dir = setup_temp_dir("same-folder");
+    let dir_a = dir.join("packages/business_a");
+    let dir_b = dir.join("packages/business_b");
+    fs::create_dir_all(&dir_a).unwrap();
+    fs::create_dir_all(&dir_b).unwrap();
+    fs::write(dir_a.join("file_a.js"), duplicate_js()).unwrap();
+    fs::write(dir_a.join("file_b.js"), duplicate_js()).unwrap();
+
+    let result = run(&config(
+        vec![dir.clone()],
+        vec![vec![dir_a.clone(), dir_b.clone()]],
+    ))
+    .unwrap();
+    assert!(
+        !result.clones.is_empty(),
+        "clones inside a single isolated folder must be kept"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn clones_outside_isolation_groups_survive() {
+    let dir = setup_temp_dir("outside-group");
+    let dir_a = dir.join("packages/business_a");
+    let globals = dir.join("globals");
+    write_pair(&dir_a, &globals);
+
+    let result = run(&config(
+        vec![dir.clone()],
+        vec![vec![dir_a.clone(), dir.join("packages/business_b")]],
+    ))
+    .unwrap();
+    assert!(
+        !result.clones.is_empty(),
+        "clones between an isolated folder and an outside folder must be kept"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -129,6 +129,33 @@ pub fn parse_cross_formats(input: &str) -> Vec<Vec<String>> {
     merged
 }
 
+/// Parse a `--skip-isolated` value: comma-separated isolation groups of
+/// pipe-separated folders, e.g. "packages/a|packages/b,libs/a|libs/b".
+/// Matches the CLI syntax of jscpd PR #628. Groups that end up with fewer
+/// than two folders can never isolate anything and are dropped with a warning.
+pub fn parse_skip_isolated(input: &str) -> Vec<Vec<String>> {
+    let mut groups: Vec<Vec<String>> = Vec::new();
+    for group in input.split(',') {
+        let folders: Vec<String> = group
+            .split('|')
+            .map(str::trim)
+            .filter(|f| !f.is_empty())
+            .map(str::to_string)
+            .collect();
+        if folders.len() < 2 {
+            if !folders.is_empty() {
+                eprintln!(
+                    "Warning: --skip-isolated group '{}' has fewer than two folders, ignored",
+                    group.trim()
+                );
+            }
+            continue;
+        }
+        groups.push(folders);
+    }
+    groups
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "cpd",
@@ -265,6 +292,12 @@ pub struct Cli {
     #[arg(long, visible_alias = "skipLocal")]
     pub skip_local: bool,
 
+    /// Skip clones between different folders of the same isolation group:
+    /// comma-separated groups of pipe-separated folders
+    /// (e.g. "packages/a|packages/b,libs/a|libs/b")
+    #[arg(long, visible_alias = "skipIsolated", value_name = "GROUPS")]
+    pub skip_isolated: Option<String>,
+
     /// Minimum percentage of duplication to report (0-100)
     #[arg(long, default_value = "0")]
     pub min_duplicated_lines: f64,
@@ -342,6 +375,10 @@ pub struct ConfigFile {
     pub cross_formats: Option<String>,
     #[serde(alias = "skip-local")]
     pub skip_local: Option<bool>,
+    /// Isolation groups as nested arrays (matching the jscpd `skipIsolated`
+    /// config shape): `[["packages/a", "packages/b"], ["libs/a", "libs/b"]]`.
+    #[serde(alias = "skip-isolated")]
+    pub skip_isolated: Option<Vec<Vec<String>>>,
     #[serde(alias = "exit-code")]
     pub exit_code: Option<i32>,
     #[serde(alias = "no-tips")]
@@ -530,6 +567,7 @@ pub(crate) static KNOWN_CONFIG_FIELDS: &[&str] = &[
     "formatsNames",
     "crossFormats",
     "skipLocal",
+    "skipIsolated",
     "exitCode",
     "noTips",
     "silent",
@@ -542,6 +580,7 @@ pub(crate) static KNOWN_CONFIG_FIELDS: &[&str] = &[
     "no-gitignore",
     "follow-symlinks",
     "skip-local",
+    "skip-isolated",
     "exit-code",
     "no-colors",
     "no-tips",
@@ -2211,6 +2250,43 @@ mod tests {
     fn config_file_kebab_case_skip_local() {
         let v: ConfigFile = serde_json::from_str(r#"{"skip-local": true}"#).unwrap();
         assert_eq!(v.skip_local, Some(true));
+    }
+
+    #[test]
+    fn config_file_skip_isolated_nested_arrays() {
+        let v: ConfigFile =
+            serde_json::from_str(r#"{"skipIsolated": [["packages/a", "packages/b"]]}"#).unwrap();
+        assert_eq!(
+            v.skip_isolated,
+            Some(vec![vec![
+                "packages/a".to_string(),
+                "packages/b".to_string()
+            ]])
+        );
+        let v: ConfigFile =
+            serde_json::from_str(r#"{"skip-isolated": [["libs/a", "libs/b"]]}"#).unwrap();
+        assert_eq!(
+            v.skip_isolated,
+            Some(vec![vec!["libs/a".to_string(), "libs/b".to_string()]])
+        );
+    }
+
+    #[test]
+    fn parse_skip_isolated_groups() {
+        assert_eq!(
+            parse_skip_isolated("packages/a|packages/b, libs/a | libs/b"),
+            vec![
+                vec!["packages/a".to_string(), "packages/b".to_string()],
+                vec!["libs/a".to_string(), "libs/b".to_string()],
+            ]
+        );
+        assert_eq!(parse_skip_isolated(""), Vec::<Vec<String>>::new());
+        assert_eq!(parse_skip_isolated(",,"), Vec::<Vec<String>>::new());
+        // Single-folder groups can never isolate anything — dropped.
+        assert_eq!(
+            parse_skip_isolated("packages/a,libs/a|libs/b"),
+            vec![vec!["libs/a".to_string(), "libs/b".to_string()]]
+        );
     }
 
     #[test]

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -51,6 +51,7 @@ struct MergedConfig {
     formats_names: std::collections::HashMap<String, Vec<String>>,
     cross_formats: Vec<Vec<String>>,
     skip_local: bool,
+    skip_isolated: Vec<Vec<String>>,
     no_tips: bool,
     silent: bool,
     pattern: Option<String>,
@@ -90,6 +91,7 @@ impl MergedConfig {
             formats_names: opts.formats_names.clone(),
             cross_formats: opts.cross_formats.clone(),
             skip_local: opts.skip_local,
+            skip_isolated: opts.skip_isolated.clone(),
             no_tips: opts.no_tips,
             silent: opts.silent,
             pattern: opts.pattern.clone(),
@@ -227,6 +229,11 @@ fn main() {
         no_gitignore: opts.no_gitignore,
         follow_symlinks: opts.follow_symlinks,
         skip_local: opts.skip_local,
+        skip_isolated: opts
+            .skip_isolated
+            .iter()
+            .map(|group| group.iter().map(std::path::PathBuf::from).collect())
+            .collect(),
         blame: opts.blame,
         workers: opts.workers,
         ignore_case: opts.ignore_case,

--- a/rust/crates/cpd/src/mcp.rs
+++ b/rust/crates/cpd/src/mcp.rs
@@ -11,10 +11,11 @@
 //   - get_statistics           ()                     — project duplication statistics
 //   - check_current_directory  (limit?)               — re-scan the configured paths
 
-use cpd_core::detect::{PreparedSource, detect_prepared};
+use cpd_core::detect::{PathFilters, PreparedSource, detect_prepared};
 use cpd_core::models::{CpdClone, Statistics};
 use cpd_finder::orchestrate::{
-    PreparedScan, RunConfig, build_thread_pool, prepare_scan_in, strip_types_formats,
+    PreparedScan, RunConfig, build_thread_pool, canonicalize_all, prepare_scan_in,
+    strip_types_formats,
 };
 use cpd_finder::statistics;
 use cpd_tokenizer::tokenizer::{TokenizeOptions, tokenize_to_detection};
@@ -48,15 +49,18 @@ pub struct McpServer {
     file_count: usize,
     /// Canonicalized scan roots, for skip_local and for relativizing paths.
     scan_roots: Vec<PathBuf>,
+    /// Canonicalized isolation groups, for skip_isolated.
+    isolated_groups: Vec<Vec<PathBuf>>,
 }
 
 impl McpServer {
     pub fn new(config: RunConfig) -> Self {
         let pool = build_thread_pool(config.workers);
-        let scan_roots = config
-            .paths
+        let scan_roots = canonicalize_all(&config.paths);
+        let isolated_groups = config
+            .skip_isolated
             .iter()
-            .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
+            .map(|group| canonicalize_all(group))
             .collect();
         let mut server = Self {
             config,
@@ -70,6 +74,7 @@ impl McpServer {
             clones: Vec::new(),
             file_count: 0,
             scan_roots,
+            isolated_groups,
         };
         server.rescan();
         server
@@ -110,9 +115,12 @@ impl McpServer {
             detect_prepared(
                 groups,
                 self.config.min_tokens,
-                self.config.skip_local,
                 self.config.min_lines,
-                &self.scan_roots,
+                &PathFilters {
+                    skip_local: self.config.skip_local,
+                    scan_roots: &self.scan_roots,
+                    isolated_groups: &self.isolated_groups,
+                },
             )
         });
         self.stats = statistics::compute(&sources, &clones);
@@ -335,9 +343,8 @@ impl McpServer {
             detect_prepared(
                 vec![pool],
                 self.config.min_tokens,
-                false,
                 self.config.min_lines,
-                &[],
+                &PathFilters::default(),
             )
         });
 

--- a/rust/crates/cpd/src/mcp.rs
+++ b/rust/crates/cpd/src/mcp.rs
@@ -354,7 +354,7 @@ impl McpServer {
                 c.fragment_a.source_id == SNIPPET_ID || c.fragment_b.source_id == SNIPPET_ID
             })
             .collect();
-        matches.sort_by(|a, b| b.token_count.cmp(&a.token_count));
+        matches.sort_by_key(|c| std::cmp::Reverse(c.token_count));
         let total = matches.len();
 
         let duplications: Vec<Value> = matches

--- a/rust/crates/cpd/src/options.rs
+++ b/rust/crates/cpd/src/options.rs
@@ -33,6 +33,7 @@ pub struct Options {
     pub formats_names: HashMap<String, Vec<String>>,
     pub cross_formats: Vec<Vec<String>>,
     pub skip_local: bool,
+    pub skip_isolated: Vec<Vec<String>>,
     pub no_tips: bool,
     pub silent: bool,
     pub summary: bool,
@@ -146,6 +147,12 @@ impl Options {
             formats_names,
             cross_formats,
             skip_local: cli.skip_local || config.skip_local.unwrap_or(false),
+            skip_isolated: cli
+                .skip_isolated
+                .as_deref()
+                .map(super::cli::parse_skip_isolated)
+                .or_else(|| config.skip_isolated.clone())
+                .unwrap_or_default(),
             no_tips: cli.no_tips || config.no_tips.unwrap_or(false) || std::env::var("CI").is_ok(),
             silent: cli.silent || config.silent.unwrap_or(false),
             summary: cli.summary || config.summary.unwrap_or(false),

--- a/rust/npm/README.md
+++ b/rust/npm/README.md
@@ -79,6 +79,7 @@ cpd --list
 | `--threshold` | `-t` | — | Max duplication % before exit 1 |
 | `--blame` | `-b` | — | Enrich clones with git blame data |
 | `--skip-local` | — | — | Skip clones within the same directory |
+| `--skip-isolated` | — | — | Skip clones between isolated monorepo folders (e.g. `packages/a\|packages/b`) |
 | `--silent` | `-s` | — | Suppress console output |
 | `--list` | — | — | List all supported formats and exit |
 


### PR DESCRIPTION
Ports the `skipIsolated` option proposed in #628 to the Rust (v5) engine.

## What

In business-oriented monorepos, packages owned by different teams often don't care about duplication *between* each other — only within their own package and against shared code. `--skip-isolated` declares isolation groups of folders; clones whose two fragments fall under two **different** folders of the same group are dropped. Everything else (within one folder, against shared code, across different groups) is still reported.

```bash
# packages/team-a is isolated from packages/team-b; libs/a from libs/b
cpd . --skip-isolated "packages/team-a|packages/team-b,libs/a|libs/b"
```

- CLI: `--skip-isolated` (visible alias `--skipIsolated`), comma-separated groups of pipe-separated folders — the same syntax as #628
- Config file: `skipIsolated` as nested arrays (the jscpd config shape from #628): `[["packages/a", "packages/b"]]`, kebab-case `skip-isolated` also accepted
- MCP server: isolation groups apply to project scans (`check_current_directory`, `get_statistics`); snippet checks stay unfiltered

## How

- `cpd-core`: new `PathFilters` bundles the existing `skip_local`/`scan_roots` pair with the new `isolated_groups`, applied at clone flush in both the primary and secondary passes. `should_skip_isolated` mirrors `SkipIsolatedValidator.shouldSkipClone` from #628: first matching folder per file, skip when both match and folders differ.
- `cpd-finder`: `RunConfig.skip_isolated: Vec<Vec<PathBuf>>`; group folders are canonicalized alongside scan roots so relative/symlinked paths match canonicalized file ids.
- Group folders given on the CLI are validated lightly: groups with fewer than two folders are dropped with a warning (they can never isolate anything).

## Tests

- Unit tests for the isolation predicate and `PathFilters` combination (cpd-core)
- Integration tests: cross-group skip, same-folder keep, outside-group keep (cpd-finder), incl. uncanonicalized group folders vs canonicalized file ids
- CLI parse + config-file shape tests (jscpd crate)
- `cargo test --workspace`, `cargo clippy --all-targets`, `cargo fmt --check` all green locally

Closes #628

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/942)
<!-- Reviewable:end -->
