### PR TITLE
feat(rust): OpenMetrics reporter for GitLab CI metrics reports

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to **cpd (Rust)** are documented here. Releases follow [Sema
 
 ---
 
+## Unreleased
+
+### New Features
+
+- **OpenMetrics reporter (`--reporters openmetrics`)** — writes `jscpd-metrics.txt` in the [OpenMetrics](https://openmetrics.io/) text exposition format, ready to be declared as a GitLab CI `artifacts:reports:metrics` artifact so merge requests show duplication metric changes against the target branch. Exposes gauges for files/lines/tokens analyzed, clones found, duplicated lines/tokens with percentages (project total plus a `format`-labeled sample per format), and detection duration in seconds. ([#422](https://github.com/kucherenko/jscpd/issues/422))
+
+---
+
 ## 5.0.16
 
 ### New Features

--- a/rust/crates/cpd-reporter/src/lib.rs
+++ b/rust/crates/cpd-reporter/src/lib.rs
@@ -7,6 +7,7 @@ pub mod csv_reporter;
 pub mod html;
 pub mod json_reporter;
 pub mod markdown_reporter;
+pub mod openmetrics;
 pub mod reporter;
 pub mod sarif;
 pub mod shared;

--- a/rust/crates/cpd-reporter/src/openmetrics.rs
+++ b/rust/crates/cpd-reporter/src/openmetrics.rs
@@ -1,0 +1,249 @@
+// openmetrics.rs — OpenMetrics text-format reporter (issue #422).
+// Produces: <output_dir>/jscpd-metrics.txt
+//
+// The output follows the OpenMetrics exposition format
+// (https://openmetrics.io/), which GitLab CI consumes via
+// `artifacts:reports:metrics` to show metric changes in merge requests.
+// Each statistic is a gauge family with an unlabeled total sample followed
+// by one `format="..."` labeled sample per detected format.
+
+use crate::context::ReportContext;
+use crate::reporter::{Reporter, ReporterError, ReporterOptions};
+use crate::shared::{Style, write_report_file};
+use cpd_core::models::{CpdClone, StatRow, Statistics};
+use std::path::Path;
+use std::time::Duration;
+
+pub struct OpenMetricsReporter {
+    style: Style,
+}
+
+impl OpenMetricsReporter {
+    pub fn new(opts: &ReporterOptions) -> Self {
+        Self {
+            style: Style::new(opts.no_colors),
+        }
+    }
+}
+
+/// Escape a label value per the OpenMetrics ABNF: backslash, double quote
+/// and line feed must be backslash-escaped.
+fn escape_label(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+/// Render a sample value. f64 Display already prints integral values
+/// without a trailing ".0" (`10.0` -> "10"), which OpenMetrics allows.
+fn fmt_value(value: f64) -> String {
+    format!("{}", value)
+}
+
+/// Append one gauge family: metadata, the unlabeled total sample, then a
+/// `format`-labeled sample per format (sorted by name).
+fn push_gauge(
+    out: &mut String,
+    stats: &Statistics,
+    format_names: &[&str],
+    name: &str,
+    unit: Option<&str>,
+    help: &str,
+    value_of: impl Fn(&StatRow) -> f64,
+) {
+    out.push_str(&format!("# HELP {name} {help}\n"));
+    out.push_str(&format!("# TYPE {name} gauge\n"));
+    if let Some(unit) = unit {
+        out.push_str(&format!("# UNIT {name} {unit}\n"));
+    }
+    out.push_str(&format!("{name} {}\n", fmt_value(value_of(&stats.total))));
+    for fmt in format_names {
+        if let Some(row) = stats.formats.get(*fmt) {
+            out.push_str(&format!(
+                "{name}{{format=\"{}\"}} {}\n",
+                escape_label(fmt),
+                fmt_value(value_of(row))
+            ));
+        }
+    }
+}
+
+fn render_openmetrics(stats: &Statistics, duration: Duration) -> String {
+    let mut format_names: Vec<&str> = stats.formats.keys().map(|s| s.as_str()).collect();
+    format_names.sort_unstable();
+
+    let mut out = String::new();
+    push_gauge(
+        &mut out,
+        stats,
+        &format_names,
+        "jscpd_source_files",
+        None,
+        "Number of source files analyzed.",
+        |r| r.sources as f64,
+    );
+    push_gauge(
+        &mut out,
+        stats,
+        &format_names,
+        "jscpd_lines_analyzed",
+        None,
+        "Total number of lines analyzed.",
+        |r| r.lines as f64,
+    );
+    push_gauge(
+        &mut out,
+        stats,
+        &format_names,
+        "jscpd_tokens_analyzed",
+        None,
+        "Total number of tokens analyzed.",
+        |r| r.tokens as f64,
+    );
+    push_gauge(
+        &mut out,
+        stats,
+        &format_names,
+        "jscpd_clones_found",
+        None,
+        "Number of duplicated code blocks found.",
+        |r| r.clones as f64,
+    );
+    push_gauge(
+        &mut out,
+        stats,
+        &format_names,
+        "jscpd_duplicated_lines",
+        None,
+        "Number of duplicated lines.",
+        |r| r.duplicated_lines as f64,
+    );
+    push_gauge(
+        &mut out,
+        stats,
+        &format_names,
+        "jscpd_duplicated_tokens",
+        None,
+        "Number of duplicated tokens.",
+        |r| r.duplicated_tokens as f64,
+    );
+    push_gauge(
+        &mut out,
+        stats,
+        &format_names,
+        "jscpd_duplicated_lines_percent",
+        Some("percent"),
+        "Percentage of duplicated lines.",
+        |r| r.percentage,
+    );
+    push_gauge(
+        &mut out,
+        stats,
+        &format_names,
+        "jscpd_duplicated_tokens_percent",
+        Some("percent"),
+        "Percentage of duplicated tokens.",
+        |r| r.percentage_tokens,
+    );
+
+    let name = "jscpd_detection_duration_seconds";
+    out.push_str(&format!("# HELP {name} Time spent detecting duplicates.\n"));
+    out.push_str(&format!("# TYPE {name} gauge\n"));
+    out.push_str(&format!("# UNIT {name} seconds\n"));
+    out.push_str(&format!("{name} {}\n", fmt_value(duration.as_secs_f64())));
+
+    out.push_str("# EOF\n");
+    out
+}
+
+impl Reporter for OpenMetricsReporter {
+    fn name(&self) -> &str {
+        "openmetrics"
+    }
+
+    fn report(
+        &self,
+        _clones: &[CpdClone],
+        ctx: &ReportContext,
+        output_dir: &Path,
+    ) -> Result<(), ReporterError> {
+        let content = render_openmetrics(ctx.stats, ctx.duration);
+        write_report_file(
+            output_dir,
+            "jscpd-metrics.txt",
+            &content,
+            &self.style,
+            "OpenMetrics",
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::ReportContext;
+    use crate::shared::fixtures::{one_clone_stats, tmp_dir};
+    use crate::{assert_empty_report_ok, assert_reporter_name};
+    use std::time::Duration;
+
+    assert_reporter_name!(
+        openmetrics_reporter_name,
+        OpenMetricsReporter,
+        "openmetrics"
+    );
+    assert_empty_report_ok!(openmetrics_empty_clones_ok, OpenMetricsReporter);
+
+    fn run_openmetrics_report() -> String {
+        let dir = tmp_dir("openmetrics");
+        let opts = ReporterOptions::new(dir.clone());
+        let reporter = OpenMetricsReporter::new(&opts);
+        let stats = one_clone_stats();
+        let ctx = ReportContext::new(&stats, Duration::from_millis(1500));
+        reporter.report(&[], &ctx, &dir).unwrap();
+        std::fs::read_to_string(dir.join("jscpd-metrics.txt")).unwrap()
+    }
+
+    #[test]
+    fn openmetrics_ends_with_eof() {
+        let content = run_openmetrics_report();
+        assert!(content.ends_with("# EOF\n"), "must end with # EOF marker");
+    }
+
+    #[test]
+    fn openmetrics_has_metadata_before_samples() {
+        let content = run_openmetrics_report();
+        let help = content.find("# HELP jscpd_clones_found").unwrap();
+        let ty = content.find("# TYPE jscpd_clones_found gauge").unwrap();
+        let sample = content.find("\njscpd_clones_found 1\n").unwrap();
+        assert!(help < ty && ty < sample);
+    }
+
+    #[test]
+    fn openmetrics_contains_total_and_format_samples() {
+        let content = run_openmetrics_report();
+        assert!(content.contains("jscpd_duplicated_lines 10\n"));
+        assert!(content.contains("jscpd_duplicated_lines{format=\"javascript\"} 10\n"));
+        assert!(content.contains("jscpd_duplicated_lines_percent{format=\"javascript\"} 10\n"));
+    }
+
+    #[test]
+    fn openmetrics_reports_duration_in_seconds() {
+        let content = run_openmetrics_report();
+        assert!(content.contains("jscpd_detection_duration_seconds 1.5\n"));
+    }
+
+    #[test]
+    fn escape_label_handles_special_chars() {
+        assert_eq!(escape_label(r#"a"b\c"#), r#"a\"b\\c"#);
+        assert_eq!(escape_label("a\nb"), "a\\nb");
+        assert_eq!(escape_label("c#"), "c#");
+    }
+
+    #[test]
+    fn fmt_value_prints_integral_floats_without_fraction() {
+        assert_eq!(fmt_value(10.0), "10");
+        assert_eq!(fmt_value(10.25), "10.25");
+    }
+}

--- a/rust/crates/cpd-reporter/src/reporter.rs
+++ b/rust/crates/cpd-reporter/src/reporter.rs
@@ -144,6 +144,9 @@ pub fn create_reporter(name: &str, options: &ReporterOptions) -> Option<Box<dyn 
             options,
         ))),
         "badge" => Some(Box::new(crate::badge::BadgeReporter::new(options))),
+        "openmetrics" => Some(Box::new(crate::openmetrics::OpenMetricsReporter::new(
+            options,
+        ))),
         "xcode" => Some(Box::new(crate::xcode::XcodeReporter::new(options))),
         "threshold" => Some(Box::new(crate::threshold::ThresholdReporter::new(options))),
         "silent" => Some(Box::new(crate::silent::SilentReporter::new(options))),

--- a/rust/crates/cpd-reporter/tests/reporters_integration.rs
+++ b/rust/crates/cpd-reporter/tests/reporters_integration.rs
@@ -5,7 +5,7 @@
 // 2. Fixture data provides realistic clone detection scenarios
 //
 // Test Coverage:
-// - json, xml, csv, markdown, sarif, html reporters (file-based)
+// - json, xml, csv, markdown, sarif, openmetrics, html reporters (file-based)
 // - console, console-full, xcode reporters (stdout-based)
 // - silent, threshold, badge, ai reporters (special behavior)
 
@@ -315,6 +315,17 @@ fn sarif_reporter_creates_output_file() {
         "jscpd-report.sarif",
         &["src/app.js"],
         "SARIF report",
+    );
+}
+
+#[test]
+fn openmetrics_reporter_creates_output_file() {
+    run_file_reporter(
+        "openmetrics",
+        "openmetrics",
+        "jscpd-metrics.txt",
+        &["jscpd_duplicated_lines", "format=\"javascript\"", "# EOF"],
+        "OpenMetrics report",
     );
 }
 

--- a/rust/crates/cpd/README.md
+++ b/rust/crates/cpd/README.md
@@ -31,7 +31,7 @@ cpd --blame .
 
 ## Output Formats
 
-`console`, `json`, `xml`, `csv`, `html`, `markdown`, `sarif`, `xcode`, `badge`, `silent`, `ai`, `threshold`
+`console`, `json`, `xml`, `csv`, `html`, `markdown`, `sarif`, `openmetrics`, `xcode`, `badge`, `silent`, `ai`, `threshold`
 
 ## npm Distribution
 

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -199,7 +199,7 @@ pub struct Cli {
     #[arg(long, value_delimiter = ',')]
     pub ignore_pattern: Vec<String>,
 
-    /// Output reporters (comma-separated): console,json,xml,csv,html,markdown,badge,sarif,ai,xcode,threshold,silent,console-full
+    /// Output reporters (comma-separated): console,json,xml,csv,html,markdown,badge,sarif,openmetrics,ai,xcode,threshold,silent,console-full
     /// Aliases: "full" and "consoleFull" are accepted for "console-full"
     #[arg(long, short = 'r', value_delimiter = ',')]
     pub reporters: Vec<String>,


### PR DESCRIPTION
## Summary

Implements the OpenMetrics reporter requested in #422 for the Rust engine.

`cpd --reporters openmetrics` writes `jscpd-metrics.txt` in the [OpenMetrics](https://openmetrics.io/) text exposition format, which GitLab CI consumes via [`artifacts:reports:metrics`](https://docs.gitlab.com/ee/ci/testing/metrics_reports.html) to show metric changes directly in merge requests. The format is a superset of the Prometheus text format, so any Prometheus-compatible tooling can parse it too.

## Report contents

One gauge family per statistic, each with an unlabeled project-total sample plus a `format="..."`-labeled sample per detected format:

- `jscpd_source_files`, `jscpd_lines_analyzed`, `jscpd_tokens_analyzed`
- `jscpd_clones_found`, `jscpd_duplicated_lines`, `jscpd_duplicated_tokens`
- `jscpd_duplicated_lines_percent`, `jscpd_duplicated_tokens_percent` (with `# UNIT` metadata)
- `jscpd_detection_duration_seconds` (total only)

Label values are escaped per the OpenMetrics ABNF and the file ends with the spec-required `# EOF` marker.

Example GitLab usage:

```yaml
jscpd:
  script:
    - jscpd --reporters openmetrics --output ./reports .
  artifacts:
    reports:
      metrics: reports/jscpd-metrics.txt
```

## Changes

- New `crates/cpd-reporter/src/openmetrics.rs` with the reporter and 8 unit tests
- Registered `openmetrics` in `create_reporter`, CLI help, and the cpd README reporter list
- Integration test in `reporters_integration.rs`
- CHANGELOG entry under Unreleased

## Testing

- `cargo test --workspace` — all suites pass
- `cargo clippy --all-targets` and `cargo fmt --check` — clean
- End-to-end smoke test of the binary produced a well-formed metrics file

Closes #422

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/943)
<!-- Reviewable:end -->
