### PR TITLE
fix(cli): warn when --format value is not a supported format

### DIFF
--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -187,6 +187,21 @@ fn main() {
     let config = config_result.config;
     let opts = Options::from_cli_and_config(&cli, &config);
 
+    // Warn about unknown format names in --format: a typo like 'cs' would
+    // otherwise silently match 0 files and report a clean scan (#964).
+    // Custom formats introduced via --formats-exts are legal.
+    if !opts.formats.is_empty() {
+        let known = cpd_tokenizer::formats::list_formats();
+        for format in &opts.formats {
+            if !known.contains(&format.as_str()) && !opts.formats_exts.contains_key(format) {
+                eprintln!(
+                    "Warning: --format: '{}' is not a supported format, no files will match it (run with --list to see supported formats)",
+                    format
+                );
+            }
+        }
+    }
+
     // Warn about unknown format names in --cross-formats. Custom formats
     // introduced via --formats-exts are legal, so validate against both.
     if !opts.cross_formats.is_empty() {

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -92,6 +92,30 @@ fn scan_nonexistent_path_exits_without_panic() {
 }
 
 #[test]
+fn unknown_format_prints_warning() {
+    let output = run_cpd(["--format", "zzzznotalang", "--reporters", "silent", "."])
+        .expect("cpd binary must exist");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("'zzzznotalang' is not a supported format"),
+        "unknown --format must print warning, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn known_format_prints_no_warning() {
+    let output = run_cpd(["--format", "csharp", "--reporters", "silent", "."])
+        .expect("cpd binary must exist");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("not a supported format"),
+        "known --format must not warn, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
 fn store_flag_prints_warning() {
     let output = run_cpd(["--store", "leveldb", "--reporters", "silent", "."])
         .expect("cpd binary must exist");


### PR DESCRIPTION
Fixes #964 (part 1: notify on unsupported format).

An unrecognized `--format` token — like `cs` instead of `csharp`, or any typo — silently matched 0 files and reported a clean scan with exit 0, so a misconfigured CI gate looked identical to a clean codebase.

Now the CLI prints a stderr warning naming the offending value:

```
Warning: --format: 'cs' is not a supported format, no files will match it (run with --list to see supported formats)
```

- Mirrors the existing `--cross-formats` unknown-format validation in `main.rs`; custom formats declared via `--formats-exts` are still accepted without warning.
- Validates the merged CLI+config format list, so a bad value in `.jscpd.json` warns too.
- Adds integration tests for the warning and its absence on a valid format; full workspace suite passes locally (842 tests), clippy and fmt clean.

The issue's part 2 (accepting `cs` as an extension alias for `csharp`) is a separate enhancement and intentionally not included here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/978)
<!-- Reviewable:end -->