### PR TITLE
chore(ci): run npm metadata cleanup from CI (2FA-exempt token)

### DIFF
--- a/.github/workflows/npm-dist-tags.yml
+++ b/.github/workflows/npm-dist-tags.yml
@@ -6,8 +6,26 @@ name: npm dist-tags
 # workflow re-points `latest` at the newest 5.x and keeps `latest-4` on the newest
 # 4.x. It runs on demand; the Release workflow runs the same guard inline.
 
+# It also performs on-demand npm metadata cleanup (removing stale dist-tags,
+# deprecating obsolete version ranges). Those run here rather than locally
+# because the account enforces 2FA on writes: an interactive OTP is required
+# for every write from a laptop, while the CI automation token is exempt.
+
 on:
   workflow_dispatch:
+    inputs:
+      remove_tags:
+        description: "Comma-separated dist-tags to delete (e.g. prerelease,canary,rc). Empty = skip"
+        type: string
+        default: ""
+      deprecate_range:
+        description: "Semver range to deprecate (e.g. <4.0.0). Empty = skip"
+        type: string
+        default: ""
+      deprecate_message:
+        description: "Deprecation message (ignored when deprecate_range is empty)"
+        type: string
+        default: "No longer maintained. Upgrade to v5 (Rust engine, 24-37x faster): npm i jscpd — or the maintained v4 line: npm i jscpd@latest-4"
 
 permissions:
   contents: read
@@ -22,6 +40,44 @@ jobs:
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Remove stale dist-tags
+        if: inputs.remove_tags != ''
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          REMOVE_TAGS: ${{ inputs.remove_tags }}
+        run: |
+          echo "before:"; npm dist-tag ls jscpd
+          IFS=',' read -ra tags <<< "$REMOVE_TAGS"
+          for tag in "${tags[@]}"; do
+            tag=$(echo "$tag" | tr -d '[:space:]')
+            [ -z "$tag" ] && continue
+            case "$tag" in
+              latest|latest-4)
+                echo "refusing to remove protected tag '$tag'"; exit 1 ;;
+            esac
+            npm dist-tag rm jscpd "$tag" && echo "removed: $tag"
+          done
+          echo "after:"; npm dist-tag ls jscpd
+
+      - name: Deprecate version range
+        if: inputs.deprecate_range != ''
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RANGE: ${{ inputs.deprecate_range }}
+          MESSAGE: ${{ inputs.deprecate_message }}
+        run: |
+          echo "deprecating jscpd@${RANGE}"
+          npm deprecate "jscpd@${RANGE}" "$MESSAGE"
+          # Read the full packument: per-version deprecation is not visible in
+          # `npm view --json`, which returns only the latest manifest.
+          echo "verifying (registry may lag a few seconds):"
+          curl -s "https://registry.npmjs.org/jscpd" \
+            | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{
+                const p=JSON.parse(d), vs=Object.entries(p.versions);
+                const dep=vs.filter(([,m])=>m.deprecated);
+                console.log(\`deprecated \${dep.length} of \${vs.length} versions\`);
+              })"
 
       - name: Retag jscpd
         env:


### PR DESCRIPTION
Follow-up to the npm versions-list cleanup.

## Why

The `jscpd` package has 179 versions, and the "Current Tags" block on npmjs.com advertises three stale tags — two of which point at versions that are *already deprecated*:

| Tag | Points at | Published |
|---|---|---|
| `rc` | 4.0.0 | 2024-05-26 |
| `canary` | 3.3.0-alpha.8 | 2020-04-29 (deprecated) |
| `prerelease` | 1.0.0-rc.6 | 2018-11-17 (deprecated) |

Running `npm dist-tag rm` and `npm deprecate` from a laptop fails with `EOTP` — the account enforces 2FA on writes, requiring an interactive one-time password per operation. The CI automation token is exempt, so these belong here.

## What

Two optional `workflow_dispatch` inputs on the existing dist-tags workflow:

- **`remove_tags`** — comma-separated dist-tags to delete. `latest` and `latest-4` are explicitly refused as a guard against fat-fingering the tags that matter.
- **`deprecate_range`** — semver range to deprecate, with a configurable message.

Both skip when empty, so dispatching with no inputs behaves exactly as before (retag `latest`/`latest-4` only). The existing retag step is unchanged and still runs last.

## Intended first run

```
remove_tags:      prerelease,canary,rc
deprecate_range:  <4.0.0
```

That covers 147 of 179 versions (v0.x–v3.x, 2013–2023) which together account for 1.7% of weekly downloads. v4 is deliberately untouched — it is 25% of traffic and still maintained.

Deprecation is reversible with an empty message, and tags can be re-added with `npm dist-tag add`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/983)
<!-- Reviewable:end -->
