### PR TITLE
feat(mcp): add glama.json and Dockerfile for Glama MCP listing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# MCP server image for jscpd (used by Glama for release builds).
+# The npm package ships prebuilt Rust binaries per platform.
+FROM node:22-slim
+
+RUN npm install -g jscpd@5 && jscpd --version
+
+# The MCP server scans its cwd at startup; give it an empty workdir so it
+# doesn't try to scan the container's root filesystem.
+WORKDIR /app
+
+# Stdio MCP server: responds to initialize/tools requests on stdin/stdout.
+ENTRYPOINT ["jscpd", "--mcp"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/glama.json",
+  "maintainers": ["kucherenko"]
+}


### PR DESCRIPTION
Improves the [Glama score](https://glama.ai/mcp/servers/kucherenko/jscpd/score) for the jscpd MCP server (currently 17%):

- **glama.json** — maintainer manifest Glama looks for in the repo root; directly fixes the failing `glama.json` criterion.
- **Dockerfile** — installs `jscpd@5` from npm (prebuilt Rust binary) and starts the stdio MCP server via `jscpd --mcp`. Glama needs this to build a release, which unlocks the Server Coherence and Tool Definition Quality scores (70%+30% of the quality score). `WORKDIR /app` matters: without it the startup scan runs against the container's root filesystem and the server never responds.

Verified locally: the built image responds to `initialize` (serverInfo jscpd 5.0.16) and `tools/list` (all 4 tools) over stdio.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/980)
<!-- Reviewable:end -->
