### PR TITLE
refactor(reporter): use badgelib for badge rendering

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -142,6 +142,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "badgelib"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e51ca8bc944c97ffd76b405052031133daafe47f21348b6200538c43b8ea3d"
+dependencies = [
+ "base64",
+ "chrono",
+ "maud",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +232,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -322,6 +343,7 @@ name = "cpd-reporter"
 version = "0.1.9"
 dependencies = [
  "askama",
+ "badgelib",
  "cpd-core",
  "cpd-finder",
  "csv",
@@ -614,6 +636,28 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "memchr"
@@ -968,6 +1012,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "version_check",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1300,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/rust/crates/cpd-reporter/Cargo.toml
+++ b/rust/crates/cpd-reporter/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 license.workspace = true
 
 [dependencies]
+badgelib = "0.5.0"
 cpd-core = { version = "0.1.9", path = "../cpd-core" }
 cpd-finder = { version = "0.1.11", path = "../cpd-finder" }
 serde = { version = "1", features = ["derive"] }

--- a/rust/crates/cpd-reporter/src/badge.rs
+++ b/rust/crates/cpd-reporter/src/badge.rs
@@ -2,6 +2,7 @@
 
 use crate::context::ReportContext;
 use crate::reporter::{Reporter, ReporterError, ReporterOptions};
+use badgelib::{Badge, Color};
 use cpd_core::models::CpdClone;
 use std::{fs, path::Path};
 
@@ -54,52 +55,12 @@ pub fn duplication_color(percentage: f64) -> &'static str {
 }
 
 fn make_badge(label: &str, value: &str, color: &str) -> String {
-    let label_width = (label.len() * 7 + 10).max(40);
-    let value_width = (value.len() * 7 + 10).max(30);
-    let total_width = label_width + value_width;
-    let lx = label_width / 2;
-    let vx = label_width + value_width / 2;
-
-    let mut svg = String::new();
-    svg.push_str(&format!(
-        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{}\" height=\"20\">\n",
-        total_width
-    ));
-    svg.push_str("  <linearGradient id=\"s\" x2=\"0\" y2=\"100%\">\n");
-    svg.push_str("    <stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/>\n");
-    svg.push_str("    <stop offset=\"1\" stop-opacity=\".1\"/>\n");
-    svg.push_str("  </linearGradient>\n");
-    svg.push_str(&format!(
-        "  <rect rx=\"3\" width=\"{}\" height=\"20\" fill=\"#555\"/>\n",
-        total_width
-    ));
-    svg.push_str(&format!(
-        "  <rect rx=\"3\" x=\"{}\" width=\"{}\" height=\"20\" fill=\"{}\"/>\n",
-        label_width, value_width, color
-    ));
-    svg.push_str(&format!(
-        "  <rect rx=\"3\" width=\"{}\" height=\"20\" fill=\"url(#s)\"/>\n",
-        total_width
-    ));
-    svg.push_str("  <g fill=\"#fff\" text-anchor=\"middle\" font-family=\"DejaVu Sans,sans-serif\" font-size=\"11\">\n");
-    svg.push_str(&format!(
-        "    <text x=\"{}\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">{}</text>\n",
-        lx, label
-    ));
-    svg.push_str(&format!(
-        "    <text x=\"{}\" y=\"14\">{}</text>\n",
-        lx, label
-    ));
-    svg.push_str(&format!(
-        "    <text x=\"{}\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">{}</text>\n",
-        vx, value
-    ));
-    svg.push_str(&format!(
-        "    <text x=\"{}\" y=\"14\">{}</text>\n",
-        vx, value
-    ));
-    svg.push_str("  </g>\n</svg>");
-    svg
+    Badge::new()
+        .label(label)
+        .label_color(Color::Hex("555".into()))
+        .value(value)
+        .value_color(Color::Hex(color.trim_start_matches('#').into()))
+        .to_svg()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hi! I came across jscpd and liked that it can publish duplication results as SVG badges alongside its other reports. The current renderer works, but badge layout and SVG generation are separate from jscpd's core task of detecting duplicated code and still need to be maintained.

I work on [badges.ws](https://badges.ws) and maintain [badgelib](https://github.com/vladkens/badgelib), a tested Rust library for generating badges. This PR uses it for the rendering step while jscpd retains control over the reported values, thresholds, colors, labels, and output files.

The change is small and preserves the reporter's current behavior. The badges become slightly more compact, and the trade-off is adding a rendering dependency; in return, jscpd no longer needs to maintain its own SVG renderer. What do you think?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/962)
<!-- Reviewable:end -->
