### PR TITLE
feat(config): discover config in .config/ subfolder (dot-config convention)

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -210,6 +210,8 @@ v5 reads the same `.jscpd.json` config file format as v4:
 
 Isolation groups use the nested-array form in the config file: `"skipIsolated": [["packages/a", "packages/b"]]`.
 
+Config discovery order: `--config <path>` → `.jscpd.json` → `.config/jscpd.json` (the [dot-config convention](https://dot-config.github.io/), also accepts `.config/.jscpd.json`) → the `jscpd` key in `package.json`.
+
 ## Format Support
 
 v5 supports **223 formats** (verified via `--list`). Use `cpd --list` to see the full list.

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -421,6 +421,7 @@ pub struct ConfigFile {
 pub(crate) enum ConfigSource {
     Explicit(PathBuf),
     AutoJscpdJson,
+    AutoDotConfig(PathBuf),
     AutoPackageJson,
 }
 
@@ -879,7 +880,8 @@ fn resolve_config_paths(cfg: &mut ConfigFile, config_dir: &Path) {
     }
 }
 
-/// Load config from file if specified, or from .jscpd.json / package.json jscpd key.
+/// Load config from file if specified, or from .jscpd.json / .config/jscpd.json /
+/// package.json jscpd key.
 /// Reports diagnostics for any errors encountered (IO, parse, unknown fields, invalid values).
 /// For explicit --config paths, all diagnostics are fatal (caller should exit with code 1).
 /// For auto-discovered configs, diagnostics are warnings and the cascade falls through
@@ -894,6 +896,10 @@ pub fn load_config(path: Option<&Path>) -> ConfigResult {
     let mut auto_diagnostics = Vec::new();
 
     if let Some(result) = try_load_jscpd_json(&mut auto_diagnostics) {
+        return result;
+    }
+
+    if let Some(result) = try_load_dot_config(&mut auto_diagnostics) {
         return result;
     }
 
@@ -984,6 +990,24 @@ fn try_load_jscpd_json(auto_diagnostics: &mut Vec<ConfigDiagnostic>) -> Option<C
         ConfigSource::AutoJscpdJson,
         &path,
     ))
+}
+
+/// Optional dot-config convention (https://dot-config.github.io/): projects can
+/// keep tool configs in a .config/ subfolder instead of the repository root.
+/// Checked only after .jscpd.json, so a root config always wins.
+fn try_load_dot_config(auto_diagnostics: &mut Vec<ConfigDiagnostic>) -> Option<ConfigResult> {
+    for candidate in [".config/jscpd.json", ".config/.jscpd.json"] {
+        let path = PathBuf::from(candidate);
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            let value = parse_json_config(&content, &path, auto_diagnostics)?;
+            return Some(build_config_result(
+                value,
+                ConfigSource::AutoDotConfig(path.clone()),
+                &path,
+            ));
+        }
+    }
+    None
 }
 
 fn try_load_package_json(auto_diagnostics: &mut Vec<ConfigDiagnostic>) -> Option<ConfigResult> {

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -146,6 +146,9 @@ fn main() {
             ConfigSource::AutoJscpdJson => {
                 eprintln!("Using config from .jscpd.json");
             }
+            ConfigSource::AutoDotConfig(p) => {
+                eprintln!("Using config from {}", p.display());
+            }
             ConfigSource::AutoPackageJson => {
                 eprintln!("Using config from package.json");
             }

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -91,6 +91,51 @@ fn scan_nonexistent_path_exits_without_panic() {
     // Just verify it doesn't crash (SIGSEGV etc.) — any exit code is fine
 }
 
+/// Run cpd in a given working directory (for config auto-discovery tests).
+fn run_cpd_in_dir(dir: &std::path::Path) -> Option<Output> {
+    let bin = maybe_bin()?;
+    Some(
+        Command::new(&bin)
+            .args(["--reporters", "silent", "."])
+            .current_dir(dir)
+            .output()
+            .expect("failed to run cpd"),
+    )
+}
+
+#[test]
+fn dot_config_subfolder_is_discovered() {
+    let dir = std::env::temp_dir().join(format!("cpd-dotconfig-{}", std::process::id()));
+    std::fs::create_dir_all(dir.join(".config")).unwrap();
+    std::fs::write(dir.join(".config/jscpd.json"), r#"{"minTokens": 42}"#).unwrap();
+
+    let output = run_cpd_in_dir(&dir).expect("cpd binary must exist");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(
+        stderr.contains("Using config from .config/jscpd.json"),
+        "must discover .config/jscpd.json, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn root_config_wins_over_dot_config_subfolder() {
+    let dir = std::env::temp_dir().join(format!("cpd-dotconfig-prec-{}", std::process::id()));
+    std::fs::create_dir_all(dir.join(".config")).unwrap();
+    std::fs::write(dir.join(".jscpd.json"), r#"{"minTokens": 42}"#).unwrap();
+    std::fs::write(dir.join(".config/jscpd.json"), r#"{"minTokens": 99}"#).unwrap();
+
+    let output = run_cpd_in_dir(&dir).expect("cpd binary must exist");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(
+        stderr.contains("Using config from .jscpd.json"),
+        "root .jscpd.json must take precedence, got stderr: {}",
+        stderr
+    );
+}
+
 #[test]
 fn unknown_format_prints_warning() {
     let output = run_cpd(["--format", "zzzznotalang", "--reporters", "silent", "."])


### PR DESCRIPTION
Closes #979.

Adds optional support for the [dot-config convention](https://dot-config.github.io/): jscpd now also looks for its config at `.config/jscpd.json` (and `.config/.jscpd.json`).

Discovery order (unchanged sources keep their positions):

1. `--config <path>` (explicit)
2. `.jscpd.json` in the project root — **still wins**, the new location is a fallback, not the main flow
3. `.config/jscpd.json`, then `.config/.jscpd.json` ← new
4. `jscpd` key in `package.json`

Notes:
- Paths inside a `.config/`-discovered config resolve relative to the working directory (same as other auto-discovered sources), so globs behave as if the file were in the root.
- A malformed `.config/jscpd.json` warns and falls through to `package.json`, matching the existing cascade behavior.
- Startup reports the source: `Using config from .config/jscpd.json`.
- Two integration tests: discovery in `.config/`, and root-config precedence. Full suite passes locally (844 tests), clippy and fmt clean. Documented in `docs/rust.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/981)
<!-- Reviewable:end -->
