### PR TITLE
docs(readme): add the Windows PowerShell install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ jscpd implements the [Rabin-Karp](https://en.wikipedia.org/wiki/Rabin%E2%80%93Ka
 ## Quick Start
 
 ```bash
-# Install (all platforms — installs the jscpd command)
+# Install on macOS / Linux (installs the jscpd command)
 curl -fsSL https://jscpd.dev/install.sh | bash
+
+# Install on Windows (PowerShell — no Node.js required)
+irm https://jscpd.dev/install.ps1 | iex
 
 # TypeScript engine (Node.js, v4.x)
 npm install -g jscpd@4


### PR DESCRIPTION
## Summary

The Quick Start block in the README offered only the `curl … | bash` installer and labelled it "all platforms" — which is wrong on Windows, where that command doesn't work.

Splits it into the two real options, matching what jscpd.dev already shows:

```bash
# Install on macOS / Linux (installs the jscpd command)
curl -fsSL https://jscpd.dev/install.sh | bash

# Install on Windows (PowerShell — no Node.js required)
irm https://jscpd.dev/install.ps1 | iex
```

## Verification

`https://jscpd.dev/install.ps1` returns HTTP 200 and serves the actual PowerShell installer, so the new line points at a script that exists.

Docs-only change; no code or behaviour affected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/986)
<!-- Reviewable:end -->
