### PR TITLE
fix(rust): correct the declared MSRV to 1.96 and enforce it in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,3 +120,37 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         working-directory: rust
         run: cargo install cargo-deny --locked && cargo deny check
+
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Read declared MSRV
+        id: msrv
+        run: |
+          version=$(sed -nE 's/^rust-version = "([0-9.]+)"$/\1/p' rust/Cargo.toml | head -1)
+          if [ -z "$version" ]; then
+            echo "ERROR: no rust-version found in rust/Cargo.toml"
+            exit 1
+          fi
+          echo "Declared MSRV: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: "rust -> rust/target"
+          key: msrv-${{ steps.msrv.outputs.version }}
+          cache-on-failure: true
+
+      # `+toolchain` outranks rust-toolchain.toml, which pins a newer compiler
+      # for day-to-day development. Without it this job would silently test the
+      # pinned version instead of the MSRV.
+      - name: cargo check at MSRV
+        working-directory: rust
+        run: cargo +${{ steps.msrv.outputs.version }} check --workspace --all-targets --locked

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.96"
 authors = ["jscpd contributors"]
 license = "MIT"
 homepage = "https://jscpd.dev"

--- a/rust/README.md
+++ b/rust/README.md
@@ -108,7 +108,8 @@ println!("Analyzed {} files", result.statistics.total.sources);
 
 ## Building
 
-Requires Rust 1.87+ (see `rust-toolchain.toml`).
+Requires Rust 1.96+ (the MSRV declared in `Cargo.toml`, enforced by the `msrv`
+job in CI). Development uses the exact toolchain pinned in `rust-toolchain.toml`.
 
 ```bash
 cargo build --release

--- a/rust/crates/cpd-finder/src/walker.rs
+++ b/rust/crates/cpd-finder/src/walker.rs
@@ -151,33 +151,31 @@ fn walk_one(root: &Path, config: &WalkConfig, results: &mut Vec<DiscoveredFile>)
             }
 
             // Skip symlinks if not following.
-            if !follow_symlinks {
-                if let Ok(meta) = std::fs::symlink_metadata(&path) {
-                    if meta.file_type().is_symlink() {
-                        return WalkState::Continue;
-                    }
-                }
+            if !follow_symlinks
+                && let Ok(meta) = std::fs::symlink_metadata(&path)
+                && meta.file_type().is_symlink()
+            {
+                return WalkState::Continue;
             }
 
             // Size limit check (metadata only — no file read yet).
-            if let Some(max) = max_size {
-                if let Ok(meta) = std::fs::metadata(&path) {
-                    if meta.len() > max {
-                        return WalkState::Continue;
-                    }
-                }
+            if let Some(max) = max_size
+                && let Ok(meta) = std::fs::metadata(&path)
+                && meta.len() > max
+            {
+                return WalkState::Continue;
             }
 
             // Pattern filter: if set, only include files matching the positive glob.
             // Try matching against both the relative path (stripped of root prefix) and
             // the full path so that both relative patterns (e.g. `src/**/*.ts`) and
             // absolute patterns (e.g. `/project/src/**/*.ts`) work correctly.
-            if let Some(ref ps) = pattern_set {
-                if !ps.is_empty() {
-                    let rel = path.strip_prefix(&root_canon).unwrap_or(&path);
-                    if !ps.is_match(rel) && !ps.is_match(&path) {
-                        return WalkState::Continue;
-                    }
+            if let Some(ref ps) = pattern_set
+                && !ps.is_empty()
+            {
+                let rel = path.strip_prefix(&root_canon).unwrap_or(&path);
+                if !ps.is_match(rel) && !ps.is_match(&path) {
+                    return WalkState::Continue;
                 }
             }
 

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -126,15 +126,14 @@ impl Reporter for SarifReporter {
             if let Some(hash) = &clone_hash {
                 props["clone_hash"] = json!(hash);
             }
-            if self.blame {
-                if let Some(blame) = &clone.fragment_a.blame {
+            if self.blame
+                && let Some(blame) = &clone.fragment_a.blame {
                     props["blame"] = json!({
                         "sha": blame.commit_sha,
                         "author": blame.author,
                         "timestamp": blame.timestamp,
                     });
                 }
-            }
 
             let mut result = json!({
                 "ruleId": "jscpd/duplicate-code",
@@ -175,10 +174,10 @@ impl Reporter for SarifReporter {
             .iter()
             .map(|(root, uri)| {
                 let mut loc = json!({ "uri": uri });
-                if let Some(root) = root {
-                    if let Some(base_id) = root_to_base_id.get(root) {
-                        loc["uriBaseId"] = json!(base_id);
-                    }
+                if let Some(root) = root
+                    && let Some(base_id) = root_to_base_id.get(root)
+                {
+                    loc["uriBaseId"] = json!(base_id);
                 }
                 json!({ "location": loc })
             })

--- a/rust/crates/cpd-tokenizer/src/javascript.rs
+++ b/rust/crates/cpd-tokenizer/src/javascript.rs
@@ -103,10 +103,10 @@ fn find_ignore_ranges(source: &str) -> Vec<[usize; 2]> {
             let comment_text = &source[i..end];
             if comment_text.contains("jscpd:ignore-start") {
                 start = Some(end);
-            } else if comment_text.contains("jscpd:ignore-end") {
-                if let Some(s) = start.take() {
-                    ranges.push([s, i]);
-                }
+            } else if comment_text.contains("jscpd:ignore-end")
+                && let Some(s) = start.take()
+            {
+                ranges.push([s, i]);
             }
             i = end;
             continue;

--- a/rust/crates/cpd-tokenizer/src/razor.rs
+++ b/rust/crates/cpd-tokenizer/src/razor.rs
@@ -91,10 +91,10 @@ fn extract_razor_blocks(source: &str) -> Vec<RazorBlock> {
                 && !waiting_for_block_brace
                 && (ch.is_whitespace() || matches!(ch, '[' | ']' | '<' | '>' | '&' | ';' | ','));
             if is_boundary {
-                if let Some(block) = current_block.take() {
-                    if !block.content.is_empty() {
-                        blocks.push(block);
-                    }
+                if let Some(block) = current_block.take()
+                    && !block.content.is_empty()
+                {
+                    blocks.push(block);
                 }
                 in_code = false;
                 offset += ch_len;

--- a/rust/crates/cpd-tokenizer/src/sfc.rs
+++ b/rust/crates/cpd-tokenizer/src/sfc.rs
@@ -108,10 +108,10 @@ fn find_sfc_blocks(source: &str, file_format: &str) -> Vec<SfcBlock> {
     let source_lower = source.to_ascii_lowercase();
     let mut blocks = Vec::new();
 
-    if file_format == "astro" {
-        if let Some(fm) = astro_frontmatter_block(source) {
-            blocks.push(fm);
-        }
+    if file_format == "astro"
+        && let Some(fm) = astro_frontmatter_block(source)
+    {
+        blocks.push(fm);
     }
 
     for tag in sfc_tag_names(file_format) {

--- a/rust/crates/cpd-tokenizer/src/ts_strip.rs
+++ b/rust/crates/cpd-tokenizer/src/ts_strip.rs
@@ -199,11 +199,11 @@ impl<'a> Visit<'a> for Collector<'_> {
         }
         if let Some(specifiers) = &it.specifiers {
             for specifier in specifiers {
-                if let ImportDeclarationSpecifier::ImportSpecifier(s) = specifier {
-                    if s.import_kind == ImportOrExportKind::Type {
-                        // Leaves a stray `,` behind — documented limitation.
-                        self.push(s.span.start, s.span.end);
-                    }
+                if let ImportDeclarationSpecifier::ImportSpecifier(s) = specifier
+                    && s.import_kind == ImportOrExportKind::Type
+                {
+                    // Leaves a stray `,` behind — documented limitation.
+                    self.push(s.span.start, s.span.end);
                 }
             }
         }

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -181,10 +181,10 @@ fn main() {
     }
 
     // CLI summary-by validation: warn on invalid value (parallels --mode)
-    if let Some(metric) = cli.summary_by.as_deref() {
-        if let Err(e) = metric.parse::<cpd_core::summary::SummaryMetric>() {
-            eprintln!("Warning: --summary-by: {} (defaulting to tokens)", e);
-        }
+    if let Some(metric) = cli.summary_by.as_deref()
+        && let Err(e) = metric.parse::<cpd_core::summary::SummaryMetric>()
+    {
+        eprintln!("Warning: --summary-by: {} (defaulting to tokens)", e);
     }
 
     let config = config_result.config;
@@ -554,20 +554,20 @@ fn main() {
     if threshold_exceeded || new_clones_exceeded {
         std::process::exit(1);
     }
-    if let Some(code) = opts.exit_code {
-        if !clones.is_empty() {
-            std::process::exit(code);
-        }
+    if let Some(code) = opts.exit_code
+        && !clones.is_empty()
+    {
+        std::process::exit(code);
     }
 }
 
 /// Convert a source_id path to absolute if it isn't already.
 fn make_path_absolute(source_id: &mut String) {
     let path = std::path::Path::new(source_id);
-    if !path.is_absolute() {
-        if let Ok(abs) = std::fs::canonicalize(path) {
-            *source_id = abs.to_string_lossy().into_owned();
-        }
+    if !path.is_absolute()
+        && let Ok(abs) = std::fs::canonicalize(path)
+    {
+        *source_id = abs.to_string_lossy().into_owned();
     }
 }
 


### PR DESCRIPTION
## The problem

The crates.io page for [`jscpd`](https://crates.io/crates/jscpd) advertises **Rust 1.87** as the minimum supported version. The crate cannot build on it:

```console
$ cargo +1.93 check -p jscpd
error: rustc 1.93.1 is not supported by the following packages:
  oxc_allocator@0.147.0 requires rustc 1.96.0
  oxc_ast@0.147.0 requires rustc 1.96.0
  ...
```

crates.io renders `[workspace.package] rust-version` verbatim, so anyone trusting the badge and installing 1.87 hits a hard resolution error rather than a build.

## Why it's wrong

The real floor is **1.96.0**. These are not optional or dev-only deps — `oxc_parser` → `cpd-tokenizer` → `jscpd` is a mandatory chain:

| Requires | Crates | Path to published crate |
|---|---|---|
| **1.96.0** | 13 × `oxc_*` 0.147.0 | `cpd-tokenizer` → `jscpd` |
| 1.88 | `ignore`, `globset` | `cpd-finder` → `jscpd` |
| 1.88 | `askama` 0.16 + macros | `cpd-reporter` → `jscpd` |

`git log -L 13,13:rust/Cargo.toml` shows one commit ever touched the line — `0ddf611` (2026-06-04), when the Rust workspace was added. It was likely accurate then (oxc was pinned to `0.133`) and drifted as oxc raised its own MSRV across later bumps.

## Why nothing caught it

Every workflow pins the toolchain to `1.97.1` — `rust.yml:29`, `release.yml:130`, `crates-publish.yml:77`, `npm-rust-publish.yml:151`. No job has ever built at the declared MSRV, so the field was free to rot.

## Changes

- `rust/Cargo.toml` — `rust-version` 1.87 → 1.96.
- `.github/workflows/rust.yml` — new `msrv` job. It reads `rust-version` straight out of `Cargo.toml` rather than hardcoding it, so the workflow can't drift out of sync with the manifest, then runs `cargo check --workspace --all-targets --locked` against exactly that toolchain.
- `rust/README.md` — said "Requires Rust 1.87+ (see `rust-toolchain.toml`)", but that file pins `1.97.1`; the two never agreed. Now states the MSRV and explains what the pin is for.

The job invokes `cargo +<version>` explicitly instead of relying on the toolchain the action installs — `rust-toolchain.toml` pins 1.97.1 for development and would otherwise take precedence, silently testing the wrong compiler.

## Verification

```console
$ cargo +1.96 check --workspace --all-targets --locked
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.95s
```

Passes with `--all-targets`, so 1.96 is achievable including dev-dependencies. `--locked` confirms it holds against the committed lockfile.

Metadata and CI only — no source or behaviour changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/987)
<!-- Reviewable:end -->
