### PR TITLE
ci: sign releases with SLSA provenance, pin download pipes (Scorecard)

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -48,7 +48,7 @@ jobs:
           # Use crates.io HTTP API for exact version match.
           # cargo info jscpd@ver exits 0 if the crate exists at ANY version.
           max_ver=$(curl -sfH "Accept: application/json" -H "User-Agent: jscpd-ci (github.com/kucherenko/jscpd)" "https://crates.io/api/v1/crates/jscpd" 2>/dev/null \
-            | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const c=JSON.parse(d);process.stdout.write(c.crate.max_version)}catch(e){process.stdout.write('')}})" || echo "")
+            | jq -r '.crate.max_version // empty' || echo "")
           if [ "$max_ver" = "$version" ] && [ -n "$max_ver" ]; then
             echo "jscpd@${version} is already published on crates.io (max_version=${max_ver}); skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -180,7 +180,7 @@ jobs:
             # cargo info crate@ver exits 0 if the crate exists at ANY version,
             # not just the specified one — so we must compare max_version instead.
             max_ver=$(curl -sfH "Accept: application/json" -H "User-Agent: jscpd-ci (github.com/kucherenko/jscpd)" "https://crates.io/api/v1/crates/${crate}" 2>/dev/null \
-              | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const c=JSON.parse(d);process.stdout.write(c.crate.max_version)}catch(e){process.stdout.write('')}})" || echo "")
+              | jq -r '.crate.max_version // empty' || echo "")
             if [ "$max_ver" = "$crate_version" ] && [ -n "$max_ver" ]; then
               echo "${crate}@${crate_version} already published on crates.io (max_version=${max_ver}); skipping"
               continue

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -67,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # gh release create
+      id-token: write # keyless signing for build provenance (OpenSSF Scorecard: Signed-Releases)
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -87,7 +89,7 @@ jobs:
               continue
             fi
             max_ver=$(curl -sfH "Accept: application/json" -H "User-Agent: jscpd-ci (github.com/kucherenko/jscpd)" "https://crates.io/api/v1/crates/${name}" 2>/dev/null \
-              | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const c=JSON.parse(d);process.stdout.write(c.crate.max_version)}catch(e){process.stdout.write('')}})" || echo "")
+              | jq -r '.crate.max_version // empty' || echo "")
             if [ "$max_ver" = "$local_ver" ]; then
               published="${published}  - \`${name}@${local_ver}\` on crates.io\n"
             else
@@ -215,3 +217,34 @@ jobs:
               --notes "${notes}" \
               --latest=false
           fi
+
+      - name: Generate checksums
+        id: checksums
+        run: |
+          if [ -d release-assets ] && ls release-assets/*.tar.gz >/dev/null 2>&1; then
+            (cd release-assets && sha256sum *.tar.gz > checksums.txt)
+            echo "have=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Signed SLSA provenance for the release binaries, verifiable with
+      # `gh attestation verify <asset> --repo kucherenko/jscpd`. The bundle is
+      # also uploaded as a release asset (multiple.intoto.jsonl) so provenance
+      # travels with the artifacts (and OpenSSF Scorecard Signed-Releases
+      # detects it).
+      - name: Attest build provenance
+        if: steps.checksums.outputs.have == 'true'
+        id: attest
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: release-assets/*.tar.gz
+
+      - name: Upload checksums and provenance to release
+        if: steps.checksums.outputs.have == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="cpd-v${{ needs.version.outputs.version }}"
+          cp "${{ steps.attest.outputs.bundle-path }}" release-assets/multiple.intoto.jsonl
+          gh release upload "${tag}" release-assets/checksums.txt release-assets/multiple.intoto.jsonl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
             # cargo info crate@ver exits 0 if the crate exists at ANY version,
             # not just the specified one — so we must check the versions list.
             published_ver=$(curl -sfH "Accept: application/json" -H "User-Agent: jscpd-ci (github.com/kucherenko/jscpd)" "https://crates.io/api/v1/crates/${name}" 2>/dev/null \
-              | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const c=JSON.parse(d);process.stdout.write(c.crate.max_version)}catch(e){process.stdout.write('')}})" || echo "")
+              | jq -r '.crate.max_version // empty' || echo "")
             if [ "$published_ver" = "$local_ver" ] && [ -n "$published_ver" ]; then
               echo "${name}@${local_ver} already on crates.io (max_version=${published_ver})"
             else
@@ -399,6 +399,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # keyless signing for build provenance (OpenSSF Scorecard: Signed-Releases)
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -427,7 +429,7 @@ jobs:
               continue
             fi
             max_ver=$(curl -sfH "Accept: application/json" -H "User-Agent: jscpd-ci (github.com/kucherenko/jscpd)" "https://crates.io/api/v1/crates/${name}" 2>/dev/null \
-              | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const c=JSON.parse(d);process.stdout.write(c.crate.max_version)}catch(e){process.stdout.write('')}})" || echo "")
+              | jq -r '.crate.max_version // empty' || echo "")
             if [ "$max_ver" = "$local_ver" ]; then
               published="${published}  - \`${name}@${local_ver}\` on crates.io\n"
             else
@@ -537,6 +539,37 @@ jobs:
               --notes "$RELEASE_NOTES" \
               --latest
           fi
+
+      - name: Generate checksums
+        id: checksums
+        run: |
+          if [ -d release-assets ] && ls release-assets/*.tar.gz >/dev/null 2>&1; then
+            (cd release-assets && sha256sum *.tar.gz > checksums.txt)
+            echo "have=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Signed SLSA provenance for the release binaries, verifiable with
+      # `gh attestation verify <asset> --repo kucherenko/jscpd`. The bundle is
+      # also uploaded as a release asset (multiple.intoto.jsonl) so provenance
+      # travels with the artifacts (and OpenSSF Scorecard Signed-Releases
+      # detects it).
+      - name: Attest build provenance
+        if: steps.checksums.outputs.have == 'true'
+        id: attest
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: release-assets/*.tar.gz
+
+      - name: Upload checksums and provenance to release
+        if: steps.checksums.outputs.have == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ needs.rust-version.outputs.version }}"
+          cp "${{ steps.attest.outputs.bundle-path }}" release-assets/multiple.intoto.jsonl
+          gh release upload "${tag}" release-assets/checksums.txt release-assets/multiple.intoto.jsonl
 
   ts-release:
     name: create typescript github release

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ![NPM License](https://img.shields.io/npm/l/jscpd)
 [![jscpd CI](https://github.com/kucherenko/jscpd/actions/workflows/nodejs.yml/badge.svg)](https://github.com/kucherenko/jscpd/actions/workflows/nodejs.yml)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/jscpd)](https://socket.dev/npm/package/jscpd)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kucherenko/jscpd/badge)](https://scorecard.dev/viewer/?uri=github.com/kucherenko/jscpd)
 
 > Copy/paste detector for programming source code. Supports 224+ formats. AI-ready with MCP server and token-efficient reporter. Now with a Rust-powered engine — 24-37x faster.
 


### PR DESCRIPTION
Improves the [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/kucherenko/jscpd) results (currently **7.2**). Code-fixable findings addressed:

## Signed-Releases (0/10 → expected 10 as new releases ship)

The `rust-release` job now, after creating the release:
1. writes `checksums.txt` (sha256 of every binary tarball),
2. generates **signed SLSA build provenance** with `actions/attest-build-provenance` (keyless via OIDC; `id-token: write` + `attestations: write` added to the job),
3. uploads the Sigstore bundle as a `multiple.intoto.jsonl` release asset alongside the checksums.

Verification for users:
```bash
gh attestation verify jscpd-<platform>.tar.gz --repo kucherenko/jscpd
```

Scorecard checks the 5 most recent releases, so the score climbs as signed releases replace unsigned ones. `release-rust.yml` (currently uncalled — `release.yml` owns releases now) gets the same steps so it stays correct if revived.

## Pinned-Dependencies (8/10 → 9+)

The five flagged `curl … | node -e "…JSON.parse…"` pipelines (crates.io max_version checks) are now `curl … | jq -r '.crate.max_version // empty'` — the downloaded bytes are consumed as data by jq instead of being piped into an interpreter, which is what the `downloadThenRun` heuristic flags. Same output, same `|| echo ""` fallback; jq is preinstalled on ubuntu runners.

The one remaining warning (`npm install -g cpd@version` in npm-rust-publish.yml) is the post-publish smoke test whose purpose is installing the just-published exact version from the live registry — left as is.

## README

Added Socket.dev and OpenSSF Scorecard badges.

## Not code-fixable (for reference)

- **CII-Best-Practices (0)**: requires registering the project at bestpractices.dev and filling the questionnaire.
- **Code-Review (1)**: counts self-merged PRs without approving review — behavioral.
- **Branch-Protection (3)**: wants required status checks + required PRs on master; requiring PRs would break the release-commit-to-master flow, so not changed here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/956)
<!-- Reviewable:end -->
