### PR TITLE
docs: OpenSSF Best Practices badge and passing-criteria docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to jscpd
+
+Thanks for considering a contribution! This document describes how to propose
+changes and what is required for a contribution to be accepted.
+
+## How to contribute
+
+1. Fork [kucherenko/jscpd](https://github.com/kucherenko/jscpd/) and clone your fork.
+2. Create a feature branch from `master`.
+3. Make your changes (see the workflows below).
+4. Open a pull request against `master` describing what the change does and why.
+
+Bug reports and feature requests go through
+[GitHub Issues](https://github.com/kucherenko/jscpd/issues). Security
+vulnerabilities must **not** be reported publicly — see [SECURITY.md](SECURITY.md).
+
+## Development setup
+
+The repository contains two engines:
+
+- **Rust engine (v5, active development)** in [`rust/`](rust) — the `cpd` binary
+  and its crates.
+- **TypeScript packages (v4, maintenance)** in [`packages/`](packages) and
+  [`apps/`](apps) — security and critical fixes only.
+
+### Rust engine
+
+```bash
+cd rust
+cargo build
+cargo test --workspace          # full test suite
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all                 # formatting is enforced
+```
+
+The Rust test suite is not run in PR CI — run it locally before submitting.
+
+### TypeScript packages
+
+```bash
+pnpm install
+pnpm dev                        # run in dev mode
+pnpm test                       # test suite
+pnpm build
+```
+
+## Requirements for acceptable contributions
+
+- **Tests are required.** New functionality must come with tests that exercise
+  it, and bug fixes should include a test that fails without the fix. As a
+  rule of thumb, look at the existing tests next to the code you touch
+  (`#[cfg(test)]` modules and `tests/` directories in Rust, `__tests__` in
+  TypeScript) and follow their patterns.
+- **CI must be green.** Lints and formatting are enforced: `cargo clippy -D
+  warnings` and `cargo fmt --check` for Rust, ESLint for TypeScript.
+- **Match the surrounding style** — naming, comment density, and idioms of the
+  file you are editing.
+- **Keep changes focused.** One logical change per pull request; unrelated
+  refactoring belongs in its own PR.
+- By submitting a contribution you agree that it is licensed under the
+  project's [MIT license](LICENSE).
+
+## Code of conduct
+
+All interactions are covered by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![jscpd CI](https://github.com/kucherenko/jscpd/actions/workflows/nodejs.yml/badge.svg)](https://github.com/kucherenko/jscpd/actions/workflows/nodejs.yml)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/jscpd)](https://socket.dev/npm/package/jscpd)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kucherenko/jscpd/badge)](https://scorecard.dev/viewer/?uri=github.com/kucherenko/jscpd)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14188/badge)](https://www.bestpractices.dev/projects/14188)
 
 > Copy/paste detector for programming source code. Supports 224+ formats. AI-ready with MCP server and token-efficient reporter. Now with a Rust-powered engine — 24-37x faster.
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ See [AI-Ready docs](docs/ai-ready.md) for full details.
 
 ## Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup (Rust and TypeScript), the test policy, and the requirements for acceptable pull requests. Security issues go through the [security policy](SECURITY.md), not public issues.
+
 1. Fork the repo [kucherenko/jscpd](https://github.com/kucherenko/jscpd/)
 2. Clone forked version (`git clone https://github.com/{your-id}/jscpd`)
 3. Install dependencies (`pnpm install`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,3 +18,5 @@ Please report security vulnerabilities **privately** — do not open a public is
 Please include a description of the issue, steps to reproduce, affected versions, and any known impact.
 
 You can expect an acknowledgement within 7 days. Once a fix is available, it is released for the supported version lines and the advisory is published with credit to the reporter (unless you prefer to stay anonymous).
+
+Fixed vulnerabilities are identified in the release notes and changelog of the release that contains the fix, with a reference to the published advisory (past examples: the ReDoS fixes in [`CHANGELOG.md`](CHANGELOG.md)).


### PR DESCRIPTION
Follow-up to #956, which was merged before these two commits landed on the branch — they never reached master:

- **README**: OpenSSF Best Practices badge for [project 14188](https://www.bestpractices.dev/projects/14188), which achieved **passing (100%)** on 2026-08-21. Renders next to the Socket and Scorecard badges.
- **CONTRIBUTING.md** (new): contribution process, dev setup for both engines, and the requirements for acceptable contributions — including the test policy (new functionality requires tests) and enforced lints. Several answers in the Best Practices questionnaire cite this file, so merging makes those links resolve.
- **SECURITY.md**: states that fixed vulnerabilities are identified in release notes/changelog with advisory references (the `release_notes_vulns` criterion), backed by the existing ReDoS entries in CHANGELOG.md.
- **README Contributing section**: links CONTRIBUTING.md and the security policy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/957)
<!-- Reviewable:end -->
