### PR TITLE
fix(ci): fail dist-tag removal step when npm rejects a delete

### DIFF
--- a/.github/workflows/npm-dist-tags.yml
+++ b/.github/workflows/npm-dist-tags.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           echo "before:"; npm dist-tag ls jscpd
           IFS=',' read -ra tags <<< "$REMOVE_TAGS"
+          failed=0
           for tag in "${tags[@]}"; do
             tag=$(echo "$tag" | tr -d '[:space:]')
             [ -z "$tag" ] && continue
@@ -56,9 +57,24 @@ jobs:
               latest|latest-4)
                 echo "refusing to remove protected tag '$tag'"; exit 1 ;;
             esac
-            npm dist-tag rm jscpd "$tag" && echo "removed: $tag"
+            # Do not chain with `&&`: under `set -e` a failing command in an
+            # `&&` list is exempt, which silently turned three 403s into a
+            # green step on the first run of this workflow.
+            if npm dist-tag rm jscpd "$tag"; then
+              echo "removed: $tag"
+            else
+              echo "FAILED to remove: $tag"
+              failed=1
+            fi
           done
           echo "after:"; npm dist-tag ls jscpd
+          if [ "$failed" -ne 0 ]; then
+            echo
+            echo "npm rejects dist-tag deletion for token auth on 2FA-enabled"
+            echo "accounts (403 on DELETE, EOTP locally). Remove them from a"
+            echo "terminal instead: npm dist-tag rm jscpd <tag>"
+            exit 1
+          fi
 
       - name: Deprecate version range
         if: inputs.deprecate_range != ''


### PR DESCRIPTION
Found by the first real run of the cleanup workflow ([run 33316058708](https://github.com/kucherenko/jscpd/actions/runs/33316058708)).

## The bug

The step chained:

```bash
npm dist-tag rm jscpd "$tag" && echo "removed: $tag"
```

Under `set -e`, a failing command inside an `&&` list is exempt from exit-on-error. npm returned **403 Forbidden** for all three tags, no `removed:` line was ever printed, and the step still reported **success** — a cleanup workflow that silently does nothing is worse than one that fails.

## The fix

Explicit `if/else`, a `failed` flag, and a non-zero exit that explains the cause.

## Why the 403 (not a permissions problem)

The same token successfully deprecated 147 versions in the same run, so it has package write access. npm gates dist-tag *deletion* behind interactive 2FA and rejects token auth for it — consistent with the `EOTP` the same command produces from a laptop. Tag removal therefore has to be done from a terminal:

```bash
npm dist-tag rm jscpd prerelease
npm dist-tag rm jscpd canary
npm dist-tag rm jscpd rc
```

The failure message now says exactly that, so the next person doesn't have to rediscover it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/984)
<!-- Reviewable:end -->
