### PR TITLE
feat: near-miss clone merging with --max-gap-lines (Type-3, stage 1 of #999)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ inputs:
   max-gap-lines:
     description: "Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3); 0 disables"
     required: false
-    default: ""
+    default: "0"
   follow-symlinks:
     description: "Follow symbolic links"
     required: false
@@ -413,7 +413,7 @@ runs:
         if [ "$INPUT_IGNORE_ANNOTATIONS" = "true" ]; then
           ARGS+=("--ignore-annotations")
         fi
-        if [ -n "$INPUT_MAX_GAP_LINES" ]; then
+        if [ -n "$INPUT_MAX_GAP_LINES" ] && [ "$INPUT_MAX_GAP_LINES" != "0" ]; then
           ARGS+=("--max-gap-lines" "$INPUT_MAX_GAP_LINES")
         fi
         if [ "$INPUT_FOLLOW_SYMLINKS" = "true" ]; then

--- a/action.yml
+++ b/action.yml
@@ -105,6 +105,10 @@ inputs:
     description: "Skip annotations and decorators (@Name, @Name(...))"
     required: false
     default: "false"
+  max-gap-lines:
+    description: "Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3); 0 disables"
+    required: false
+    default: ""
   follow-symlinks:
     description: "Follow symbolic links"
     required: false
@@ -282,6 +286,7 @@ runs:
         INPUT_IGNORE_IDENTIFIERS: ${{ inputs.ignore-identifiers }}
         INPUT_IGNORE_LITERALS: ${{ inputs.ignore-literals }}
         INPUT_IGNORE_ANNOTATIONS: ${{ inputs.ignore-annotations }}
+        INPUT_MAX_GAP_LINES: ${{ inputs.max-gap-lines }}
         INPUT_FOLLOW_SYMLINKS: ${{ inputs.follow-symlinks }}
         INPUT_NO_GITIGNORE: ${{ inputs.no-gitignore }}
         INPUT_ABSOLUTE: ${{ inputs.absolute }}
@@ -407,6 +412,9 @@ runs:
         fi
         if [ "$INPUT_IGNORE_ANNOTATIONS" = "true" ]; then
           ARGS+=("--ignore-annotations")
+        fi
+        if [ -n "$INPUT_MAX_GAP_LINES" ]; then
+          ARGS+=("--max-gap-lines" "$INPUT_MAX_GAP_LINES")
         fi
         if [ "$INPUT_FOLLOW_SYMLINKS" = "true" ]; then
           ARGS+=("--follow-symlinks")

--- a/docs/ci-and-hooks.md
+++ b/docs/ci-and-hooks.md
@@ -66,7 +66,7 @@ The workflow fails if more than 5% of the code is duplicated.
 | `ignore-identifiers` | Treat all identifiers as equal (Type-2 clones) | `false` |
 | `ignore-literals` | Treat all string and numeric literals as equal | `false` |
 | `ignore-annotations` | Skip annotations and decorators (`@Name`, `@Name(...)`) | `false` |
-| `max-gap-lines` | Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3) | — |
+| `max-gap-lines` | Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3); `0` disables | `0` |
 | `follow-symlinks` | Follow symbolic links | `false` |
 | `no-gitignore` | Don't respect .gitignore files | `false` |
 | `absolute` | Use absolute paths in reports | `false` |

--- a/docs/ci-and-hooks.md
+++ b/docs/ci-and-hooks.md
@@ -66,6 +66,7 @@ The workflow fails if more than 5% of the code is duplicated.
 | `ignore-identifiers` | Treat all identifiers as equal (Type-2 clones) | `false` |
 | `ignore-literals` | Treat all string and numeric literals as equal | `false` |
 | `ignore-annotations` | Skip annotations and decorators (`@Name`, `@Name(...)`) | `false` |
+| `max-gap-lines` | Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3) | — |
 | `follow-symlinks` | Follow symbolic links | `false` |
 | `no-gitignore` | Don't respect .gitignore files | `false` |
 | `absolute` | Use absolute paths in reports | `false` |

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -83,6 +83,7 @@ cpd [OPTIONS] [PATH]...
 | `--ignore-identifiers` | | Treat all identifiers as equal, so clones that differ only in variable, function or type names are found. See [Type-2 clones](#type-2-clones-renamed-identifiers-literals-and-annotations) | off |
 | `--ignore-literals` | | Treat all string literals as equal and all numeric literals as equal | off |
 | `--ignore-annotations` | | Skip annotations and decorators (`@Name`, `@Name(...)`) before detection | off |
+| `--max-gap-lines` | | Merge clones of one file pair separated by at most N unmatched lines in both files into one near-miss clone reported as `similar`. See [Type-3 clones](#type-3-clones-near-miss-merging-with---max-gap-lines) | 0 (off) |
 | `--formats-exts` | | Custom format-to-extension mapping (e.g. `javascript:es,es6;dart:dt`) | — |
 | `--formats-names` | | Custom format-to-filename mapping | — |
 | `--cross-formats` | | Detect clones across formats: `;`-separated groups of `,`-separated formats (e.g. `javascript,typescript`). Preset `js-ts` = `javascript,jsx,typescript,tsx` | — |
@@ -248,6 +249,7 @@ Options can also come from a `.jscpd.json` config file (camelCase keys; existing
   "ignoreIdentifiers": false,
   "ignoreLiterals": false,
   "ignoreAnnotations": false,
+  "maxGapLines": 0,
   "gitignore": true,
   "mode": "mild"
 }
@@ -318,6 +320,21 @@ jscpd --ignore-annotations src/main/java/             # @Override / @Deprecated 
 ```
 
 Normalized runs find more and longer clones than exact runs, so their snippet fingerprints (`jscpdCloneHash/v1`) differ from an exact run's. Keep a separate `--baseline` file per configuration. See [`fixtures/type2-demo`](../fixtures/type2-demo/README.md) for a runnable example of each flag.
+
+### Type-3 clones: near-miss merging with `--max-gap-lines`
+
+A copy with a line inserted, removed or changed in the middle shows up as two shorter exact clones with a gap between them, each of which must clear `--min-tokens` and `--min-lines` on its own. `--max-gap-lines N` (config key `maxGapLines`) merges clones of the same file pair whose fragments follow each other in *both* files with at most `N` unmatched lines in between, and reports the result as one clone of kind `similar`:
+
+```bash
+jscpd src/                       # a.js 1-4 ↔ b.js 1-4, a.js 4-9 ↔ b.js 5-10: two exact clones
+jscpd --max-gap-lines 1 src/     # Clone found (javascript, similar ~0.85): a.js 1-9 ↔ b.js 1-10
+```
+
+A merged clone's `tokens` is the number of matched tokens and `similarity` is that number divided by the tokens of the longer merged span, so a single inserted line in a 60-token block gives roughly `0.9`. Chains of matches merge transitively, and the merge is applied after every other filter (`--min-lines`, `--skip-local`, `--skip-isolated`). Because merging only ever joins clones the exact run already reported, it cannot introduce a match that was not there; it removes fragmentation. It applies to every language.
+
+Reporting: the console prints `Clone found (javascript, similar ~0.85)`, the `ai` reporter appends `[~0.85]`, the JSON report adds `"kind": "similar"` and a `"similarity"` value, SARIF files merged clones under `jscpd/near-miss-code` with a `similarity` property, and Code Climate uses the same `check_name`. Duplicated-line statistics count the merged span, gap lines included. With the default `0` the merge pass is skipped entirely and output is identical to earlier releases. See [`fixtures/type3-demo`](../fixtures/type3-demo/README.md) for a runnable example.
+
+Function-level similarity scoring for JavaScript and TypeScript (AST-based, catching edits spread through a function rather than a single gap) is the second stage of [#999](https://github.com/kucherenko/jscpd/issues/999) and is not part of this option.
 
 ## Format Support
 

--- a/fixtures/type3-demo/README.md
+++ b/fixtures/type3-demo/README.md
@@ -1,0 +1,77 @@
+# Type-3 clones (near-miss)
+
+A near-miss clone is a copy with a few lines inserted, removed or changed in
+the middle. A token-window detector sees it as two shorter exact clones with
+a gap between them. `--max-gap-lines N` (config key `maxGapLines`, off at
+`0`) merges clones of the same file pair whose fragments follow each other in
+both files with at most `N` unmatched lines between them, and reports one
+clone of kind `similar` with a `similarity` value (matched tokens over the
+tokens of the longer merged span).
+
+Commands run from the repository root at default thresholds; the lines after
+`#` are what the console reporter prints.
+
+| Directory | Gap | Default scan | `--max-gap-lines 1` | `--max-gap-lines 2` |
+|-----------|-----|--------------|---------------------|---------------------|
+| `inserted-line/` | 1 line | 2 exact clones | 1 similar clone | 1 similar clone |
+| `wide-gap/` | 2 lines | 2 exact clones | 2 exact clones | 1 similar clone |
+
+## `inserted-line/` — one inserted guard
+
+`save-account.js` is `save-user.js` with one `if (...) throw` line added in
+the middle.
+
+```bash
+jscpd fixtures/type3-demo/inserted-line
+# Clone found (javascript)
+#  - save-account.js [1:1 - 6:5] (6 lines, 60 tokens)
+#    save-user.js [1:1 - 6:6]
+# Clone found (javascript)
+#  - save-account.js [6:66 - 12:2] (7 lines, 100 tokens)
+#    save-user.js [5:55 - 11:2]
+# Found 2 clones.
+
+jscpd fixtures/type3-demo/inserted-line --max-gap-lines 1
+# Clone found (javascript, similar ~0.91)
+#  - save-account.js [1:1 - 12:2] (12 lines, 157 tokens)
+#    save-user.js [1:1 - 11:2]
+# Found 1 clones.
+```
+
+The two halves overlap on their boundary token (the `;` that ends line 5 of
+`save-user.js`), so the merged clone matches 157 tokens, not 160.
+
+## `wide-gap/` — a three-line block, two lines of gap
+
+`place-order-guarded.js` is `place-order.js` with a three-line `if` block
+inserted. The first exact clone ends on the `if` line and the second starts
+on the closing brace, leaving two unmatched lines between them, so a limit
+of 1 keeps the halves apart and a limit of 2 merges them.
+
+```bash
+jscpd fixtures/type3-demo/wide-gap --max-gap-lines 1
+# Found 2 clones.
+
+jscpd fixtures/type3-demo/wide-gap --max-gap-lines 2
+# Clone found (javascript, similar ~0.91)
+#  - place-order-guarded.js [1:1 - 15:2] (15 lines, 172 tokens)
+#    place-order.js [1:1 - 12:2]
+# Found 1 clones.
+```
+
+## Whole directory
+
+```bash
+jscpd fixtures/type3-demo
+# Found 4 clones.
+
+jscpd fixtures/type3-demo --max-gap-lines 2
+# Found 2 clones.
+
+jscpd fixtures/type3-demo --max-gap-lines 2 --reporters json,silent --output report
+# each entry in "duplicates" has "kind": "similar" and "similarity": 0.91…
+```
+
+Merging only joins clones the exact run already reported, so it never adds a
+match that was not there. Merged spans differ from the exact fragments, so a
+run with `--max-gap-lines` needs its own `--baseline` file.

--- a/fixtures/type3-demo/inserted-line/save-account.js
+++ b/fixtures/type3-demo/inserted-line/save-account.js
@@ -1,0 +1,12 @@
+export async function saveUser(user, db, clock) {
+  const row = toRow(user);
+  row.updatedAt = clock.now();
+  row.version = (row.version || 0) + 1;
+  row.normalizedEmail = user.email.trim().toLowerCase();
+  if (!row.id) throw new Error('cannot save a user without an id');
+  row.displayName = [user.firstName, user.lastName].filter(Boolean).join(' ');
+  await db.put('users', row.id, row);
+  await audit('save', row.id, row.version, clock.now());
+  await notify(user.email, 'profile-updated', { version: row.version });
+  return { id: row.id, version: row.version, updatedAt: row.updatedAt };
+}

--- a/fixtures/type3-demo/inserted-line/save-user.js
+++ b/fixtures/type3-demo/inserted-line/save-user.js
@@ -1,0 +1,11 @@
+export async function saveUser(user, db, clock) {
+  const row = toRow(user);
+  row.updatedAt = clock.now();
+  row.version = (row.version || 0) + 1;
+  row.normalizedEmail = user.email.trim().toLowerCase();
+  row.displayName = [user.firstName, user.lastName].filter(Boolean).join(' ');
+  await db.put('users', row.id, row);
+  await audit('save', row.id, row.version, clock.now());
+  await notify(user.email, 'profile-updated', { version: row.version });
+  return { id: row.id, version: row.version, updatedAt: row.updatedAt };
+}

--- a/fixtures/type3-demo/wide-gap/place-order-guarded.js
+++ b/fixtures/type3-demo/wide-gap/place-order-guarded.js
@@ -1,0 +1,15 @@
+export async function placeOrder(cart, customer, gateway) {
+  const order = buildOrder(cart, customer);
+  order.subtotal = cart.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  order.shipping = estimateShipping(customer.address, cart.weight);
+  order.total = order.subtotal + order.shipping + order.tax;
+  if (order.total <= 0) {
+    throw new RangeError('order total must be positive');
+  }
+  const payment = await gateway.charge(customer.paymentMethod, order.total, order.currency);
+  order.paymentId = payment.id;
+  order.status = payment.approved ? 'confirmed' : 'declined';
+  await orders.insert(order);
+  await mailer.send(customer.email, 'order-' + order.status, { order });
+  return { id: order.id, status: order.status, total: order.total };
+}

--- a/fixtures/type3-demo/wide-gap/place-order.js
+++ b/fixtures/type3-demo/wide-gap/place-order.js
@@ -1,0 +1,12 @@
+export async function placeOrder(cart, customer, gateway) {
+  const order = buildOrder(cart, customer);
+  order.subtotal = cart.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  order.shipping = estimateShipping(customer.address, cart.weight);
+  order.total = order.subtotal + order.shipping + order.tax;
+  const payment = await gateway.charge(customer.paymentMethod, order.total, order.currency);
+  order.paymentId = payment.id;
+  order.status = payment.approved ? 'confirmed' : 'declined';
+  await orders.insert(order);
+  await mailer.send(customer.email, 'order-' + order.status, { order });
+  return { id: order.id, status: order.status, total: order.total };
+}

--- a/rust/crates/cpd-core/src/detect.rs
+++ b/rust/crates/cpd-core/src/detect.rs
@@ -533,6 +533,7 @@ fn flush_clone(
         token_count: match_len as u32,
         is_new: false,
         kind,
+        similarity: None,
     });
 }
 
@@ -596,6 +597,89 @@ fn make_fragment(
 // ---------------------------------------------------------------------------
 // Deduplication — O(n) FxHashSet + sub-clone suppression
 // ---------------------------------------------------------------------------
+
+/// Gap-tolerant merging (issue #999, stage 1).
+///
+/// Two clones of the same file pair whose fragments follow each other in
+/// *both* files with at most `max_gap_lines` unmatched lines in between are
+/// merged into one `similar` clone spanning both. `token_count` becomes the
+/// number of matched tokens and `similarity` the matched tokens divided by
+/// the tokens of the longer merged span. Chains merge transitively. With
+/// `max_gap_lines == 0` the input is returned as-is, so default runs never
+/// enter this pass.
+pub fn merge_gapped_clones(mut clones: Vec<CpdClone>, max_gap_lines: usize) -> Vec<CpdClone> {
+    if max_gap_lines == 0 || clones.len() < 2 {
+        return clones;
+    }
+    clones.sort_by(|x, y| {
+        pair_key(x)
+            .cmp(&pair_key(y))
+            .then(x.fragment_a.range[0].cmp(&y.fragment_a.range[0]))
+            .then(x.fragment_b.range[0].cmp(&y.fragment_b.range[0]))
+    });
+    let mut merged: Vec<CpdClone> = Vec::with_capacity(clones.len());
+    let mut matched_tokens: u32 = 0;
+    for clone in clones {
+        match merged.last_mut() {
+            Some(last) if pair_key(last) == pair_key(&clone) => {
+                // Both fragments must continue after `last`'s. Adjacent exact
+                // windows may share their boundary token; that overlap is
+                // matched once.
+                let Some(overlap_a) =
+                    continuation(&last.fragment_a, &clone.fragment_a, max_gap_lines)
+                else {
+                    matched_tokens = clone.token_count;
+                    merged.push(clone);
+                    continue;
+                };
+                let Some(overlap_b) =
+                    continuation(&last.fragment_b, &clone.fragment_b, max_gap_lines)
+                else {
+                    matched_tokens = clone.token_count;
+                    merged.push(clone);
+                    continue;
+                };
+                matched_tokens += clone.token_count.saturating_sub(overlap_a.max(overlap_b));
+                last.fragment_a.end = clone.fragment_a.end.clone();
+                last.fragment_a.range[1] = clone.fragment_a.range[1];
+                last.fragment_b.end = clone.fragment_b.end.clone();
+                last.fragment_b.range[1] = clone.fragment_b.range[1];
+                let span_a = last.fragment_a.range[1] - last.fragment_a.range[0] + 1;
+                let span_b = last.fragment_b.range[1] - last.fragment_b.range[0] + 1;
+                last.token_count = matched_tokens;
+                last.similarity = Some(matched_tokens as f32 / span_a.max(span_b) as f32);
+                last.kind = CloneKind::Similar;
+            }
+            _ => {
+                matched_tokens = clone.token_count;
+                merged.push(clone);
+            }
+        }
+    }
+    merged
+}
+
+fn pair_key(c: &CpdClone) -> (&str, &str, &str) {
+    (
+        c.format.as_str(),
+        c.fragment_a.source_id.as_str(),
+        c.fragment_b.source_id.as_str(),
+    )
+}
+
+/// `next` extends `prev` when it starts after `prev` starts, ends after
+/// `prev` ends, and at most `max_gap_lines` lines lie between them. Returns
+/// the number of tokens the two windows share at the boundary.
+fn continuation(prev: &Fragment, next: &Fragment, max_gap_lines: usize) -> Option<u32> {
+    if next.range[0] <= prev.range[0] || next.range[1] <= prev.range[1] {
+        return None;
+    }
+    let gap = (next.start.line as usize).saturating_sub(prev.end.line as usize + 1);
+    if gap > max_gap_lines {
+        return None;
+    }
+    Some((prev.range[1] + 1).saturating_sub(next.range[0]))
+}
 
 fn dedup_exact_clones(clones: &mut Vec<CpdClone>) {
     // Normalize each clone so fragment_a <= fragment_b (by id then start line).
@@ -797,6 +881,7 @@ fn add_secondary_clones(
                 token_count: min_tokens as u32,
                 is_new: false,
                 kind: Default::default(),
+                similarity: None,
             },
             source_a: candidate.source_a,
             source_b: candidate.source_b,
@@ -985,6 +1070,118 @@ mod tests {
             end: loc,
             range: [line as usize, line as usize + 1],
         }
+    }
+
+    /// A clone of `format` between `a` and `b` covering the given token index
+    /// ranges (inclusive) and line ranges.
+    fn gap_clone(
+        a: &str,
+        a_tok: [u32; 2],
+        a_lines: [u32; 2],
+        b: &str,
+        b_tok: [u32; 2],
+        b_lines: [u32; 2],
+    ) -> CpdClone {
+        let frag = |id: &str, tok: [u32; 2], lines: [u32; 2]| Fragment {
+            source_id: id.to_string(),
+            source_root: None,
+            start: Location {
+                line: lines[0],
+                column: 1,
+                offset: tok[0],
+            },
+            end: Location {
+                line: lines[1],
+                column: 1,
+                offset: tok[1],
+            },
+            range: tok,
+            blame: None,
+        };
+        CpdClone {
+            format: "javascript".to_string(),
+            fragment_a: frag(a, a_tok, a_lines),
+            fragment_b: frag(b, b_tok, b_lines),
+            token_count: a_tok[1] - a_tok[0] + 1,
+            is_new: false,
+            kind: CloneKind::Exact,
+            similarity: None,
+        }
+    }
+
+    #[test]
+    fn merge_gapped_is_a_no_op_at_zero() {
+        let clones = vec![
+            gap_clone("a", [0, 9], [1, 4], "b", [0, 9], [1, 4]),
+            gap_clone("a", [10, 19], [5, 8], "b", [12, 21], [6, 9]),
+        ];
+        let out = merge_gapped_clones(clones.clone(), 0);
+        assert_eq!(out, clones);
+    }
+
+    #[test]
+    fn merge_gapped_joins_adjacent_fragments_within_gap() {
+        // a: lines 1-4 then 5-8 (no gap); b: lines 1-4 then 6-9 (one inserted line)
+        let clones = vec![
+            gap_clone("a", [0, 9], [1, 4], "b", [0, 9], [1, 4]),
+            gap_clone("a", [10, 19], [5, 8], "b", [12, 21], [6, 9]),
+        ];
+        let out = merge_gapped_clones(clones, 1);
+        assert_eq!(out.len(), 1);
+        let c = &out[0];
+        assert_eq!(c.kind, CloneKind::Similar);
+        assert_eq!(c.token_count, 20, "matched tokens");
+        assert_eq!(c.fragment_a.range, [0, 19]);
+        assert_eq!(c.fragment_b.range, [0, 21]);
+        assert_eq!(c.fragment_a.end.line, 8);
+        assert_eq!(c.fragment_b.end.line, 9);
+        // 20 matched over the longer span of 22 tokens
+        assert!((c.similarity.unwrap() - 20.0 / 22.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn merge_gapped_respects_the_line_limit_and_file_pair() {
+        let far = vec![
+            gap_clone("a", [0, 9], [1, 4], "b", [0, 9], [1, 4]),
+            gap_clone("a", [10, 19], [5, 8], "b", [20, 29], [8, 11]), // 3-line gap in b
+        ];
+        assert_eq!(merge_gapped_clones(far.clone(), 2).len(), 2);
+        assert_eq!(merge_gapped_clones(far, 3).len(), 1);
+
+        let other_pair = vec![
+            gap_clone("a", [0, 9], [1, 4], "b", [0, 9], [1, 4]),
+            gap_clone("a", [10, 19], [5, 8], "c", [10, 19], [5, 8]),
+        ];
+        assert_eq!(merge_gapped_clones(other_pair, 5).len(), 2);
+    }
+
+    #[test]
+    fn merge_gapped_counts_a_shared_boundary_token_once_and_chains() {
+        // second window starts on the last token of the first in `a`
+        let clones = vec![
+            gap_clone("a", [0, 9], [1, 4], "b", [0, 9], [1, 4]),
+            gap_clone("a", [9, 18], [4, 8], "b", [11, 20], [6, 9]),
+            gap_clone("a", [19, 28], [9, 12], "b", [22, 31], [10, 13]),
+        ];
+        let out = merge_gapped_clones(clones, 1);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].token_count, 29, "10 + (10 - 1 overlap) + 10");
+        assert_eq!(out[0].fragment_a.range, [0, 28]);
+        assert_eq!(out[0].fragment_b.range, [0, 31]);
+    }
+
+    #[test]
+    fn merge_gapped_never_merges_overlapping_or_reordered_fragments() {
+        let nested = vec![
+            gap_clone("a", [0, 19], [1, 8], "b", [0, 19], [1, 8]),
+            gap_clone("a", [5, 9], [3, 4], "b", [5, 9], [3, 4]),
+        ];
+        assert_eq!(merge_gapped_clones(nested, 5).len(), 2);
+        let crossed = vec![
+            gap_clone("a", [0, 9], [1, 4], "b", [20, 29], [10, 13]),
+            gap_clone("a", [10, 19], [5, 8], "b", [0, 9], [1, 4]),
+        ];
+        assert_eq!(merge_gapped_clones(crossed, 5).len(), 2);
     }
 
     #[test]

--- a/rust/crates/cpd-core/src/models.rs
+++ b/rust/crates/cpd-core/src/models.rs
@@ -67,6 +67,9 @@ pub enum CloneKind {
     /// normalization (`--ignore-identifiers`, `--ignore-literals`,
     /// `--ignore-annotations`): a Type-2 clone.
     Renamed,
+    /// Two or more matches of the same file pair merged across a gap of
+    /// unmatched lines (`--max-gap-lines`): a Type-3 near-miss clone.
+    Similar,
 }
 
 impl CloneKind {
@@ -74,10 +77,19 @@ impl CloneKind {
         matches!(self, CloneKind::Renamed)
     }
 
+    pub fn is_similar(self) -> bool {
+        matches!(self, CloneKind::Similar)
+    }
+
+    pub fn is_exact(self) -> bool {
+        matches!(self, CloneKind::Exact)
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             CloneKind::Exact => "exact",
             CloneKind::Renamed => "renamed",
+            CloneKind::Similar => "similar",
         }
     }
 }
@@ -93,7 +105,7 @@ pub struct Fragment {
     pub blame: Option<BlameEntry>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CpdClone {
     pub format: String,
     pub fragment_a: Fragment,
@@ -108,6 +120,19 @@ pub struct CpdClone {
     /// when no normalization option is on.
     #[serde(default)]
     pub kind: CloneKind,
+    /// For `similar` clones: matched tokens divided by the tokens of the
+    /// longer merged span, in `(0, 1)`. `None` for exact and renamed clones.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub similarity: Option<f32>,
+}
+
+impl CpdClone {
+    /// `similarity` rounded to three decimals as an f64, the form reporters
+    /// print (an f32 widened to JSON would print as `0.8510638475418091`).
+    pub fn similarity_rounded(&self) -> Option<f64> {
+        self.similarity
+            .map(|s| (f64::from(s) * 1000.0).round() / 1000.0)
+    }
 }
 
 /// Internal detection unit — no heap allocation per token.
@@ -251,6 +276,7 @@ mod tests {
             token_count: 50,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         };
         let json = serde_json::to_string(&clone).unwrap();
         assert!(json.contains("abc123"));

--- a/rust/crates/cpd-core/src/summary.rs
+++ b/rust/crates/cpd-core/src/summary.rs
@@ -346,6 +346,7 @@ mod tests {
             token_count: tokens,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         }
     }
 

--- a/rust/crates/cpd-finder/src/blame.rs
+++ b/rust/crates/cpd-finder/src/blame.rs
@@ -137,6 +137,7 @@ mod tests {
             token_count: 20,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         }
     }
 

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -2,7 +2,7 @@
 
 use crate::statistics;
 use crate::walker::{WalkConfig, walk};
-use cpd_core::detect::{PathFilters, PreparedSource, detect_prepared};
+use cpd_core::detect::{PathFilters, PreparedSource, detect_prepared, merge_gapped_clones};
 use cpd_core::models::{CpdClone, SourceFile, Statistics};
 use cpd_tokenizer::tokenizer::{
     Mode, TokenizeOptions, code_ignore_ranges, tokenize_to_detection, tokenize_to_detection_maps,
@@ -16,6 +16,9 @@ pub struct RunConfig {
     pub min_tokens: usize,
     pub min_lines: usize,
     pub max_lines: Option<usize>,
+    /// Merge clones of one file pair separated by at most this many unmatched
+    /// lines into a `similar` clone (issue #999). 0 = off.
+    pub max_gap_lines: usize,
     pub mode: Mode,
     pub formats: Vec<String>,
     pub ignore: Vec<String>,
@@ -49,6 +52,7 @@ impl Default for RunConfig {
             min_tokens: 50,
             min_lines: 5,
             max_lines: None,
+            max_gap_lines: 0,
             mode: Mode::Mild,
             formats: vec![],
             ignore: vec![],
@@ -168,6 +172,9 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
             },
         )
     });
+
+    // 4b. Near-miss merging — a no-op unless --max-gap-lines is set.
+    let clones = merge_gapped_clones(clones, config.max_gap_lines);
 
     // 5. Compute statistics.
     let statistics = statistics::compute(&source_files, &clones);

--- a/rust/crates/cpd-finder/src/statistics.rs
+++ b/rust/crates/cpd-finder/src/statistics.rs
@@ -151,6 +151,7 @@ mod tests {
             token_count: tc,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         }
     }
 

--- a/rust/crates/cpd-reporter/src/ai.rs
+++ b/rust/crates/cpd-reporter/src/ai.rs
@@ -1,7 +1,7 @@
 use crate::context::ReportContext;
 use crate::reporter::{Reporter, ReporterError, ReporterOptions};
 use crate::shared::Style;
-use cpd_core::models::CpdClone;
+use cpd_core::models::{CloneKind, CpdClone};
 use std::path::Path;
 
 pub struct AiReporter {
@@ -70,10 +70,11 @@ impl Reporter for AiReporter {
             let range_a = format_range(clone.fragment_a.start.line, clone.fragment_a.end.line);
             let range_b = format_range(clone.fragment_b.start.line, clone.fragment_b.end.line);
             let line = compress_clone_line(path_a, path_b, &range_a, &range_b);
-            if clone.kind.is_renamed() {
-                println!("{} (renamed)", line);
-            } else {
-                println!("{}", line);
+            match (clone.kind, clone.similarity) {
+                (CloneKind::Renamed, _) => println!("{} (renamed)", line),
+                (CloneKind::Similar, Some(s)) => println!("{} [~{:.2}]", line, s),
+                (CloneKind::Similar, None) => println!("{} [~]", line),
+                (CloneKind::Exact, _) => println!("{}", line),
             }
         }
 

--- a/rust/crates/cpd-reporter/src/codeclimate.rs
+++ b/rust/crates/cpd-reporter/src/codeclimate.rs
@@ -89,7 +89,11 @@ fn make_issue(
 ) -> Value {
     json!({
         "type": "issue",
-        "check_name": if clone.kind.is_renamed() { "jscpd/similar-code" } else { "jscpd/duplicate-code" },
+        "check_name": match clone.kind {
+            cpd_core::models::CloneKind::Exact => "jscpd/duplicate-code",
+            cpd_core::models::CloneKind::Renamed => "jscpd/similar-code",
+            cpd_core::models::CloneKind::Similar => "jscpd/near-miss-code",
+        },
         "description": format!(
             "Duplicated code block ({} tokens), duplicated at {}:{}",
             clone.token_count,

--- a/rust/crates/cpd-reporter/src/console.rs
+++ b/rust/crates/cpd-reporter/src/console.rs
@@ -32,7 +32,7 @@ impl Reporter for ConsoleReporter {
         report_console_style(clones, ctx.stats, &self.style, BoxChars::ascii(), |clone| {
             let fa = &clone.fragment_a;
             let lines = fa.end.line.saturating_sub(fa.start.line) + 1;
-            print_clone_header(&self.style, &clone.format, clone.is_new, clone.kind);
+            print_clone_header(&self.style, clone);
             println!(
                 " - {} [{}:{} - {}:{}] ({} lines, {} tokens)",
                 self.style.bold_green(&fa.source_id),

--- a/rust/crates/cpd-reporter/src/console_full.rs
+++ b/rust/crates/cpd-reporter/src/console_full.rs
@@ -139,7 +139,7 @@ impl Reporter for ConsoleFullReporter {
                 let fa = &clone.fragment_a;
                 let fb = &clone.fragment_b;
 
-                print_clone_header(&self.style, &clone.format, clone.is_new, clone.kind);
+                print_clone_header(&self.style, clone);
                 print_clone_locations(&self.style, clone);
 
                 if self.blame {
@@ -197,6 +197,7 @@ mod tests {
             token_count: 50,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         }
     }
 
@@ -221,6 +222,7 @@ mod tests {
             token_count: 30,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         }
     }
 

--- a/rust/crates/cpd-reporter/src/html.rs
+++ b/rust/crates/cpd-reporter/src/html.rs
@@ -224,6 +224,7 @@ mod tests {
             token_count: 50,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         };
         let mut stats = empty_stats();
         stats.total.clones = 1;

--- a/rust/crates/cpd-reporter/src/json_reporter.rs
+++ b/rust/crates/cpd-reporter/src/json_reporter.rs
@@ -77,7 +77,7 @@ fn clone_to_dup(
         }
     }
 
-    json!({
+    let mut duplicate = json!({
         "format": clone.format,
         "lines": lines,
         "fragment": fragment,
@@ -86,7 +86,11 @@ fn clone_to_dup(
         "secondFile": second_file,
         "isNew": clone.is_new,
         "kind": clone.kind.as_str(),
-    })
+    });
+    if let Some(similarity) = clone.similarity_rounded() {
+        duplicate["similarity"] = json!(similarity);
+    }
+    duplicate
 }
 
 impl Reporter for JsonReporter {
@@ -327,6 +331,19 @@ mod tests {
         let parsed = parse_json_report(&content);
         assert_eq!(parsed["duplicates"][0]["isNew"], true);
         assert_eq!(parsed["duplicates"][1]["isNew"], false);
+    }
+
+    #[test]
+    fn json_duplicate_includes_similarity_only_for_similar_clones() {
+        let mut similar = make_clone("nonexistent.js", "also_nonexistent.js", 10);
+        similar.kind = cpd_core::models::CloneKind::Similar;
+        similar.similarity = Some(0.851_063_8);
+        let exact = make_clone("nonexistent.js", "also_nonexistent.js", 10);
+        let content = run_json_report(&[similar, exact], false);
+        let parsed = parse_json_report(&content);
+        assert_eq!(parsed["duplicates"][0]["kind"], "similar");
+        assert_eq!(parsed["duplicates"][0]["similarity"], 0.851);
+        assert!(parsed["duplicates"][1].get("similarity").is_none());
     }
 
     #[test]

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -10,12 +10,13 @@ use std::{collections::HashMap, fs, path::Path};
 
 const DUPLICATE_RULE: &str = "jscpd/duplicate-code";
 const SIMILAR_RULE: &str = "jscpd/similar-code";
+const NEAR_MISS_RULE: &str = "jscpd/near-miss-code";
 
 fn rule_id(kind: CloneKind) -> &'static str {
-    if kind.is_renamed() {
-        SIMILAR_RULE
-    } else {
-        DUPLICATE_RULE
+    match kind {
+        CloneKind::Exact => DUPLICATE_RULE,
+        CloneKind::Renamed => SIMILAR_RULE,
+        CloneKind::Similar => NEAR_MISS_RULE,
     }
 }
 
@@ -146,6 +147,9 @@ impl Reporter for SarifReporter {
             let mut props = json!({
                 "token_count": clone.token_count,
             });
+            if let Some(similarity) = clone.similarity_rounded() {
+                props["similarity"] = json!(similarity);
+            }
             if let Some(hash) = &clone_hash {
                 props["clone_hash"] = json!(hash);
             }
@@ -234,6 +238,13 @@ impl Reporter for SarifReporter {
                 "Code blocks that are identical after renaming identifiers, literals or annotations (Type-2 clones). They carry the same maintenance risk as exact duplicates and usually indicate a missing abstraction.",
             ));
         }
+        if clones.iter().any(|c| c.kind.is_similar()) {
+            rules.push(rule_json(
+                NEAR_MISS_RULE,
+                "Near-miss duplicate code detected",
+                "Code blocks that match except for a few inserted, removed or changed lines (Type-3 clones), merged across a gap of at most --max-gap-lines lines. The similarity property is the share of matched tokens.",
+            ));
+        }
         let mut run = json!({
             "tool": {
                 "driver": {
@@ -310,6 +321,7 @@ mod tests {
             token_count: 80,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         }
     }
 
@@ -373,6 +385,23 @@ mod tests {
             .unwrap();
         assert_eq!(rules.len(), 2);
         assert_eq!(rules[1]["id"], "jscpd/similar-code");
+    }
+
+    #[test]
+    fn sarif_similar_clone_uses_near_miss_rule_with_similarity_property() {
+        let mut similar = make_clone();
+        similar.kind = CloneKind::Similar;
+        similar.similarity = Some(0.9);
+        let content = run_sarif_report(&[similar], false);
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let result = &parsed["runs"][0]["results"][0];
+        assert_eq!(result["ruleId"], "jscpd/near-miss-code");
+        assert_eq!(result["properties"]["similarity"], 0.9);
+        let rules = parsed["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[1]["id"], "jscpd/near-miss-code");
     }
 
     #[test]

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -340,15 +340,26 @@ pub fn format_location(
     )
 }
 
+/// Label for a clone header: the format, plus `, renamed` for Type-2 clones
+/// and `, similar ~0.91` for near-miss clones.
+pub fn clone_label(format: &str, kind: CloneKind, similarity: Option<f32>) -> String {
+    match (kind, similarity) {
+        (CloneKind::Exact, _) => format.to_string(),
+        (CloneKind::Renamed, _) => format!("{format}, renamed"),
+        (CloneKind::Similar, Some(s)) => format!("{format}, similar ~{s:.2}"),
+        (CloneKind::Similar, None) => format!("{format}, similar"),
+    }
+}
+
 /// Print a clone header line in console style: `Clone found (format)`, with a
-/// `, renamed` suffix for Type-2 clones and a ` [NEW]` marker for clones
-/// absent from the baseline.
-pub fn print_clone_header(style: &Style, format: &str, is_new: bool, kind: CloneKind) {
-    let header = if kind.is_renamed() {
-        style.bold(&format!("Clone found ({}, renamed)", format))
-    } else {
-        style.bold(&format!("Clone found ({})", format))
-    };
+/// `, renamed` / `, similar ~0.91` suffix for non-exact clones and a ` [NEW]`
+/// marker for clones absent from the baseline.
+pub fn print_clone_header(style: &Style, clone: &CpdClone) {
+    let header = style.bold(&format!(
+        "Clone found ({})",
+        clone_label(&clone.format, clone.kind, clone.similarity)
+    ));
+    let is_new = clone.is_new;
     if is_new {
         println!("{} {}", header, style.red("[NEW]"));
     } else {
@@ -645,6 +656,7 @@ pub mod fixtures {
             token_count,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         }
     }
 }

--- a/rust/crates/cpd-reporter/src/xcode.rs
+++ b/rust/crates/cpd-reporter/src/xcode.rs
@@ -99,6 +99,7 @@ mod tests {
             token_count: 30,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         };
         let opts = ReporterOptions::new(PathBuf::from("/tmp"));
         let reporter = XcodeReporter::new(&opts);

--- a/rust/crates/cpd-reporter/src/xml_reporter.rs
+++ b/rust/crates/cpd-reporter/src/xml_reporter.rs
@@ -209,6 +209,7 @@ mod tests {
             token_count: 50,
             is_new: false,
             kind: Default::default(),
+            similarity: None,
         };
         let opts = ReporterOptions::new(dir.clone());
         let reporter = XmlReporter::new(&opts);

--- a/rust/crates/cpd-reporter/tests/blame_integration.rs
+++ b/rust/crates/cpd-reporter/tests/blame_integration.rs
@@ -64,6 +64,7 @@ fn make_clone_with_blame() -> CpdClone {
         token_count: 50,
         is_new: false,
         kind: Default::default(),
+        similarity: None,
     }
 }
 
@@ -94,6 +95,7 @@ fn make_clone_no_blame() -> CpdClone {
         token_count: 10,
         is_new: false,
         kind: Default::default(),
+        similarity: None,
     }
 }
 

--- a/rust/crates/cpd-reporter/tests/reporters_integration.rs
+++ b/rust/crates/cpd-reporter/tests/reporters_integration.rs
@@ -89,6 +89,7 @@ fn make_test_clone() -> CpdClone {
         token_count: 50,
         is_new: false,
         kind: Default::default(),
+        similarity: None,
     }
 }
 
@@ -156,6 +157,7 @@ fn make_test_clone_with_real_files(dir: &Path) -> CpdClone {
         token_count: 50,
         is_new: false,
         kind: Default::default(),
+        similarity: None,
     }
 }
 

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -213,6 +213,10 @@ pub struct Cli {
     #[arg(long, short = 'x')]
     pub max_lines: Option<usize>,
 
+    /// Merge clones of the same file pair that are separated by at most N unmatched lines in both files into one near-miss clone (Type-3, reported as "similar"); 0 disables
+    #[arg(long, value_name = "N")]
+    pub max_gap_lines: Option<usize>,
+
     /// Detection mode: mild, weak, strict
     #[arg(long, short = 'm')]
     pub mode: Option<String>,
@@ -409,6 +413,8 @@ pub struct ConfigFile {
     pub min_lines: Option<usize>,
     #[serde(alias = "max-lines")]
     pub max_lines: Option<usize>,
+    #[serde(alias = "max-gap-lines")]
+    pub max_gap_lines: Option<usize>,
     pub mode: Option<String>,
     #[serde(alias = "formats")]
     pub format: Option<Vec<String>>,
@@ -623,6 +629,7 @@ pub(crate) static KNOWN_CONFIG_FIELDS: &[&str] = &[
     "minTokens",
     "minLines",
     "maxLines",
+    "maxGapLines",
     "mode",
     "format",
     "formats",
@@ -660,6 +667,7 @@ pub(crate) static KNOWN_CONFIG_FIELDS: &[&str] = &[
     "min-tokens",
     "min-lines",
     "max-lines",
+    "max-gap-lines",
     "max-size",
     "ignore-case",
     "ignore-identifiers",
@@ -1408,6 +1416,27 @@ mod tests {
         let long = Cli::parse_from(["cpd", "--blame", "."]);
         assert_eq!(short.blame, long.blame);
         assert!(short.blame);
+    }
+
+    #[test]
+    fn max_gap_lines_flag_and_config() {
+        let cli = Cli::parse_from(["cpd", "--max-gap-lines", "2", "."]);
+        assert_eq!(cli.max_gap_lines, Some(2));
+        let opts = crate::options::Options::from_cli_and_config(&cli, &ConfigFile::default());
+        assert_eq!(opts.max_gap_lines, 2);
+
+        let cli = Cli::parse_from(["cpd", "."]);
+        let opts = crate::options::Options::from_cli_and_config(&cli, &ConfigFile::default());
+        assert_eq!(opts.max_gap_lines, 0, "off by default");
+
+        let config = ConfigFile {
+            max_gap_lines: Some(3),
+            ..Default::default()
+        };
+        let opts = crate::options::Options::from_cli_and_config(&cli, &config);
+        assert_eq!(opts.max_gap_lines, 3);
+        let v: ConfigFile = serde_json::from_str(r#"{"max-gap-lines": 1}"#).unwrap();
+        assert_eq!(v.max_gap_lines, Some(1));
     }
 
     #[test]

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -290,6 +290,7 @@ fn main() {
         min_tokens: opts.min_tokens,
         min_lines: opts.min_lines,
         max_lines: opts.max_lines,
+        max_gap_lines: opts.max_gap_lines,
         mode: opts.mode,
         formats: opts.formats.clone(),
         ignore: opts.ignore.clone(),

--- a/rust/crates/cpd/src/options.rs
+++ b/rust/crates/cpd/src/options.rs
@@ -12,6 +12,7 @@ pub struct Options {
     pub min_tokens: usize,
     pub min_lines: usize,
     pub max_lines: Option<usize>,
+    pub max_gap_lines: usize,
     pub mode: Mode,
     pub formats: Vec<String>,
     pub ignore: Vec<String>,
@@ -107,6 +108,7 @@ impl Options {
             min_tokens: cli.min_tokens.or(config.min_tokens).unwrap_or(50),
             min_lines: cli.min_lines.or(config.min_lines).unwrap_or(5),
             max_lines: cli.max_lines.or(config.max_lines),
+            max_gap_lines: cli.max_gap_lines.or(config.max_gap_lines).unwrap_or(0),
             mode,
             formats: if cli.format.is_empty() {
                 config.format.clone().unwrap_or_default()

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -509,6 +509,78 @@ fn ignore_identifiers_reports_renamed_and_exact_kinds() {
     let _ = std::fs::remove_dir_all(&out);
 }
 
+/// Near-miss detection (issue #999, stage 1): two exact halves around an
+/// inserted line stay separate by default and merge into one `similar` clone
+/// with `--max-gap-lines 1`.
+#[test]
+fn max_gap_lines_merges_near_miss_clones_only_when_set() {
+    let Some(bin) = maybe_bin() else {
+        return;
+    };
+    let dir = std::env::temp_dir().join(format!("cpd-type3-{}", std::process::id()));
+    let out = std::env::temp_dir().join(format!("cpd-type3-report-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let head = "export function saveUser(user, db) {\n  const row = toRow(user);\n  row.updatedAt = Date.now();\n  row.version = (row.version || 0) + 1;\n";
+    let tail = "  db.put('users', row.id, row);\n  audit('save', row.id, row.version);\n  notify(user.email, 'profile-updated');\n  return row;\n}\n";
+    std::fs::write(dir.join("a.js"), format!("{head}{tail}")).unwrap();
+    std::fs::write(
+        dir.join("b.js"),
+        format!("{head}  if (!row.id) throw new Error('missing id');\n{tail}"),
+    )
+    .unwrap();
+    let scan = |extra: &[&str]| {
+        let output = Command::new(&bin)
+            .args([
+                "--min-tokens",
+                "15",
+                "--min-lines",
+                "2",
+                "--reporters",
+                "json,silent",
+            ])
+            .args(["--output", out.to_str().unwrap()])
+            .args(extra)
+            .arg(&dir)
+            .output()
+            .expect("failed to run cpd");
+        assert!(output.status.success(), "scan failed: {}", output.status);
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(out.join("jscpd-report.json")).unwrap())
+                .unwrap();
+        json["duplicates"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| {
+                (
+                    d["kind"].as_str().unwrap().to_string(),
+                    d["similarity"].as_f64(),
+                    d["tokens"].as_u64().unwrap(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let default = scan(&[]);
+    assert_eq!(default.len(), 2, "two exact halves by default: {default:?}");
+    assert!(default.iter().all(|(k, s, _)| k == "exact" && s.is_none()));
+    assert_eq!(scan(&["--max-gap-lines", "0"]), default, "0 is the default");
+
+    let merged = scan(&["--max-gap-lines", "1"]);
+    assert_eq!(merged.len(), 1, "one similar clone: {merged:?}");
+    let (kind, similarity, tokens) = &merged[0];
+    assert_eq!(kind, "similar");
+    let similarity = similarity.expect("similar clones carry a similarity");
+    assert!(similarity > 0.7 && similarity < 1.0, "got {similarity}");
+    assert!(
+        *tokens > default[0].2 && *tokens < default[0].2 + default[1].2,
+        "matched tokens cover both halves minus the shared boundary token"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
 // --- snippet regression test (scan root != CWD) --------------------------------
 
 #[test]


### PR DESCRIPTION
Stage 1 of #999. Builds on #1019 (its commits are included here; the diff shrinks to this PR's own commit once #1019 lands, so merge that one first).

## Behaviour

`--max-gap-lines N` (config `maxGapLines`, Action input `max-gap-lines`), **default `0` = off**. When set, clones of the same file pair whose fragments follow each other in *both* files with at most `N` unmatched lines between them are merged into one clone:

- `kind: similar`, `tokens` = matched tokens, `similarity` = matched tokens / tokens of the longer merged span
- adjacent exact windows that share their boundary token count it once; chains merge transitively; overlapping or reordered fragments never merge
- runs after every other filter (`--min-lines`, `--skip-local`, `--skip-isolated`) and only joins clones the exact run already reported, so it cannot introduce a match that was not there
- at `0` the pass returns its input untouched: default output is byte-identical to before

```
$ jscpd fixtures/type3-demo/inserted-line
Clone found (javascript)  save-account.js [1:1 - 6:5] ↔ save-user.js [1:1 - 6:6]   (60 tokens)
Clone found (javascript)  save-account.js [6:66 - 12:2] ↔ save-user.js [5:55 - 11:2] (100 tokens)
Found 2 clones.

$ jscpd fixtures/type3-demo/inserted-line --max-gap-lines 1
Clone found (javascript, similar ~0.91)  save-account.js [1:1 - 12:2] ↔ save-user.js [1:1 - 11:2] (157 tokens)
Found 1 clones.
```

## Reporting

Console `Clone found (javascript, similar ~0.91)`, `ai` appends `[~0.91]`, JSON adds `"kind": "similar"` and `"similarity"` (three decimals; absent for exact/renamed clones), SARIF uses `jscpd/near-miss-code` with a `similarity` property (rule declared only when referenced), Code Climate uses the same `check_name`. Duplicated-line statistics count the merged span, gap lines included (documented).

## Fixtures — `fixtures/type3-demo/`

| Directory | Gap | Default | `--max-gap-lines 1` | `--max-gap-lines 2` |
|---|---|---|---|---|
| `inserted-line/` | 1 line | 2 exact | 1 similar ~0.91 | 1 similar |
| `wide-gap/` | 2 lines | 2 exact | 2 exact | 1 similar ~0.91 |

The [README](../blob/feat/type3-gap-merge/fixtures/type3-demo/README.md) lists every command with its output. The corpus-wide smoke scan gains the 4 exact halves (by design) and no cross-directory pairs.

## Tests

- core: no-op at 0; adjacent fragments within the gap merge with the right ranges, token count and similarity; line limit and file-pair identity respected; shared boundary token counted once and three-way chain; nested or crossed fragments never merge
- reporters: JSON `similarity` rounding and absence on exact clones; SARIF near-miss rule id, property and declaration
- CLI: flag, config key, kebab alias, default 0
- integration: near-miss pair — default and `--max-gap-lines 0` give two exact clones, `--max-gap-lines 1` gives one similar clone with `0.7 < similarity < 1` and a token count between one half and the sum

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` clean.

## Not in this PR

Stage 2 of #999 (function-level AST similarity for JS/TS with a `--similarity` threshold and the MCP `similarity` argument) is a separate engine and will follow in its own PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1020)
<!-- Reviewable:end -->
