### PR TITLE
feat: function-level similarity for JS/TS with --similarity (Type-3, stage 2 of #999)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -110,9 +110,9 @@ inputs:
     required: false
     default: "0"
   similarity:
-    description: "Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches this ratio (a number in (0, 1], e.g. 0.85; leave empty to disable) as near-miss clones"
+    description: "Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches this ratio (a number in (0, 1]) as near-miss clones; 1 means exact matches only, e.g. 0.85 enables it"
     required: false
-    default: ""
+    default: "1"
   follow-symlinks:
     description: "Follow symbolic links"
     required: false
@@ -421,7 +421,7 @@ runs:
         if [ -n "$INPUT_MAX_GAP_LINES" ] && [ "$INPUT_MAX_GAP_LINES" != "0" ]; then
           ARGS+=("--max-gap-lines" "$INPUT_MAX_GAP_LINES")
         fi
-        if [ -n "$INPUT_SIMILARITY" ]; then
+        if [ -n "$INPUT_SIMILARITY" ] && [ "$INPUT_SIMILARITY" != "1" ]; then
           ARGS+=("--similarity" "$INPUT_SIMILARITY")
         fi
         if [ "$INPUT_FOLLOW_SYMLINKS" = "true" ]; then

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ inputs:
     required: false
     default: "0"
   similarity:
-    description: "Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches this ratio (0-1, e.g. 0.85) as near-miss clones"
+    description: "Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches this ratio (a number in (0, 1], e.g. 0.85; leave empty to disable) as near-miss clones"
     required: false
     default: ""
   follow-symlinks:

--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,10 @@ inputs:
     description: "Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3); 0 disables"
     required: false
     default: "0"
+  similarity:
+    description: "Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches this ratio (0-1, e.g. 0.85) as near-miss clones"
+    required: false
+    default: ""
   follow-symlinks:
     description: "Follow symbolic links"
     required: false
@@ -287,6 +291,7 @@ runs:
         INPUT_IGNORE_LITERALS: ${{ inputs.ignore-literals }}
         INPUT_IGNORE_ANNOTATIONS: ${{ inputs.ignore-annotations }}
         INPUT_MAX_GAP_LINES: ${{ inputs.max-gap-lines }}
+        INPUT_SIMILARITY: ${{ inputs.similarity }}
         INPUT_FOLLOW_SYMLINKS: ${{ inputs.follow-symlinks }}
         INPUT_NO_GITIGNORE: ${{ inputs.no-gitignore }}
         INPUT_ABSOLUTE: ${{ inputs.absolute }}
@@ -415,6 +420,9 @@ runs:
         fi
         if [ -n "$INPUT_MAX_GAP_LINES" ] && [ "$INPUT_MAX_GAP_LINES" != "0" ]; then
           ARGS+=("--max-gap-lines" "$INPUT_MAX_GAP_LINES")
+        fi
+        if [ -n "$INPUT_SIMILARITY" ]; then
+          ARGS+=("--similarity" "$INPUT_SIMILARITY")
         fi
         if [ "$INPUT_FOLLOW_SYMLINKS" = "true" ]; then
           ARGS+=("--follow-symlinks")

--- a/docs/ai-ready.md
+++ b/docs/ai-ready.md
@@ -102,7 +102,7 @@ Client configuration (Claude Desktop, Claude Code, Cursor, APM, ...):
 
 The server implements MCP protocol revision `2025-06-18` (also accepting `2025-03-26` and `2024-11-05` clients) and exposes four tools:
 
-- `check_duplication(code, format, limit?, similarity?)` — check a snippet against the scanned project; with `similarity` (a ratio in `(0, 1]`, JavaScript/TypeScript only) the response also lists project functions structurally similar to each function in the snippet, best first, under `similar`; `format` accepts format names (`javascript`) or file extensions (`js`)
+- `check_duplication(code, format, limit?, similarity?)` — check a snippet against the scanned project; with `similarity` (a ratio in `(0, 1]`, JavaScript/TypeScript only; `1` means exact matches only, and the server's `--similarity` is the default) the response also lists project functions structurally similar to each function in the snippet, best first, under `similar`; `format` accepts format names (`javascript`) or file extensions (`js`)
 - `get_file_clones(path, limit?)` — clones involving one file, for file-scoped refactoring; `path` is scan-root-relative (as shown in results) or absolute
 - `get_statistics()` — totals and per-format statistics from the last scan
 - `check_current_directory(limit?)` — re-scan the configured paths and return updated counts plus the clone list

--- a/docs/ai-ready.md
+++ b/docs/ai-ready.md
@@ -102,7 +102,7 @@ Client configuration (Claude Desktop, Claude Code, Cursor, APM, ...):
 
 The server implements MCP protocol revision `2025-06-18` (also accepting `2025-03-26` and `2024-11-05` clients) and exposes four tools:
 
-- `check_duplication(code, format, limit?)` — check a snippet against the scanned project; `format` accepts format names (`javascript`) or file extensions (`js`)
+- `check_duplication(code, format, limit?, similarity?)` — check a snippet against the scanned project; with `similarity` (a ratio in `(0, 1]`, JavaScript/TypeScript only) the response also lists project functions structurally similar to each function in the snippet, best first, under `similar`; `format` accepts format names (`javascript`) or file extensions (`js`)
 - `get_file_clones(path, limit?)` — clones involving one file, for file-scoped refactoring; `path` is scan-root-relative (as shown in results) or absolute
 - `get_statistics()` — totals and per-format statistics from the last scan
 - `check_current_directory(limit?)` — re-scan the configured paths and return updated counts plus the clone list

--- a/docs/ci-and-hooks.md
+++ b/docs/ci-and-hooks.md
@@ -67,7 +67,7 @@ The workflow fails if more than 5% of the code is duplicated.
 | `ignore-literals` | Treat all string and numeric literals as equal | `false` |
 | `ignore-annotations` | Skip annotations and decorators (`@Name`, `@Name(...)`) | `false` |
 | `max-gap-lines` | Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3); `0` disables | `0` |
-| `similarity` | Report JS/TS function pairs whose syntax-tree similarity reaches this ratio, a number in `(0, 1]`; leave empty to disable | — |
+| `similarity` | Report JS/TS function pairs whose syntax-tree similarity reaches this ratio, a number in `(0, 1]`; `1` means exact matches only | `1` |
 | `follow-symlinks` | Follow symbolic links | `false` |
 | `no-gitignore` | Don't respect .gitignore files | `false` |
 | `absolute` | Use absolute paths in reports | `false` |

--- a/docs/ci-and-hooks.md
+++ b/docs/ci-and-hooks.md
@@ -67,6 +67,7 @@ The workflow fails if more than 5% of the code is duplicated.
 | `ignore-literals` | Treat all string and numeric literals as equal | `false` |
 | `ignore-annotations` | Skip annotations and decorators (`@Name`, `@Name(...)`) | `false` |
 | `max-gap-lines` | Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3); `0` disables | `0` |
+| `similarity` | Report JS/TS function pairs whose syntax-tree similarity reaches this ratio (0-1) as near-miss clones | — |
 | `follow-symlinks` | Follow symbolic links | `false` |
 | `no-gitignore` | Don't respect .gitignore files | `false` |
 | `absolute` | Use absolute paths in reports | `false` |

--- a/docs/ci-and-hooks.md
+++ b/docs/ci-and-hooks.md
@@ -67,7 +67,7 @@ The workflow fails if more than 5% of the code is duplicated.
 | `ignore-literals` | Treat all string and numeric literals as equal | `false` |
 | `ignore-annotations` | Skip annotations and decorators (`@Name`, `@Name(...)`) | `false` |
 | `max-gap-lines` | Merge clones separated by at most N unmatched lines into one near-miss clone (Type-3); `0` disables | `0` |
-| `similarity` | Report JS/TS function pairs whose syntax-tree similarity reaches this ratio (0-1) as near-miss clones | — |
+| `similarity` | Report JS/TS function pairs whose syntax-tree similarity reaches this ratio, a number in `(0, 1]`; leave empty to disable | — |
 | `follow-symlinks` | Follow symbolic links | `false` |
 | `no-gitignore` | Don't respect .gitignore files | `false` |
 | `absolute` | Use absolute paths in reports | `false` |

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -84,7 +84,7 @@ cpd [OPTIONS] [PATH]...
 | `--ignore-literals` | | Treat all string literals as equal and all numeric literals as equal | off |
 | `--ignore-annotations` | | Skip annotations and decorators (`@Name`, `@Name(...)`) before detection | off |
 | `--max-gap-lines` | | Merge clones of one file pair separated by at most N unmatched lines in both files into one near-miss clone reported as `similar`. See [Type-3 clones](#type-3-clones-near-miss-merging-with---max-gap-lines) | 0 (off) |
-| `--similarity` | | Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches RATIO, a number in `(0, 1]`, as `similar` clones; omit to disable. See [function similarity](#function-level-similarity-with---similarity) | off |
+| `--similarity` | | Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches RATIO, a number in `(0, 1]`, as `similar` clones; `1` means exact matches only. See [function similarity](#function-level-similarity-with---similarity) | 1 (off) |
 | `--formats-exts` | | Custom format-to-extension mapping (e.g. `javascript:es,es6;dart:dt`) | — |
 | `--formats-names` | | Custom format-to-filename mapping | — |
 | `--cross-formats` | | Detect clones across formats: `;`-separated groups of `,`-separated formats (e.g. `javascript,typescript`). Preset `js-ts` = `javascript,jsx,typescript,tsx` | — |
@@ -337,14 +337,14 @@ Reporting: the console prints `Clone found (javascript, similar ~0.85)`, the `ai
 
 ### Function-level similarity with `--similarity`
 
-Edits spread through a function rather than concentrated in one gap still escape a token window. `--similarity RATIO` (config key `similarity`, a number in `(0, 1]`) compares whole functions instead: every function declaration, function expression, method and arrow function in a JavaScript, TypeScript, JSX or TSX file is summarized by the bag of 4-grams over the pre-order sequence of its syntax-tree node *types*, and two functions are reported as one `similar` clone when the weighted Jaccard index of their bags reaches `RATIO`. Names and literal values are not part of the summary, so a renamed copy scores `1.0`; one inserted line scores about `0.9`; two inserted statements plus renames score about `0.75`. Candidates come from a MinHash index, so the search stays close to linear in the number of functions.
+Edits spread through a function rather than concentrated in one gap still escape a token window. `--similarity RATIO` (config key `similarity`, a number in `(0, 1]`; the default `1` means exact matches only, so the pass never runs until you set a lower value) compares whole functions instead: every function declaration, function expression, method and arrow function in a JavaScript, TypeScript, JSX or TSX file is summarized by the bag of 4-grams over the pre-order sequence of its syntax-tree node *types*, and two functions are reported as one `similar` clone when the weighted Jaccard index of their bags reaches `RATIO`. Names and literal values are not part of the summary, so a renamed copy scores `1.0`; one inserted line scores about `0.9`; two inserted statements plus renames score about `0.75`. Candidates come from a MinHash index, so the search stays close to linear in the number of functions.
 
 ```bash
 jscpd --similarity 0.85 src/        # near-identical structure: renames, literal changes, a one-line edit
 jscpd --similarity 0.7 src/         # looser: a couple of added or removed statements
 ```
 
-Functions must clear `--min-tokens` and `--min-lines` on their own, nested functions are never paired with their parent, and a pair that an exact, renamed or merged clone already covers is not reported again. Reporting is the same as for merged clones (`kind: similar`, `similarity`, `jscpd/near-miss-code` in SARIF); `tokens` is the smaller function's token count and the fragments span the whole functions. Values outside `(0, 1]` print a warning and disable the option.
+Functions must clear `--min-tokens` and `--min-lines` on their own, nested functions are never paired with their parent, and a pair that an exact, renamed or merged clone already covers is not reported again. Reporting is the same as for merged clones (`kind: similar`, `similarity`, `jscpd/near-miss-code` in SARIF); `tokens` is the smaller function's token count and the fragments span the whole functions. Values outside `(0, 1]` print a warning and fall back to `1`.
 
 Scoring needs a syntax tree, and today only JavaScript/TypeScript have one (oxc). Each language plugs in through the `FunctionExtractor` trait in `cpd-tokenizer` (`functions.rs`): a grammar id, the formats it serves, and a walk that opens a function at every function-like node and records the node-type sequence inside it. Signatures carry their grammar id and are only compared within one grammar, so a tree-sitter-backed extractor for another language is a self-contained addition; the scoring, CLI, MCP tool and reporters need no change. Formats without an extractor are a silent no-op. The MCP `check_duplication` tool accepts the same `similarity` argument and returns the structurally similar project functions for each function in the snippet.
 

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -84,7 +84,7 @@ cpd [OPTIONS] [PATH]...
 | `--ignore-literals` | | Treat all string literals as equal and all numeric literals as equal | off |
 | `--ignore-annotations` | | Skip annotations and decorators (`@Name`, `@Name(...)`) before detection | off |
 | `--max-gap-lines` | | Merge clones of one file pair separated by at most N unmatched lines in both files into one near-miss clone reported as `similar`. See [Type-3 clones](#type-3-clones-near-miss-merging-with---max-gap-lines) | 0 (off) |
-| `--similarity` | | Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches RATIO (0-1) as `similar` clones. See [function similarity](#function-level-similarity-with---similarity) | off |
+| `--similarity` | | Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches RATIO, a number in `(0, 1]`, as `similar` clones; omit to disable. See [function similarity](#function-level-similarity-with---similarity) | off |
 | `--formats-exts` | | Custom format-to-extension mapping (e.g. `javascript:es,es6;dart:dt`) | — |
 | `--formats-names` | | Custom format-to-filename mapping | — |
 | `--cross-formats` | | Detect clones across formats: `;`-separated groups of `,`-separated formats (e.g. `javascript,typescript`). Preset `js-ts` = `javascript,jsx,typescript,tsx` | — |

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -84,6 +84,7 @@ cpd [OPTIONS] [PATH]...
 | `--ignore-literals` | | Treat all string literals as equal and all numeric literals as equal | off |
 | `--ignore-annotations` | | Skip annotations and decorators (`@Name`, `@Name(...)`) before detection | off |
 | `--max-gap-lines` | | Merge clones of one file pair separated by at most N unmatched lines in both files into one near-miss clone reported as `similar`. See [Type-3 clones](#type-3-clones-near-miss-merging-with---max-gap-lines) | 0 (off) |
+| `--similarity` | | Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches RATIO (0-1) as `similar` clones. See [function similarity](#function-level-similarity-with---similarity) | off |
 | `--formats-exts` | | Custom format-to-extension mapping (e.g. `javascript:es,es6;dart:dt`) | — |
 | `--formats-names` | | Custom format-to-filename mapping | — |
 | `--cross-formats` | | Detect clones across formats: `;`-separated groups of `,`-separated formats (e.g. `javascript,typescript`). Preset `js-ts` = `javascript,jsx,typescript,tsx` | — |
@@ -334,7 +335,16 @@ A merged clone's `tokens` is the number of matched tokens and `similarity` is th
 
 Reporting: the console prints `Clone found (javascript, similar ~0.85)`, the `ai` reporter appends `[~0.85]`, the JSON report adds `"kind": "similar"` and a `"similarity"` value, SARIF files merged clones under `jscpd/near-miss-code` with a `similarity` property, and Code Climate uses the same `check_name`. Duplicated-line statistics count the merged span, gap lines included. With the default `0` the merge pass is skipped entirely and output is identical to earlier releases. See [`fixtures/type3-demo`](../fixtures/type3-demo/README.md) for a runnable example.
 
-Function-level similarity scoring for JavaScript and TypeScript (AST-based, catching edits spread through a function rather than a single gap) is the second stage of [#999](https://github.com/kucherenko/jscpd/issues/999) and is not part of this option.
+### Function-level similarity with `--similarity`
+
+Edits spread through a function rather than concentrated in one gap still escape a token window. `--similarity RATIO` (config key `similarity`, a number in `(0, 1]`) compares whole functions instead: every function declaration, function expression, method and arrow function in a JavaScript, TypeScript, JSX or TSX file is summarized by the bag of 4-grams over the pre-order sequence of its syntax-tree node *types*, and two functions are reported as one `similar` clone when the weighted Jaccard index of their bags reaches `RATIO`. Names and literal values are not part of the summary, so a renamed copy scores `1.0`; one inserted line scores about `0.9`; two inserted statements plus renames score about `0.75`. Candidates come from a MinHash index, so the search stays close to linear in the number of functions.
+
+```bash
+jscpd --similarity 0.85 src/        # near-identical structure: renames, literal changes, a one-line edit
+jscpd --similarity 0.7 src/         # looser: a couple of added or removed statements
+```
+
+Functions must clear `--min-tokens` and `--min-lines` on their own, nested functions are never paired with their parent, and a pair that an exact, renamed or merged clone already covers is not reported again. Reporting is the same as for merged clones (`kind: similar`, `similarity`, `jscpd/near-miss-code` in SARIF); `tokens` is the smaller function's token count and the fragments span the whole functions. Other languages are not scored yet; the option is silently a no-op for them. Values outside `(0, 1]` print a warning and disable the option. The MCP `check_duplication` tool accepts the same `similarity` argument and returns the structurally similar project functions for each function in the snippet.
 
 ## Format Support
 

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -328,12 +328,12 @@ A copy with a line inserted, removed or changed in the middle shows up as two sh
 
 ```bash
 jscpd src/                       # a.js 1-4 ↔ b.js 1-4, a.js 4-9 ↔ b.js 5-10: two exact clones
-jscpd --max-gap-lines 1 src/     # Clone found (javascript, similar ~0.85): a.js 1-9 ↔ b.js 1-10
+jscpd --max-gap-lines 1 src/     # Clone found (javascript, similar (gap) ~0.85): a.js 1-9 ↔ b.js 1-10
 ```
 
 A merged clone's `tokens` is the number of matched tokens and `similarity` is that number divided by the tokens of the longer merged span, so a single inserted line in a 60-token block gives roughly `0.9`. Chains of matches merge transitively, and the merge is applied after every other filter (`--min-lines`, `--skip-local`, `--skip-isolated`). Because merging only ever joins clones the exact run already reported, it cannot introduce a match that was not there; it removes fragmentation. It applies to every language.
 
-Reporting: the console prints `Clone found (javascript, similar ~0.85)`, the `ai` reporter appends `[~0.85]`, the JSON report adds `"kind": "similar"` and a `"similarity"` value, SARIF files merged clones under `jscpd/near-miss-code` with a `similarity` property, and Code Climate uses the same `check_name`. Duplicated-line statistics count the merged span, gap lines included. With the default `0` the merge pass is skipped entirely and output is identical to earlier releases. See [`fixtures/type3-demo`](../fixtures/type3-demo/README.md) for a runnable example.
+Reporting: the console prints `Clone found (javascript, similar (gap) ~0.85)`, the `ai` reporter appends `[~0.85 gap]`, the JSON report adds `"kind": "similar"`, a `"similarity"` value and `"method": "gap"`, SARIF files merged clones under `jscpd/near-miss-code` with `similarity` and `similarity_method` properties, and Code Climate uses the same `check_name`. The method is shown because the two near-miss mechanisms score on different scales: `gap` is matched tokens over the merged span, `ast` (from `--similarity`, below) is structural overlap of whole functions. Duplicated-line statistics count the merged span, gap lines included. With the default `0` the merge pass is skipped entirely and output is identical to earlier releases. See [`fixtures/type3-demo`](../fixtures/type3-demo/README.md) for a runnable example.
 
 ### Function-level similarity with `--similarity`
 
@@ -344,7 +344,7 @@ jscpd --similarity 0.85 src/        # near-identical structure: renames, literal
 jscpd --similarity 0.7 src/         # looser: a couple of added or removed statements
 ```
 
-Functions must clear `--min-tokens` and `--min-lines` on their own, nested functions are never paired with their parent, and a pair that an exact, renamed or merged clone already covers is not reported again. Reporting is the same as for merged clones (`kind: similar`, `similarity`, `jscpd/near-miss-code` in SARIF); `tokens` is the smaller function's token count and the fragments span the whole functions. Values outside `(0, 1]` print a warning and fall back to `1`.
+Functions must clear `--min-tokens` and `--min-lines` on their own, nested functions are never paired with their parent, and a pair that an exact, renamed or merged clone already covers is not reported again. Reporting is the same as for merged clones except for the method: the console prints `Clone found (javascript, similar (ast) ~0.75)`, the `ai` reporter `[~0.75 ast]`, JSON carries `"method": "ast"` and SARIF `similarity_method`; `tokens` is the smaller function's token count and the fragments span the whole functions. Values outside `(0, 1]` print a warning and fall back to `1`.
 
 Scoring needs a syntax tree, and today only JavaScript/TypeScript have one (oxc). Each language plugs in through the `FunctionExtractor` trait in `cpd-tokenizer` (`functions.rs`): a grammar id, the formats it serves, and a walk that opens a function at every function-like node and records the node-type sequence inside it. Signatures carry their grammar id and are only compared within one grammar, so a tree-sitter-backed extractor for another language is a self-contained addition; the scoring, CLI, MCP tool and reporters need no change. Formats without an extractor are a silent no-op. The MCP `check_duplication` tool accepts the same `similarity` argument and returns the structurally similar project functions for each function in the snippet.
 

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -344,7 +344,9 @@ jscpd --similarity 0.85 src/        # near-identical structure: renames, literal
 jscpd --similarity 0.7 src/         # looser: a couple of added or removed statements
 ```
 
-Functions must clear `--min-tokens` and `--min-lines` on their own, nested functions are never paired with their parent, and a pair that an exact, renamed or merged clone already covers is not reported again. Reporting is the same as for merged clones (`kind: similar`, `similarity`, `jscpd/near-miss-code` in SARIF); `tokens` is the smaller function's token count and the fragments span the whole functions. Other languages are not scored yet; the option is silently a no-op for them. Values outside `(0, 1]` print a warning and disable the option. The MCP `check_duplication` tool accepts the same `similarity` argument and returns the structurally similar project functions for each function in the snippet.
+Functions must clear `--min-tokens` and `--min-lines` on their own, nested functions are never paired with their parent, and a pair that an exact, renamed or merged clone already covers is not reported again. Reporting is the same as for merged clones (`kind: similar`, `similarity`, `jscpd/near-miss-code` in SARIF); `tokens` is the smaller function's token count and the fragments span the whole functions. Values outside `(0, 1]` print a warning and disable the option.
+
+Scoring needs a syntax tree, and today only JavaScript/TypeScript have one (oxc). Each language plugs in through the `FunctionExtractor` trait in `cpd-tokenizer` (`functions.rs`): a grammar id, the formats it serves, and a walk that opens a function at every function-like node and records the node-type sequence inside it. Signatures carry their grammar id and are only compared within one grammar, so a tree-sitter-backed extractor for another language is a self-contained addition; the scoring, CLI, MCP tool and reporters need no change. Formats without an extractor are a silent no-op. The MCP `check_duplication` tool accepts the same `similarity` argument and returns the structurally similar project functions for each function in the snippet.
 
 ## Format Support
 

--- a/fixtures/type3-demo/README.md
+++ b/fixtures/type3-demo/README.md
@@ -16,6 +16,10 @@ Commands run from the repository root at default thresholds; the lines after
 | `inserted-line/` | 1 line | 2 exact clones | 1 similar clone | 1 similar clone |
 | `wide-gap/` | 2 lines | 2 exact clones | 2 exact clones | 1 similar clone |
 
+`similar-functions/` demonstrates the second mechanism, `--similarity RATIO`,
+which compares whole JavaScript/TypeScript functions by syntax-tree structure
+instead of joining token runs (see below).
+
 ## `inserted-line/` — one inserted guard
 
 `save-account.js` is `save-user.js` with one `if (...) throw` line added in
@@ -59,6 +63,39 @@ jscpd fixtures/type3-demo/wide-gap --max-gap-lines 2
 # Found 1 clones.
 ```
 
+## `similar-functions/` — edits spread through a function
+
+`credit-note.js` is `invoice.js` after a realistic second use: every name
+changed, one `continue` guard and one logging call inserted. No two token
+runs are long enough to clear the default thresholds, so neither a default
+scan nor `--max-gap-lines` reports anything. `--similarity RATIO` compares
+functions by the bag of 4-grams over their syntax-tree node types (names and
+values do not take part), so the pair scores by how much structure survived.
+
+```bash
+jscpd fixtures/type3-demo/similar-functions
+# Found 0 clones.
+
+jscpd fixtures/type3-demo/similar-functions --max-gap-lines 3
+# Found 0 clones.
+
+jscpd fixtures/type3-demo/similar-functions --similarity 0.85
+# Found 0 clones.
+
+jscpd fixtures/type3-demo/similar-functions --similarity 0.7
+# Clone found (javascript, similar ~0.75)
+#  - credit-note.js [1:8 - 19:2] (19 lines, 126 tokens)
+#    invoice.js [1:8 - 17:2]
+# Found 1 clones.
+```
+
+Calibration: a copy that only renames things scores `1.00` (try
+`jscpd fixtures/type2-demo/identifiers --similarity 0.9`), a single inserted
+line scores about `0.9`, and two inserted statements plus renames, as here,
+score `0.75`. Functions must clear `--min-tokens` and `--min-lines` on their
+own, and a pair already reported as an exact or merged clone is not reported
+again.
+
 ## Whole directory
 
 ```bash
@@ -68,8 +105,14 @@ jscpd fixtures/type3-demo
 jscpd fixtures/type3-demo --max-gap-lines 2
 # Found 2 clones.
 
-jscpd fixtures/type3-demo --max-gap-lines 2 --reporters json,silent --output report
-# each entry in "duplicates" has "kind": "similar" and "similarity": 0.91…
+jscpd fixtures/type3-demo --similarity 0.7
+# Found 7 clones.   (the four exact halves, plus one similar function pair per directory)
+
+jscpd fixtures/type3-demo --max-gap-lines 2 --similarity 0.7
+# Found 3 clones.   (merged clones cover the whole functions, so only similar-functions/ adds one)
+
+jscpd fixtures/type3-demo --max-gap-lines 2 --similarity 0.7 --reporters json,silent --output report
+# every entry in "duplicates" has "kind": "similar" and a "similarity" value
 ```
 
 Merging only joins clones the exact run already reported, so it never adds a

--- a/fixtures/type3-demo/README.md
+++ b/fixtures/type3-demo/README.md
@@ -36,7 +36,7 @@ jscpd fixtures/type3-demo/inserted-line
 # Found 2 clones.
 
 jscpd fixtures/type3-demo/inserted-line --max-gap-lines 1
-# Clone found (javascript, similar ~0.91)
+# Clone found (javascript, similar (gap) ~0.91)
 #  - save-account.js [1:1 - 12:2] (12 lines, 157 tokens)
 #    save-user.js [1:1 - 11:2]
 # Found 1 clones.
@@ -57,7 +57,7 @@ jscpd fixtures/type3-demo/wide-gap --max-gap-lines 1
 # Found 2 clones.
 
 jscpd fixtures/type3-demo/wide-gap --max-gap-lines 2
-# Clone found (javascript, similar ~0.91)
+# Clone found (javascript, similar (gap) ~0.91)
 #  - place-order-guarded.js [1:1 - 15:2] (15 lines, 172 tokens)
 #    place-order.js [1:1 - 12:2]
 # Found 1 clones.
@@ -83,7 +83,7 @@ jscpd fixtures/type3-demo/similar-functions --similarity 0.85
 # Found 0 clones.
 
 jscpd fixtures/type3-demo/similar-functions --similarity 0.7
-# Clone found (javascript, similar ~0.75)
+# Clone found (javascript, similar (ast) ~0.75)
 #  - credit-note.js [1:8 - 19:2] (19 lines, 126 tokens)
 #    invoice.js [1:8 - 17:2]
 # Found 1 clones.
@@ -113,7 +113,8 @@ jscpd fixtures/type3-demo --max-gap-lines 2 --similarity 0.7
 # Found 3 clones.   (merged clones cover the whole functions, so only similar-functions/ adds one)
 
 jscpd fixtures/type3-demo --max-gap-lines 2 --similarity 0.7 --reporters json,silent --output report
-# every entry in "duplicates" has "kind": "similar" and a "similarity" value
+# every entry in "duplicates" has "kind": "similar", a "similarity" value and
+# "method": "gap" or "ast" — the two scores are not on the same scale
 ```
 
 Merging only joins clones the exact run already reported, so it never adds a

--- a/fixtures/type3-demo/README.md
+++ b/fixtures/type3-demo/README.md
@@ -89,7 +89,8 @@ jscpd fixtures/type3-demo/similar-functions --similarity 0.7
 # Found 1 clones.
 ```
 
-Calibration: a copy that only renames things scores `1.00` (try
+`--similarity 1` is the default and means exact matches only: the pass does
+not run. Calibration: a copy that only renames things scores `1.00` (try
 `jscpd fixtures/type2-demo/identifiers --similarity 0.9`), a single inserted
 line scores about `0.9`, and two inserted statements plus renames, as here,
 score `0.75`. Functions must clear `--min-tokens` and `--min-lines` on their

--- a/fixtures/type3-demo/similar-functions/credit-note.js
+++ b/fixtures/type3-demo/similar-functions/credit-note.js
@@ -1,0 +1,19 @@
+export function buildCreditNote(refund, account, vatRate) {
+  const entries = [];
+  for (const item of refund.items) {
+    if (!item.refundable) continue;
+    const net = item.price * item.quantity;
+    entries.push({ sku: item.sku, quantity: item.quantity, net });
+  }
+  const subtotal = entries.reduce((sum, entry) => sum + entry.net, 0);
+  const vat = Math.round(subtotal * vatRate * 100) / 100;
+  logger.info('credit note', { account: account.id, subtotal });
+  return {
+    number: nextCreditNoteNumber(),
+    account: account.id,
+    entries,
+    subtotal,
+    vat,
+    total: subtotal + vat,
+  };
+}

--- a/fixtures/type3-demo/similar-functions/invoice.js
+++ b/fixtures/type3-demo/similar-functions/invoice.js
@@ -1,0 +1,17 @@
+export function buildInvoice(order, customer, taxRate) {
+  const lines = [];
+  for (const item of order.items) {
+    const net = item.price * item.quantity;
+    lines.push({ sku: item.sku, quantity: item.quantity, net });
+  }
+  const subtotal = lines.reduce((sum, line) => sum + line.net, 0);
+  const tax = Math.round(subtotal * taxRate * 100) / 100;
+  return {
+    number: nextInvoiceNumber(),
+    customer: customer.id,
+    lines,
+    subtotal,
+    tax,
+    total: subtotal + tax,
+  };
+}

--- a/rust/crates/cpd-core/src/detect.rs
+++ b/rust/crates/cpd-core/src/detect.rs
@@ -127,6 +127,7 @@ pub fn detect_with_options(
                         hashes,
                         spans,
                         raw_hashes: Vec::new(),
+                        functions: Vec::new(),
                     }
                 })
                 .collect();
@@ -174,6 +175,9 @@ pub struct PreparedSource {
     /// normalization option rewrote at least one token of this source; then
     /// it is used to classify clones as exact or renamed (issue #998).
     pub raw_hashes: Vec<u64>,
+    /// Function signatures for similarity scoring (issue #999). Empty unless
+    /// `--similarity` is set and the format is JavaScript/TypeScript.
+    pub functions: Vec<crate::similarity::FunctionSig>,
 }
 
 impl PreparedSource {
@@ -201,6 +205,7 @@ impl PreparedSource {
             hashes,
             spans,
             raw_hashes,
+            functions: Vec::new(),
         }
     }
 }
@@ -1335,6 +1340,7 @@ mod tests {
                 hashes,
                 spans,
                 raw_hashes: Vec::new(),
+                functions: Vec::new(),
             }
         };
         let group = vec![

--- a/rust/crates/cpd-core/src/detect.rs
+++ b/rust/crates/cpd-core/src/detect.rs
@@ -6,7 +6,10 @@ use std::path::{Path, PathBuf};
 
 use crate::{
     hash::{base_pow, hash_window, roll, token_hash},
-    models::{CloneKind, CpdClone, DetectionToken, Fragment, Location, SourceFile, TokenKind},
+    models::{
+        CloneKind, CpdClone, DetectionToken, Fragment, Location, SimilarityMethod, SourceFile,
+        TokenKind,
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -539,6 +542,7 @@ fn flush_clone(
         is_new: false,
         kind,
         similarity: None,
+        similarity_method: None,
     });
 }
 
@@ -653,6 +657,7 @@ pub fn merge_gapped_clones(mut clones: Vec<CpdClone>, max_gap_lines: usize) -> V
                 let span_b = last.fragment_b.range[1] - last.fragment_b.range[0] + 1;
                 last.token_count = matched_tokens;
                 last.similarity = Some(matched_tokens as f32 / span_a.max(span_b) as f32);
+                last.similarity_method = Some(SimilarityMethod::Gap);
                 last.kind = CloneKind::Similar;
             }
             _ => {
@@ -887,6 +892,7 @@ fn add_secondary_clones(
                 is_new: false,
                 kind: Default::default(),
                 similarity: None,
+                similarity_method: None,
             },
             source_a: candidate.source_a,
             source_b: candidate.source_b,
@@ -1111,6 +1117,7 @@ mod tests {
             is_new: false,
             kind: CloneKind::Exact,
             similarity: None,
+            similarity_method: None,
         }
     }
 

--- a/rust/crates/cpd-core/src/lib.rs
+++ b/rust/crates/cpd-core/src/lib.rs
@@ -2,4 +2,5 @@ pub mod detect;
 pub mod hash;
 pub mod models;
 pub mod paths;
+pub mod similarity;
 pub mod summary;

--- a/rust/crates/cpd-core/src/models.rs
+++ b/rust/crates/cpd-core/src/models.rs
@@ -105,6 +105,27 @@ pub struct Fragment {
     pub blame: Option<BlameEntry>,
 }
 
+/// How a `similar` clone was produced (issue #999).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SimilarityMethod {
+    /// Exact matches merged across a gap of unmatched lines
+    /// (`--max-gap-lines`); `similarity` is matched tokens over the span.
+    Gap,
+    /// Whole functions compared by syntax-tree structure (`--similarity`);
+    /// `similarity` is the weighted Jaccard index of node-type shingles.
+    Ast,
+}
+
+impl SimilarityMethod {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SimilarityMethod::Gap => "gap",
+            SimilarityMethod::Ast => "ast",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CpdClone {
     pub format: String,
@@ -124,6 +145,10 @@ pub struct CpdClone {
     /// longer merged span, in `(0, 1)`. `None` for exact and renamed clones.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub similarity: Option<f32>,
+    /// Which mechanism produced a `similar` clone; the two scores are not
+    /// on the same scale, so reporters show it next to the value.
+    #[serde(default, rename = "method", skip_serializing_if = "Option::is_none")]
+    pub similarity_method: Option<SimilarityMethod>,
 }
 
 impl CpdClone {
@@ -277,6 +302,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         };
         let json = serde_json::to_string(&clone).unwrap();
         assert!(json.contains("abc123"));

--- a/rust/crates/cpd-core/src/similarity.rs
+++ b/rust/crates/cpd-core/src/similarity.rs
@@ -176,9 +176,11 @@ pub fn collect_function_sources(prepared: &[PreparedSource]) -> Vec<FunctionSour
         .collect()
 }
 
-/// LSH index over the functions of many sources.
-pub struct SimilarityIndex<'a> {
-    sources: &'a [FunctionSource],
+/// LSH index over the functions of many sources. Owns its sources so a
+/// long-lived holder (the MCP server) can build it once per scan and answer
+/// any number of queries from it.
+pub struct SimilarityIndex {
+    sources: Vec<FunctionSource>,
     /// (source index, function index) per item.
     items: Vec<(usize, usize)>,
     buckets: FxHashMap<(u8, u64), Vec<usize>>,
@@ -186,10 +188,10 @@ pub struct SimilarityIndex<'a> {
     min_lines: u32,
 }
 
-impl<'a> SimilarityIndex<'a> {
+impl SimilarityIndex {
     /// Index every function with at least `min_tokens` tokens and a line
     /// span of at least `min_lines` (jscpd's usual clone thresholds).
-    pub fn build(sources: &'a [FunctionSource], min_tokens: usize, min_lines: usize) -> Self {
+    pub fn build(sources: Vec<FunctionSource>, min_tokens: usize, min_lines: usize) -> Self {
         let mut items = Vec::new();
         let mut buckets: FxHashMap<(u8, u64), Vec<usize>> = FxHashMap::default();
         for (si, src) in sources.iter().enumerate() {
@@ -213,11 +215,16 @@ impl<'a> SimilarityIndex<'a> {
         }
     }
 
+    /// The indexed sources, in the order they were given.
+    pub fn sources(&self) -> &[FunctionSource] {
+        &self.sources
+    }
+
     fn eligible(f: &FunctionSig, min_tokens: u32, min_lines: u32) -> bool {
         f.token_count >= min_tokens && f.line_span() >= min_lines
     }
 
-    fn sig(&self, item: usize) -> &'a FunctionSig {
+    fn sig(&self, item: usize) -> &FunctionSig {
         let (si, fi) = self.items[item];
         &self.sources[si].functions[fi]
     }
@@ -295,7 +302,7 @@ impl<'a> SimilarityIndex<'a> {
 
 /// Find similar function pairs across `sources` (issue #999, stage 2).
 pub fn find_similar_functions(
-    sources: &[FunctionSource],
+    sources: Vec<FunctionSource>,
     threshold: f32,
     min_tokens: usize,
     min_lines: usize,
@@ -494,7 +501,7 @@ mod tests {
                 functions: vec![sig("edited", &edited, 0, 62), sig("other", &other, 70, 140)],
             },
         ];
-        let clones = find_similar_functions(&sources, 0.75, 10, 3, &[]);
+        let clones = find_similar_functions(sources.clone(), 0.75, 10, 3, &[]);
         assert_eq!(clones.len(), 1, "{clones:?}");
         let c = &clones[0];
         assert_eq!(c.kind, CloneKind::Similar);
@@ -505,7 +512,7 @@ mod tests {
         // two node edits in 80 nodes break 8 of the 77 shingles
         assert!(sim > 0.75 && sim < 0.9, "got {sim}");
         assert_eq!(c.token_count, 61);
-        assert!(find_similar_functions(&sources, 0.99, 10, 3, &[]).is_empty());
+        assert!(find_similar_functions(sources.clone(), 0.99, 10, 3, &[]).is_empty());
     }
 
     #[test]
@@ -518,7 +525,7 @@ mod tests {
             format: "javascript".into(),
             functions: vec![outer.clone(), inner],
         }];
-        assert!(find_similar_functions(&same_file, 0.5, 10, 3, &[]).is_empty());
+        assert!(find_similar_functions(same_file.clone(), 0.5, 10, 3, &[]).is_empty());
 
         let two = vec![
             FunctionSource {
@@ -532,13 +539,16 @@ mod tests {
                 functions: vec![sig("copy", &base, 0, 60)],
             },
         ];
-        assert_eq!(find_similar_functions(&two, 0.5, 10, 3, &[]).len(), 1);
+        assert_eq!(
+            find_similar_functions(two.clone(), 0.5, 10, 3, &[]).len(),
+            1
+        );
         assert!(
-            find_similar_functions(&two, 0.5, 100, 3, &[]).is_empty(),
+            find_similar_functions(two.clone(), 0.5, 100, 3, &[]).is_empty(),
             "min_tokens"
         );
         assert!(
-            find_similar_functions(&two, 0.5, 10, 100, &[]).is_empty(),
+            find_similar_functions(two.clone(), 0.5, 10, 100, &[]).is_empty(),
             "min_lines"
         );
 
@@ -546,7 +556,7 @@ mod tests {
         exact.kind = CloneKind::Exact;
         exact.similarity = None;
         assert!(
-            find_similar_functions(&two, 0.5, 10, 3, &[exact]).is_empty(),
+            find_similar_functions(two.clone(), 0.5, 10, 3, &[exact]).is_empty(),
             "already reported"
         );
     }
@@ -565,7 +575,7 @@ mod tests {
             format: "javascript".into(),
             functions: vec![sig("far", &far, 0, 60), sig("near", &near, 70, 130)],
         }];
-        let index = SimilarityIndex::build(&sources, 10, 3);
+        let index = SimilarityIndex::build(sources, 10, 3);
         let hits = index.query(&sig("q", &base, 0, 60), 0.5);
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].1, 1, "near first");

--- a/rust/crates/cpd-core/src/similarity.rs
+++ b/rust/crates/cpd-core/src/similarity.rs
@@ -10,6 +10,12 @@
 //! Node *types* only: identifier names and literal values do not take part,
 //! so a renamed copy scores 1.0 and an edited copy scores by how much of
 //! its structure survived. Positions always reference the original source.
+//!
+//! The scoring is grammar-agnostic: node-type ids are opaque `u16`s from
+//! whichever extractor produced them (`cpd_tokenizer::functions`), and a
+//! signature records its `grammar` so functions are only compared within
+//! one grammar. Adding a language means adding an extractor, not touching
+//! this module.
 
 use crate::detect::PreparedSource;
 use crate::models::{CloneKind, CpdClone, Fragment, Location};
@@ -30,6 +36,9 @@ const MAX_BUCKET: usize = 256;
 /// Structural summary of one function, method or arrow function.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionSig {
+    /// Grammar that produced the node-type sequence; pairs are only formed
+    /// within one grammar.
+    pub grammar: &'static str,
     /// Declared or inferred name (`<arrow>` / `<anonymous>` when none).
     pub name: String,
     pub start: Location,
@@ -48,6 +57,7 @@ impl FunctionSig {
     /// token spans. Returns `None` when no detection token lies inside the
     /// function's byte range (comment-only or type-only bodies).
     pub fn build(
+        grammar: &'static str,
         name: String,
         start: Location,
         end: Location,
@@ -65,6 +75,7 @@ impl FunctionSig {
         }
         let minhash = minhash(&shingles);
         Some(Self {
+            grammar,
             name,
             start,
             end,
@@ -326,6 +337,9 @@ fn band_keys(minhash: &[u64; MINHASH_SIZE]) -> impl Iterator<Item = (u8, u64)> +
 /// Exact score for a candidate pair, `None` below `threshold`. The size
 /// ratio bounds the Jaccard index from above, so it is checked first.
 fn score(a: &FunctionSig, b: &FunctionSig, threshold: f32) -> Option<f32> {
+    if a.grammar != b.grammar {
+        return None;
+    }
     let (small, large) = if a.shingles.len() <= b.shingles.len() {
         (a.shingles.len(), b.shingles.len())
     } else {
@@ -428,6 +442,7 @@ mod tests {
     fn sig(name: &str, kinds: &[u16], first_tok: u32, last_tok: u32) -> FunctionSig {
         let spans = spans(last_tok + 1);
         FunctionSig::build(
+            "test",
             name.into(),
             loc(first_tok + 1, first_tok * 10),
             loc(last_tok + 1, last_tok * 10 + 5),
@@ -472,8 +487,15 @@ mod tests {
         assert_eq!(s.line_span(), 5);
         let spans = spans(4);
         assert!(
-            FunctionSig::build("g".into(), loc(9, 900), loc(9, 950), &[1, 2, 3, 4], &spans)
-                .is_none()
+            FunctionSig::build(
+                "test",
+                "g".into(),
+                loc(9, 900),
+                loc(9, 950),
+                &[1, 2, 3, 4],
+                &spans
+            )
+            .is_none()
         );
     }
 
@@ -559,6 +581,26 @@ mod tests {
             find_similar_functions(two.clone(), 0.5, 10, 3, &[exact]).is_empty(),
             "already reported"
         );
+    }
+
+    #[test]
+    fn functions_of_different_grammars_are_never_paired() {
+        let base = kinds(1, 80);
+        let mut foreign = sig("copy", &base, 0, 60);
+        foreign.grammar = "tree-sitter-python";
+        let sources = vec![
+            FunctionSource {
+                id: "a.js".into(),
+                format: "javascript".into(),
+                functions: vec![sig("orig", &base, 0, 60)],
+            },
+            FunctionSource {
+                id: "b.py".into(),
+                format: "python".into(),
+                functions: vec![foreign],
+            },
+        ];
+        assert!(find_similar_functions(sources, 0.5, 10, 3, &[]).is_empty());
     }
 
     #[test]

--- a/rust/crates/cpd-core/src/similarity.rs
+++ b/rust/crates/cpd-core/src/similarity.rs
@@ -18,7 +18,7 @@
 //! this module.
 
 use crate::detect::PreparedSource;
-use crate::models::{CloneKind, CpdClone, Fragment, Location};
+use crate::models::{CloneKind, CpdClone, Fragment, Location, SimilarityMethod};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Shingle length over the node-type sequence.
@@ -418,6 +418,7 @@ fn make_clone(
         is_new: false,
         kind: CloneKind::Similar,
         similarity: Some(similarity),
+        similarity_method: Some(SimilarityMethod::Ast),
     }
 }
 

--- a/rust/crates/cpd-core/src/similarity.rs
+++ b/rust/crates/cpd-core/src/similarity.rs
@@ -1,0 +1,574 @@
+//! Function-level similarity (issue #999, stage 2).
+//!
+//! Each function is summarized by the bag of `k`-grams over the pre-order
+//! sequence of its AST node types ("shingles"). Two functions are similar
+//! when the weighted Jaccard index of their shingle bags reaches the
+//! configured threshold. Candidate pairs come from MinHash + LSH banding so
+//! the search stays close to linear in the number of functions; the exact
+//! bag Jaccard is only computed for candidates.
+//!
+//! Node *types* only: identifier names and literal values do not take part,
+//! so a renamed copy scores 1.0 and an edited copy scores by how much of
+//! its structure survived. Positions always reference the original source.
+
+use crate::detect::PreparedSource;
+use crate::models::{CloneKind, CpdClone, Fragment, Location};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+/// Shingle length over the node-type sequence.
+pub const SHINGLE_K: usize = 4;
+/// MinHash signature size; `BANDS * ROWS` must equal it.
+pub const MINHASH_SIZE: usize = 64;
+const BANDS: usize = 16;
+const ROWS: usize = 4;
+const _: () = assert!(BANDS * ROWS == MINHASH_SIZE);
+/// Buckets larger than this are truncated before pairing: a bucket that
+/// size means hundreds of structurally identical functions, and the first
+/// members already carry the signal.
+const MAX_BUCKET: usize = 256;
+
+/// Structural summary of one function, method or arrow function.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionSig {
+    /// Declared or inferred name (`<arrow>` / `<anonymous>` when none).
+    pub name: String,
+    pub start: Location,
+    pub end: Location,
+    /// Inclusive detection-token index range inside the owning source.
+    pub range: [u32; 2],
+    /// Detection tokens covered by the function.
+    pub token_count: u32,
+    /// Sorted bag of shingle hashes.
+    pub shingles: Vec<u64>,
+    pub minhash: [u64; MINHASH_SIZE],
+}
+
+impl FunctionSig {
+    /// Build a signature from a node-type sequence and the owning source's
+    /// token spans. Returns `None` when no detection token lies inside the
+    /// function's byte range (comment-only or type-only bodies).
+    pub fn build(
+        name: String,
+        start: Location,
+        end: Location,
+        kinds: &[u16],
+        spans: &[(Location, Location)],
+    ) -> Option<Self> {
+        let first = spans.partition_point(|(s, _)| s.offset < start.offset);
+        let last = spans.partition_point(|(_, e)| e.offset <= end.offset);
+        if first >= last {
+            return None;
+        }
+        let shingles = shingles_from_kinds(kinds, SHINGLE_K);
+        if shingles.is_empty() {
+            return None;
+        }
+        let minhash = minhash(&shingles);
+        Some(Self {
+            name,
+            start,
+            end,
+            range: [first as u32, (last - 1) as u32],
+            token_count: (last - first) as u32,
+            shingles,
+            minhash,
+        })
+    }
+
+    /// Lines spanned, in jscpd's `end - start` convention.
+    pub fn line_span(&self) -> u32 {
+        self.end.line.saturating_sub(self.start.line)
+    }
+}
+
+/// Hash every `k`-gram of `kinds`; the result is sorted so it can be used as
+/// a multiset by [`bag_jaccard`].
+pub fn shingles_from_kinds(kinds: &[u16], k: usize) -> Vec<u64> {
+    if kinds.len() < k {
+        return Vec::new();
+    }
+    let mut out: Vec<u64> = kinds
+        .windows(k)
+        .map(|w| {
+            w.iter().fold(0xcbf2_9ce4_8422_2325u64, |acc, &t| {
+                (acc ^ u64::from(t)).wrapping_mul(0x0000_0100_0000_01b3)
+            })
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+/// Weighted (multiset) Jaccard index of two sorted shingle bags.
+pub fn bag_jaccard(a: &[u64], b: &[u64]) -> f32 {
+    if a.is_empty() && b.is_empty() {
+        return 0.0;
+    }
+    let (mut i, mut j) = (0usize, 0usize);
+    let (mut inter, mut union) = (0usize, 0usize);
+    while i < a.len() && j < b.len() {
+        match a[i].cmp(&b[j]) {
+            std::cmp::Ordering::Less => {
+                i += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                j += 1;
+            }
+            std::cmp::Ordering::Equal => {
+                inter += 1;
+                i += 1;
+                j += 1;
+            }
+        }
+        union += 1;
+    }
+    union += (a.len() - i) + (b.len() - j);
+    inter as f32 / union as f32
+}
+
+/// MinHash signature over the *distinct* shingles of a sorted bag.
+pub fn minhash(sorted_shingles: &[u64]) -> [u64; MINHASH_SIZE] {
+    let mut sig = [u64::MAX; MINHASH_SIZE];
+    let mut prev: Option<u64> = None;
+    for &s in sorted_shingles {
+        if prev == Some(s) {
+            continue;
+        }
+        prev = Some(s);
+        for (i, slot) in sig.iter_mut().enumerate() {
+            let h = mix(s, i as u64);
+            if h < *slot {
+                *slot = h;
+            }
+        }
+    }
+    sig
+}
+
+#[inline]
+fn mix(h: u64, i: u64) -> u64 {
+    // splitmix64 finalizer over (shingle, hash index): cheap and well mixed.
+    let mut z = h ^ i.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// The functions of one source, as needed by the similarity search.
+#[derive(Debug, Clone)]
+pub struct FunctionSource {
+    pub id: String,
+    pub format: String,
+    pub functions: Vec<FunctionSig>,
+}
+
+/// Pull the function signatures out of prepared sources (clones only the
+/// sources that carry any, so a run without `--similarity` copies nothing).
+pub fn collect_function_sources(prepared: &[PreparedSource]) -> Vec<FunctionSource> {
+    prepared
+        .iter()
+        .filter(|p| !p.functions.is_empty())
+        .map(|p| FunctionSource {
+            id: p.id.clone(),
+            format: p.format.clone(),
+            functions: p.functions.clone(),
+        })
+        .collect()
+}
+
+/// LSH index over the functions of many sources.
+pub struct SimilarityIndex<'a> {
+    sources: &'a [FunctionSource],
+    /// (source index, function index) per item.
+    items: Vec<(usize, usize)>,
+    buckets: FxHashMap<(u8, u64), Vec<usize>>,
+    min_tokens: u32,
+    min_lines: u32,
+}
+
+impl<'a> SimilarityIndex<'a> {
+    /// Index every function with at least `min_tokens` tokens and a line
+    /// span of at least `min_lines` (jscpd's usual clone thresholds).
+    pub fn build(sources: &'a [FunctionSource], min_tokens: usize, min_lines: usize) -> Self {
+        let mut items = Vec::new();
+        let mut buckets: FxHashMap<(u8, u64), Vec<usize>> = FxHashMap::default();
+        for (si, src) in sources.iter().enumerate() {
+            for (fi, f) in src.functions.iter().enumerate() {
+                if !Self::eligible(f, min_tokens as u32, min_lines as u32) {
+                    continue;
+                }
+                let item = items.len();
+                items.push((si, fi));
+                for (band, key) in band_keys(&f.minhash) {
+                    buckets.entry((band, key)).or_default().push(item);
+                }
+            }
+        }
+        Self {
+            sources,
+            items,
+            buckets,
+            min_tokens: min_tokens as u32,
+            min_lines: min_lines as u32,
+        }
+    }
+
+    fn eligible(f: &FunctionSig, min_tokens: u32, min_lines: u32) -> bool {
+        f.token_count >= min_tokens && f.line_span() >= min_lines
+    }
+
+    fn sig(&self, item: usize) -> &'a FunctionSig {
+        let (si, fi) = self.items[item];
+        &self.sources[si].functions[fi]
+    }
+
+    /// Indexed functions structurally similar to `query`, best first.
+    /// Returns `(source index, function index, similarity)`.
+    pub fn query(&self, query: &FunctionSig, threshold: f32) -> Vec<(usize, usize, f32)> {
+        if !Self::eligible(query, self.min_tokens, self.min_lines) {
+            return Vec::new();
+        }
+        let mut seen: FxHashSet<usize> = FxHashSet::default();
+        let mut hits = Vec::new();
+        for (band, key) in band_keys(&query.minhash) {
+            let Some(bucket) = self.buckets.get(&(band, key)) else {
+                continue;
+            };
+            for &item in bucket.iter().take(MAX_BUCKET) {
+                if !seen.insert(item) {
+                    continue;
+                }
+                let cand = self.sig(item);
+                if let Some(sim) = score(query, cand, threshold) {
+                    let (si, fi) = self.items[item];
+                    hits.push((si, fi, sim));
+                }
+            }
+        }
+        hits.sort_by(|a, b| b.2.total_cmp(&a.2).then(a.0.cmp(&b.0)).then(a.1.cmp(&b.1)));
+        hits
+    }
+
+    /// All similar pairs among the indexed functions, as `similar` clones.
+    /// Pairs already covered by a clone in `existing` (an exact or renamed
+    /// match spanning both functions) are left out so nothing is reported
+    /// twice.
+    pub fn all_pairs(&self, threshold: f32, existing: &[CpdClone]) -> Vec<CpdClone> {
+        let mut pairs: FxHashSet<(usize, usize)> = FxHashSet::default();
+        for bucket in self.buckets.values() {
+            let members = &bucket[..bucket.len().min(MAX_BUCKET)];
+            for (x, &a) in members.iter().enumerate() {
+                for &b in &members[x + 1..] {
+                    pairs.insert((a.min(b), a.max(b)));
+                }
+            }
+        }
+        let mut clones: Vec<CpdClone> = pairs
+            .into_iter()
+            .filter_map(|(a, b)| {
+                let (sa, fa) = self.items[a];
+                let (sb, fb) = self.items[b];
+                let (fa_sig, fb_sig) = (self.sig(a), self.sig(b));
+                if sa == sb && nested(fa_sig, fb_sig) {
+                    return None;
+                }
+                let sim = score(fa_sig, fb_sig, threshold)?;
+                let (src_a, src_b) = (&self.sources[sa], &self.sources[sb]);
+                if covered_by_existing(src_a, fa_sig, src_b, fb_sig, existing) {
+                    return None;
+                }
+                let _ = (fa, fb);
+                Some(make_clone(src_a, fa_sig, src_b, fb_sig, sim))
+            })
+            .collect();
+        clones.sort_by(|x, y| {
+            x.fragment_a
+                .source_id
+                .cmp(&y.fragment_a.source_id)
+                .then(x.fragment_a.start.line.cmp(&y.fragment_a.start.line))
+                .then(x.fragment_b.source_id.cmp(&y.fragment_b.source_id))
+                .then(x.fragment_b.start.line.cmp(&y.fragment_b.start.line))
+        });
+        clones
+    }
+}
+
+/// Find similar function pairs across `sources` (issue #999, stage 2).
+pub fn find_similar_functions(
+    sources: &[FunctionSource],
+    threshold: f32,
+    min_tokens: usize,
+    min_lines: usize,
+    existing: &[CpdClone],
+) -> Vec<CpdClone> {
+    if sources.is_empty() {
+        return Vec::new();
+    }
+    SimilarityIndex::build(sources, min_tokens, min_lines).all_pairs(threshold, existing)
+}
+
+fn band_keys(minhash: &[u64; MINHASH_SIZE]) -> impl Iterator<Item = (u8, u64)> + '_ {
+    minhash.chunks(ROWS).enumerate().map(|(band, rows)| {
+        let key = rows.iter().fold(0x9E37_79B9_7F4A_7C15u64, |acc, &r| {
+            mix(acc ^ r, band as u64)
+        });
+        (band as u8, key)
+    })
+}
+
+/// Exact score for a candidate pair, `None` below `threshold`. The size
+/// ratio bounds the Jaccard index from above, so it is checked first.
+fn score(a: &FunctionSig, b: &FunctionSig, threshold: f32) -> Option<f32> {
+    let (small, large) = if a.shingles.len() <= b.shingles.len() {
+        (a.shingles.len(), b.shingles.len())
+    } else {
+        (b.shingles.len(), a.shingles.len())
+    };
+    if (small as f32 / large as f32) < threshold {
+        return None;
+    }
+    let sim = bag_jaccard(&a.shingles, &b.shingles);
+    (sim >= threshold).then_some(sim)
+}
+
+fn nested(a: &FunctionSig, b: &FunctionSig) -> bool {
+    (a.range[0] <= b.range[0] && b.range[1] <= a.range[1])
+        || (b.range[0] <= a.range[0] && a.range[1] <= b.range[1])
+}
+
+/// True when an existing clone between the same two sources already spans
+/// at least 90% of the lines of both functions.
+fn covered_by_existing(
+    src_a: &FunctionSource,
+    a: &FunctionSig,
+    src_b: &FunctionSource,
+    b: &FunctionSig,
+    existing: &[CpdClone],
+) -> bool {
+    let covers = |frag: &Fragment, f: &FunctionSig| {
+        let lo = frag.start.line.max(f.start.line);
+        let hi = frag.end.line.min(f.end.line);
+        if hi < lo {
+            return false;
+        }
+        let overlap = hi - lo + 1;
+        let span = f.end.line - f.start.line + 1;
+        overlap as f32 >= 0.9 * span as f32
+    };
+    existing.iter().any(|c| {
+        (c.fragment_a.source_id == src_a.id
+            && c.fragment_b.source_id == src_b.id
+            && covers(&c.fragment_a, a)
+            && covers(&c.fragment_b, b))
+            || (c.fragment_a.source_id == src_b.id
+                && c.fragment_b.source_id == src_a.id
+                && covers(&c.fragment_a, b)
+                && covers(&c.fragment_b, a))
+    })
+}
+
+fn make_clone(
+    src_a: &FunctionSource,
+    a: &FunctionSig,
+    src_b: &FunctionSource,
+    b: &FunctionSig,
+    similarity: f32,
+) -> CpdClone {
+    let frag = |src: &FunctionSource, f: &FunctionSig| Fragment {
+        source_id: src.id.clone(),
+        source_root: None,
+        start: f.start.clone(),
+        end: f.end.clone(),
+        range: f.range,
+        blame: None,
+    };
+    // Deterministic fragment order: by source id, then position.
+    let a_first = (src_a.id.as_str(), a.start.line) <= (src_b.id.as_str(), b.start.line);
+    let (fa, fb) = if a_first {
+        (frag(src_a, a), frag(src_b, b))
+    } else {
+        (frag(src_b, b), frag(src_a, a))
+    };
+    CpdClone {
+        format: src_a.format.clone(),
+        fragment_a: fa,
+        fragment_b: fb,
+        token_count: a.token_count.min(b.token_count),
+        is_new: false,
+        kind: CloneKind::Similar,
+        similarity: Some(similarity),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loc(line: u32, offset: u32) -> Location {
+        Location {
+            line,
+            column: 0,
+            offset,
+        }
+    }
+
+    fn spans(n: u32) -> Vec<(Location, Location)> {
+        (0..n)
+            .map(|i| (loc(i + 1, i * 10), loc(i + 1, i * 10 + 5)))
+            .collect()
+    }
+
+    fn sig(name: &str, kinds: &[u16], first_tok: u32, last_tok: u32) -> FunctionSig {
+        let spans = spans(last_tok + 1);
+        FunctionSig::build(
+            name.into(),
+            loc(first_tok + 1, first_tok * 10),
+            loc(last_tok + 1, last_tok * 10 + 5),
+            kinds,
+            &spans,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn shingles_are_order_sensitive_and_sorted() {
+        let a = shingles_from_kinds(&[1, 2, 3, 4, 5], 4);
+        let b = shingles_from_kinds(&[5, 4, 3, 2, 1], 4);
+        assert_eq!(a.len(), 2);
+        assert_ne!(a, b);
+        assert!(a.windows(2).all(|w| w[0] <= w[1]));
+        assert!(shingles_from_kinds(&[1, 2, 3], 4).is_empty());
+    }
+
+    #[test]
+    fn bag_jaccard_counts_multiplicity() {
+        assert_eq!(bag_jaccard(&[1, 2, 3], &[1, 2, 3]), 1.0);
+        assert_eq!(bag_jaccard(&[1, 1, 2], &[1, 2, 2]), 0.5);
+        assert_eq!(bag_jaccard(&[1, 2], &[3, 4]), 0.0);
+        assert_eq!(bag_jaccard(&[], &[]), 0.0);
+    }
+
+    #[test]
+    fn minhash_of_equal_sets_is_equal_and_of_disjoint_sets_differs() {
+        let a = minhash(&[1, 2, 3, 3, 4]);
+        let b = minhash(&[1, 2, 3, 4]);
+        assert_eq!(a, b, "multiplicity does not affect the signature");
+        let c = minhash(&[10, 20, 30, 40]);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn build_maps_bytes_to_token_range_and_rejects_empty_bodies() {
+        let s = sig("f", &[1, 2, 3, 4, 5, 6], 2, 7);
+        assert_eq!(s.range, [2, 7]);
+        assert_eq!(s.token_count, 6);
+        assert_eq!(s.line_span(), 5);
+        let spans = spans(4);
+        assert!(
+            FunctionSig::build("g".into(), loc(9, 900), loc(9, 950), &[1, 2, 3, 4], &spans)
+                .is_none()
+        );
+    }
+
+    fn kinds(seed: u16, n: usize) -> Vec<u16> {
+        (0..n).map(|i| ((i as u16 * 7 + seed) % 23) + 1).collect()
+    }
+
+    #[test]
+    fn index_finds_edited_copies_and_ignores_unrelated_functions() {
+        let base = kinds(1, 80);
+        let mut edited = base.clone();
+        edited.insert(40, 99); // one inserted node
+        edited[10] = 98; // one changed node
+        // A genuinely different structure, not a shifted copy of `base`.
+        let other: Vec<u16> = (0..80u16).map(|i| (i * i * 3 + 11) % 29 + 1).collect();
+        let sources = vec![
+            FunctionSource {
+                id: "a.js".into(),
+                format: "javascript".into(),
+                functions: vec![sig("base", &base, 0, 60)],
+            },
+            FunctionSource {
+                id: "b.js".into(),
+                format: "javascript".into(),
+                functions: vec![sig("edited", &edited, 0, 62), sig("other", &other, 70, 140)],
+            },
+        ];
+        let clones = find_similar_functions(&sources, 0.75, 10, 3, &[]);
+        assert_eq!(clones.len(), 1, "{clones:?}");
+        let c = &clones[0];
+        assert_eq!(c.kind, CloneKind::Similar);
+        assert_eq!(c.fragment_a.source_id, "a.js");
+        assert_eq!(c.fragment_b.source_id, "b.js");
+        assert_eq!(c.fragment_b.start.line, 1);
+        let sim = c.similarity.unwrap();
+        // two node edits in 80 nodes break 8 of the 77 shingles
+        assert!(sim > 0.75 && sim < 0.9, "got {sim}");
+        assert_eq!(c.token_count, 61);
+        assert!(find_similar_functions(&sources, 0.99, 10, 3, &[]).is_empty());
+    }
+
+    #[test]
+    fn index_skips_nested_functions_small_functions_and_covered_pairs() {
+        let base = kinds(1, 80);
+        let outer = sig("outer", &base, 0, 60);
+        let inner = sig("inner", &base, 10, 50);
+        let same_file = vec![FunctionSource {
+            id: "a.js".into(),
+            format: "javascript".into(),
+            functions: vec![outer.clone(), inner],
+        }];
+        assert!(find_similar_functions(&same_file, 0.5, 10, 3, &[]).is_empty());
+
+        let two = vec![
+            FunctionSource {
+                id: "a.js".into(),
+                format: "javascript".into(),
+                functions: vec![outer.clone()],
+            },
+            FunctionSource {
+                id: "b.js".into(),
+                format: "javascript".into(),
+                functions: vec![sig("copy", &base, 0, 60)],
+            },
+        ];
+        assert_eq!(find_similar_functions(&two, 0.5, 10, 3, &[]).len(), 1);
+        assert!(
+            find_similar_functions(&two, 0.5, 100, 3, &[]).is_empty(),
+            "min_tokens"
+        );
+        assert!(
+            find_similar_functions(&two, 0.5, 10, 100, &[]).is_empty(),
+            "min_lines"
+        );
+
+        let mut exact = make_clone(&two[0], &outer, &two[1], &two[1].functions[0], 1.0);
+        exact.kind = CloneKind::Exact;
+        exact.similarity = None;
+        assert!(
+            find_similar_functions(&two, 0.5, 10, 3, &[exact]).is_empty(),
+            "already reported"
+        );
+    }
+
+    #[test]
+    fn query_returns_best_match_first() {
+        let base = kinds(1, 80);
+        let mut near = base.clone();
+        near[3] = 99;
+        let mut far = base.clone();
+        for k in far.iter_mut().take(20) {
+            *k = 99;
+        }
+        let sources = vec![FunctionSource {
+            id: "lib.js".into(),
+            format: "javascript".into(),
+            functions: vec![sig("far", &far, 0, 60), sig("near", &near, 70, 130)],
+        }];
+        let index = SimilarityIndex::build(&sources, 10, 3);
+        let hits = index.query(&sig("q", &base, 0, 60), 0.5);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].1, 1, "near first");
+        assert!(hits[0].2 > hits[1].2);
+    }
+}

--- a/rust/crates/cpd-core/src/summary.rs
+++ b/rust/crates/cpd-core/src/summary.rs
@@ -347,6 +347,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         }
     }
 

--- a/rust/crates/cpd-finder/src/blame.rs
+++ b/rust/crates/cpd-finder/src/blame.rs
@@ -138,6 +138,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         }
     }
 

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -22,8 +22,10 @@ pub struct RunConfig {
     /// lines into a `similar` clone (issue #999). 0 = off.
     pub max_gap_lines: usize,
     /// Report JS/TS function pairs whose AST similarity reaches this value
-    /// as `similar` clones (issue #999, stage 2). `None` = off.
-    pub similarity: Option<f32>,
+    /// as `similar` clones (issue #999, stage 2). `1.0` (the default) means
+    /// exact matches only: the pass does not run. See
+    /// [`RunConfig::similarity_threshold`].
+    pub similarity: f32,
     pub mode: Mode,
     pub formats: Vec<String>,
     pub ignore: Vec<String>,
@@ -58,7 +60,7 @@ impl Default for RunConfig {
             min_lines: 5,
             max_lines: None,
             max_gap_lines: 0,
-            similarity: None,
+            similarity: 1.0,
             mode: Mode::Mild,
             formats: vec![],
             ignore: vec![],
@@ -79,6 +81,16 @@ impl Default for RunConfig {
             pattern: None,
             cross_formats: vec![],
         }
+    }
+}
+
+impl RunConfig {
+    /// The function-similarity threshold when the pass is enabled: values
+    /// strictly between 0 and 1. `1.0` (exact only) and out-of-range values
+    /// yield `None`, so a run without `--similarity` never touches the
+    /// function extractor or the index.
+    pub fn similarity_threshold(&self) -> Option<f32> {
+        (self.similarity > 0.0 && self.similarity < 1.0).then_some(self.similarity)
     }
 }
 
@@ -187,7 +199,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
     let mut clones = merge_gapped_clones(clones, config.max_gap_lines);
 
     // 4c. Function-level similarity — only when --similarity is set.
-    if let Some(threshold) = config.similarity {
+    if let Some(threshold) = config.similarity_threshold() {
         let similar = find_similar_functions(
             function_sources,
             threshold,
@@ -251,7 +263,7 @@ pub fn prepare_scan_in(pool: &rayon::ThreadPool, config: &RunConfig) -> Prepared
     let ignore_identifiers = config.ignore_identifiers;
     let ignore_literals = config.ignore_literals;
     let ignore_annotations = config.ignore_annotations;
-    let want_functions = config.similarity.is_some();
+    let want_functions = config.similarity_threshold().is_some();
 
     // Pre-compile code-level ignore regex patterns once for all threads.
     // Invalid patterns are silently skipped.

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -189,7 +189,7 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
     // 4c. Function-level similarity — only when --similarity is set.
     if let Some(threshold) = config.similarity {
         let similar = find_similar_functions(
-            &function_sources,
+            function_sources,
             threshold,
             config.min_tokens,
             config.min_lines,

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -4,6 +4,8 @@ use crate::statistics;
 use crate::walker::{WalkConfig, walk};
 use cpd_core::detect::{PathFilters, PreparedSource, detect_prepared, merge_gapped_clones};
 use cpd_core::models::{CpdClone, SourceFile, Statistics};
+use cpd_core::similarity::{FunctionSig, collect_function_sources, find_similar_functions};
+use cpd_tokenizer::functions::{extract_functions, supports_functions};
 use cpd_tokenizer::tokenizer::{
     Mode, TokenizeOptions, code_ignore_ranges, tokenize_to_detection, tokenize_to_detection_maps,
 };
@@ -19,6 +21,9 @@ pub struct RunConfig {
     /// Merge clones of one file pair separated by at most this many unmatched
     /// lines into a `similar` clone (issue #999). 0 = off.
     pub max_gap_lines: usize,
+    /// Report JS/TS function pairs whose AST similarity reaches this value
+    /// as `similar` clones (issue #999, stage 2). `None` = off.
+    pub similarity: Option<f32>,
     pub mode: Mode,
     pub formats: Vec<String>,
     pub ignore: Vec<String>,
@@ -53,6 +58,7 @@ impl Default for RunConfig {
             min_lines: 5,
             max_lines: None,
             max_gap_lines: 0,
+            similarity: None,
             mode: Mode::Mild,
             formats: vec![],
             ignore: vec![],
@@ -144,6 +150,10 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
         prepared: prepared_sources,
     } = prepare_scan_in(&pool, config);
 
+    // Function signatures must be taken before the pools consume the
+    // prepared sources; empty unless --similarity is set.
+    let function_sources = collect_function_sources(&prepared_sources);
+
     // 3. Group prepared sources into detection pools (deterministic order).
     let format_groups = build_pools(prepared_sources, &config.cross_formats);
 
@@ -174,7 +184,19 @@ pub fn run(config: &RunConfig) -> Result<RunResult, FinderError> {
     });
 
     // 4b. Near-miss merging — a no-op unless --max-gap-lines is set.
-    let clones = merge_gapped_clones(clones, config.max_gap_lines);
+    let mut clones = merge_gapped_clones(clones, config.max_gap_lines);
+
+    // 4c. Function-level similarity — only when --similarity is set.
+    if let Some(threshold) = config.similarity {
+        let similar = find_similar_functions(
+            &function_sources,
+            threshold,
+            config.min_tokens,
+            config.min_lines,
+            &clones,
+        );
+        clones.extend(similar);
+    }
 
     // 5. Compute statistics.
     let statistics = statistics::compute(&source_files, &clones);
@@ -229,6 +251,7 @@ pub fn prepare_scan_in(pool: &rayon::ThreadPool, config: &RunConfig) -> Prepared
     let ignore_identifiers = config.ignore_identifiers;
     let ignore_literals = config.ignore_literals;
     let ignore_annotations = config.ignore_annotations;
+    let want_functions = config.similarity.is_some();
 
     // Pre-compile code-level ignore regex patterns once for all threads.
     // Invalid patterns are silently skipped.
@@ -387,8 +410,22 @@ pub fn prepare_scan_in(pool: &rayon::ThreadPool, config: &RunConfig) -> Prepared
                         return None;
                     }
 
-                    let prepared =
+                    let mut prepared =
                         PreparedSource::from_detection_tokens(id, file.format, &det_tokens);
+                    if want_functions && supports_functions(&prepared.format) {
+                        prepared.functions = extract_functions(content, &prepared.format)
+                            .into_iter()
+                            .filter_map(|f| {
+                                FunctionSig::build(
+                                    f.name,
+                                    f.start,
+                                    f.end,
+                                    &f.kinds,
+                                    &prepared.spans,
+                                )
+                            })
+                            .collect();
+                    }
 
                     Some((vec![source_file], vec![prepared]))
                 }
@@ -474,6 +511,7 @@ mod tests {
             hashes: vec![],
             spans: vec![],
             raw_hashes: Vec::new(),
+            functions: Vec::new(),
         }
     }
 

--- a/rust/crates/cpd-finder/src/orchestrate.rs
+++ b/rust/crates/cpd-finder/src/orchestrate.rs
@@ -417,6 +417,7 @@ pub fn prepare_scan_in(pool: &rayon::ThreadPool, config: &RunConfig) -> Prepared
                             .into_iter()
                             .filter_map(|f| {
                                 FunctionSig::build(
+                                    f.grammar,
                                     f.name,
                                     f.start,
                                     f.end,

--- a/rust/crates/cpd-finder/src/statistics.rs
+++ b/rust/crates/cpd-finder/src/statistics.rs
@@ -152,6 +152,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         }
     }
 

--- a/rust/crates/cpd-reporter/src/ai.rs
+++ b/rust/crates/cpd-reporter/src/ai.rs
@@ -72,7 +72,10 @@ impl Reporter for AiReporter {
             let line = compress_clone_line(path_a, path_b, &range_a, &range_b);
             match (clone.kind, clone.similarity) {
                 (CloneKind::Renamed, _) => println!("{} (renamed)", line),
-                (CloneKind::Similar, Some(s)) => println!("{} [~{:.2}]", line, s),
+                (CloneKind::Similar, Some(s)) => match clone.similarity_method {
+                    Some(m) => println!("{} [~{:.2} {}]", line, s, m.as_str()),
+                    None => println!("{} [~{:.2}]", line, s),
+                },
                 (CloneKind::Similar, None) => println!("{} [~]", line),
                 (CloneKind::Exact, _) => println!("{}", line),
             }

--- a/rust/crates/cpd-reporter/src/console_full.rs
+++ b/rust/crates/cpd-reporter/src/console_full.rs
@@ -198,6 +198,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         }
     }
 
@@ -223,6 +224,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         }
     }
 

--- a/rust/crates/cpd-reporter/src/html.rs
+++ b/rust/crates/cpd-reporter/src/html.rs
@@ -225,6 +225,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         };
         let mut stats = empty_stats();
         stats.total.clones = 1;

--- a/rust/crates/cpd-reporter/src/json_reporter.rs
+++ b/rust/crates/cpd-reporter/src/json_reporter.rs
@@ -90,6 +90,9 @@ fn clone_to_dup(
     if let Some(similarity) = clone.similarity_rounded() {
         duplicate["similarity"] = json!(similarity);
     }
+    if let Some(method) = clone.similarity_method {
+        duplicate["method"] = json!(method.as_str());
+    }
     duplicate
 }
 
@@ -338,11 +341,14 @@ mod tests {
         let mut similar = make_clone("nonexistent.js", "also_nonexistent.js", 10);
         similar.kind = cpd_core::models::CloneKind::Similar;
         similar.similarity = Some(0.851_063_8);
+        similar.similarity_method = Some(cpd_core::models::SimilarityMethod::Gap);
         let exact = make_clone("nonexistent.js", "also_nonexistent.js", 10);
         let content = run_json_report(&[similar, exact], false);
         let parsed = parse_json_report(&content);
         assert_eq!(parsed["duplicates"][0]["kind"], "similar");
         assert_eq!(parsed["duplicates"][0]["similarity"], 0.851);
+        assert_eq!(parsed["duplicates"][0]["method"], "gap");
+        assert!(parsed["duplicates"][1].get("method").is_none());
         assert!(parsed["duplicates"][1].get("similarity").is_none());
     }
 

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -150,6 +150,9 @@ impl Reporter for SarifReporter {
             if let Some(similarity) = clone.similarity_rounded() {
                 props["similarity"] = json!(similarity);
             }
+            if let Some(method) = clone.similarity_method {
+                props["similarity_method"] = json!(method.as_str());
+            }
             if let Some(hash) = &clone_hash {
                 props["clone_hash"] = json!(hash);
             }
@@ -322,6 +325,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         }
     }
 
@@ -392,11 +396,13 @@ mod tests {
         let mut similar = make_clone();
         similar.kind = CloneKind::Similar;
         similar.similarity = Some(0.9);
+        similar.similarity_method = Some(cpd_core::models::SimilarityMethod::Ast);
         let content = run_sarif_report(&[similar], false);
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
         let result = &parsed["runs"][0]["results"][0];
         assert_eq!(result["ruleId"], "jscpd/near-miss-code");
         assert_eq!(result["properties"]["similarity"], 0.9);
+        assert_eq!(result["properties"]["similarity_method"], "ast");
         let rules = parsed["runs"][0]["tool"]["driver"]["rules"]
             .as_array()
             .unwrap();

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -694,7 +694,7 @@ mod label_tests {
             clone_label(
                 "javascript",
                 CloneKind::Similar,
-                Some(0.905),
+                Some(0.91),
                 Some(SimilarityMethod::Gap)
             ),
             "javascript, similar (gap) ~0.91"

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -1,6 +1,6 @@
 // shared.rs — common reporter utilities to keep output formatting DRY.
 
-use cpd_core::models::{CloneKind, CpdClone, Fragment, StatRow, Statistics};
+use cpd_core::models::{CloneKind, CpdClone, Fragment, SimilarityMethod, StatRow, Statistics};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
@@ -341,12 +341,21 @@ pub fn format_location(
 }
 
 /// Label for a clone header: the format, plus `, renamed` for Type-2 clones
-/// and `, similar ~0.91` for near-miss clones.
-pub fn clone_label(format: &str, kind: CloneKind, similarity: Option<f32>) -> String {
+/// and `, similar (gap) ~0.91` / `, similar (ast) ~0.75` for near-miss
+/// clones — the method matters because the two scores are not comparable.
+pub fn clone_label(
+    format: &str,
+    kind: CloneKind,
+    similarity: Option<f32>,
+    method: Option<SimilarityMethod>,
+) -> String {
     match (kind, similarity) {
         (CloneKind::Exact, _) => format.to_string(),
         (CloneKind::Renamed, _) => format!("{format}, renamed"),
-        (CloneKind::Similar, Some(s)) => format!("{format}, similar ~{s:.2}"),
+        (CloneKind::Similar, Some(s)) => match method {
+            Some(m) => format!("{format}, similar ({}) ~{s:.2}", m.as_str()),
+            None => format!("{format}, similar ~{s:.2}"),
+        },
         (CloneKind::Similar, None) => format!("{format}, similar"),
     }
 }
@@ -357,7 +366,12 @@ pub fn clone_label(format: &str, kind: CloneKind, similarity: Option<f32>) -> St
 pub fn print_clone_header(style: &Style, clone: &CpdClone) {
     let header = style.bold(&format!(
         "Clone found ({})",
-        clone_label(&clone.format, clone.kind, clone.similarity)
+        clone_label(
+            &clone.format,
+            clone.kind,
+            clone.similarity,
+            clone.similarity_method
+        )
     ));
     let is_new = clone.is_new;
     if is_new {
@@ -657,6 +671,46 @@ pub mod fixtures {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod label_tests {
+    use super::*;
+
+    #[test]
+    fn clone_label_shows_kind_method_and_score() {
+        assert_eq!(
+            clone_label("javascript", CloneKind::Exact, None, None),
+            "javascript"
+        );
+        assert_eq!(
+            clone_label("javascript", CloneKind::Renamed, None, None),
+            "javascript, renamed"
+        );
+        assert_eq!(
+            clone_label(
+                "javascript",
+                CloneKind::Similar,
+                Some(0.905),
+                Some(SimilarityMethod::Gap)
+            ),
+            "javascript, similar (gap) ~0.91"
+        );
+        assert_eq!(
+            clone_label(
+                "typescript",
+                CloneKind::Similar,
+                Some(0.752),
+                Some(SimilarityMethod::Ast)
+            ),
+            "typescript, similar (ast) ~0.75"
+        );
+        assert_eq!(
+            clone_label("java", CloneKind::Similar, None, None),
+            "java, similar"
+        );
     }
 }

--- a/rust/crates/cpd-reporter/src/xcode.rs
+++ b/rust/crates/cpd-reporter/src/xcode.rs
@@ -100,6 +100,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         };
         let opts = ReporterOptions::new(PathBuf::from("/tmp"));
         let reporter = XcodeReporter::new(&opts);

--- a/rust/crates/cpd-reporter/src/xml_reporter.rs
+++ b/rust/crates/cpd-reporter/src/xml_reporter.rs
@@ -210,6 +210,7 @@ mod tests {
             is_new: false,
             kind: Default::default(),
             similarity: None,
+            similarity_method: None,
         };
         let opts = ReporterOptions::new(dir.clone());
         let reporter = XmlReporter::new(&opts);

--- a/rust/crates/cpd-reporter/tests/blame_integration.rs
+++ b/rust/crates/cpd-reporter/tests/blame_integration.rs
@@ -65,6 +65,7 @@ fn make_clone_with_blame() -> CpdClone {
         is_new: false,
         kind: Default::default(),
         similarity: None,
+        similarity_method: None,
     }
 }
 
@@ -96,6 +97,7 @@ fn make_clone_no_blame() -> CpdClone {
         is_new: false,
         kind: Default::default(),
         similarity: None,
+        similarity_method: None,
     }
 }
 

--- a/rust/crates/cpd-reporter/tests/reporters_integration.rs
+++ b/rust/crates/cpd-reporter/tests/reporters_integration.rs
@@ -90,6 +90,7 @@ fn make_test_clone() -> CpdClone {
         is_new: false,
         kind: Default::default(),
         similarity: None,
+        similarity_method: None,
     }
 }
 
@@ -158,6 +159,7 @@ fn make_test_clone_with_real_files(dir: &Path) -> CpdClone {
         is_new: false,
         kind: Default::default(),
         similarity: None,
+        similarity_method: None,
     }
 }
 

--- a/rust/crates/cpd-tokenizer/src/functions.rs
+++ b/rust/crates/cpd-tokenizer/src/functions.rs
@@ -1,10 +1,24 @@
 //! Function extraction for similarity scoring (issue #999, stage 2).
 //!
-//! Walks the oxc AST of a JavaScript/TypeScript source and records, for
-//! every function declaration, function expression, method and arrow
-//! function, its name, span and the pre-order sequence of AST node types
-//! inside it. Node *types* only: identifiers and literal values are not
-//! part of the sequence, so the summary describes structure.
+//! A [`FunctionExtractor`] turns a source file into its functions, each with
+//! a name, a span and the pre-order sequence of syntax-tree node types
+//! inside it. Node *types* only: identifiers and literal values are not part
+//! of the sequence, so the summary describes structure. The scoring in
+//! `cpd_core::similarity` is grammar-agnostic; it only ever compares two
+//! functions that carry the same [`FunctionExtractor::grammar`] id.
+//!
+//! # Adding a language
+//!
+//! 1. Implement [`FunctionExtractor`]: pick a stable `grammar` id (for a
+//!    tree-sitter grammar, its name), list the jscpd `formats` it serves,
+//!    and in `extract` walk the tree, opening a [`RawFunction`] at every
+//!    function-like node and appending each visited node's type id (any
+//!    dense `u16`, e.g. tree-sitter's `node.kind_id()`) to every open
+//!    function.
+//! 2. Add the extractor to [`EXTRACTORS`].
+//!
+//! Nothing else changes: the CLI, the MCP tool, the reporters and the
+//! fixtures pick the new formats up through [`supports_functions`].
 
 use crate::line_index::LineIndex;
 use cpd_core::models::Location;
@@ -17,24 +31,77 @@ use oxc_span::GetSpan;
 /// A function found in a source, before token ranges are attached.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RawFunction {
+    /// Grammar that produced `kinds`; functions of different grammars are
+    /// never compared.
+    pub grammar: &'static str,
     pub name: String,
     pub start: Location,
     pub end: Location,
-    /// Pre-order AST node types of the function, itself included.
+    /// Pre-order syntax-tree node types of the function, itself included.
     pub kinds: Vec<u16>,
+}
+
+/// Language plug-in for function extraction.
+pub trait FunctionExtractor: Send + Sync {
+    /// Stable identifier of the grammar behind the node-type ids.
+    fn grammar(&self) -> &'static str;
+    /// jscpd format names this extractor serves.
+    fn formats(&self) -> &'static [&'static str];
+    /// All functions of `source`; empty when the source does not parse.
+    fn extract(&self, source: &str, format: &str) -> Vec<RawFunction>;
+}
+
+/// Registered extractors, consulted in order. Add new languages here.
+pub static EXTRACTORS: &[&dyn FunctionExtractor] = &[&OxcExtractor];
+
+/// The extractor serving `format`, if any.
+pub fn extractor_for(format: &str) -> Option<&'static dyn FunctionExtractor> {
+    EXTRACTORS
+        .iter()
+        .copied()
+        .find(|e| e.formats().contains(&format))
 }
 
 /// Formats handled by [`extract_functions`].
 pub fn supports_functions(format: &str) -> bool {
-    matches!(format, "javascript" | "typescript" | "jsx" | "tsx")
+    extractor_for(format).is_some()
 }
 
-/// Extract every function of a JS/TS source. Returns an empty vector for
-/// unsupported formats and for sources that fail to parse.
+/// Every format some extractor serves, for messages and docs.
+pub fn supported_function_formats() -> Vec<&'static str> {
+    EXTRACTORS
+        .iter()
+        .flat_map(|e| e.formats().iter().copied())
+        .collect()
+}
+
+/// Extract every function of a source. Returns an empty vector for formats
+/// without an extractor and for sources that fail to parse.
 pub fn extract_functions(source: &str, format: &str) -> Vec<RawFunction> {
-    if !supports_functions(format) || source.is_empty() {
-        return Vec::new();
+    match extractor_for(format) {
+        Some(extractor) if !source.is_empty() => extractor.extract(source, format),
+        _ => Vec::new(),
     }
+}
+
+/// JavaScript, TypeScript, JSX and TSX through the oxc parser.
+pub struct OxcExtractor;
+
+impl FunctionExtractor for OxcExtractor {
+    fn grammar(&self) -> &'static str {
+        "oxc"
+    }
+
+    fn formats(&self) -> &'static [&'static str] {
+        &["javascript", "typescript", "jsx", "tsx"]
+    }
+
+    fn extract(&self, source: &str, format: &str) -> Vec<RawFunction> {
+        extract_with_oxc(source, format)
+    }
+}
+
+fn extract_with_oxc(source: &str, format: &str) -> Vec<RawFunction> {
     let allocator = Allocator::new();
     let source_type = crate::javascript::source_type_for_format(format);
     let parsed = Parser::new(&allocator, source, source_type).parse();
@@ -87,6 +154,7 @@ impl Extractor<'_> {
         let start = (frame.start as usize).min(self.len);
         let end = (frame.end as usize).min(self.len);
         self.out.push(RawFunction {
+            grammar: OxcExtractor.grammar(),
             name: frame.name,
             start: self.line_index.location(start),
             end: self.line_index.location(end),
@@ -173,6 +241,20 @@ mod tests {
         assert_eq!(fns[0].name, "inner"); // closed first
         assert_eq!(fns[1].name, "outer");
         assert!(fns[1].kinds.len() > fns[0].kinds.len());
+    }
+
+    #[test]
+    fn registry_dispatches_by_format_and_tags_the_grammar() {
+        assert_eq!(extractor_for("typescript").unwrap().grammar(), "oxc");
+        assert!(extractor_for("python").is_none());
+        let formats = supported_function_formats();
+        for f in ["javascript", "typescript", "jsx", "tsx"] {
+            assert!(formats.contains(&f), "{f}");
+            assert!(supports_functions(f));
+        }
+        let fns = extract_functions("const f = () => 1;", "jsx");
+        assert_eq!(fns.len(), 1);
+        assert_eq!(fns[0].grammar, "oxc");
     }
 
     #[test]

--- a/rust/crates/cpd-tokenizer/src/functions.rs
+++ b/rust/crates/cpd-tokenizer/src/functions.rs
@@ -1,0 +1,191 @@
+//! Function extraction for similarity scoring (issue #999, stage 2).
+//!
+//! Walks the oxc AST of a JavaScript/TypeScript source and records, for
+//! every function declaration, function expression, method and arrow
+//! function, its name, span and the pre-order sequence of AST node types
+//! inside it. Node *types* only: identifiers and literal values are not
+//! part of the sequence, so the summary describes structure.
+
+use crate::line_index::LineIndex;
+use cpd_core::models::Location;
+use oxc_allocator::Allocator;
+use oxc_ast::AstKind;
+use oxc_ast_visit::Visit;
+use oxc_parser::Parser;
+use oxc_span::GetSpan;
+
+/// A function found in a source, before token ranges are attached.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawFunction {
+    pub name: String,
+    pub start: Location,
+    pub end: Location,
+    /// Pre-order AST node types of the function, itself included.
+    pub kinds: Vec<u16>,
+}
+
+/// Formats handled by [`extract_functions`].
+pub fn supports_functions(format: &str) -> bool {
+    matches!(format, "javascript" | "typescript" | "jsx" | "tsx")
+}
+
+/// Extract every function of a JS/TS source. Returns an empty vector for
+/// unsupported formats and for sources that fail to parse.
+pub fn extract_functions(source: &str, format: &str) -> Vec<RawFunction> {
+    if !supports_functions(format) || source.is_empty() {
+        return Vec::new();
+    }
+    let allocator = Allocator::new();
+    let source_type = crate::javascript::source_type_for_format(format);
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if !parsed.diagnostics.is_empty() {
+        return Vec::new();
+    }
+    let line_index = LineIndex::new(source.as_bytes());
+    let mut extractor = Extractor {
+        frames: Vec::new(),
+        out: Vec::new(),
+        pending_name: None,
+        line_index: &line_index,
+        len: source.len(),
+    };
+    extractor.visit_program(&parsed.program);
+    extractor.out
+}
+
+struct Frame {
+    name: String,
+    start: u32,
+    end: u32,
+    kinds: Vec<u16>,
+}
+
+struct Extractor<'i> {
+    frames: Vec<Frame>,
+    out: Vec<RawFunction>,
+    /// Name from the enclosing declarator, property or method, consumed by
+    /// the next function node.
+    pending_name: Option<String>,
+    line_index: &'i LineIndex,
+    len: usize,
+}
+
+impl Extractor<'_> {
+    fn open(&mut self, name: String, start: u32, end: u32) {
+        self.frames.push(Frame {
+            name,
+            start,
+            end,
+            kinds: Vec::new(),
+        });
+    }
+
+    fn close(&mut self) {
+        let Some(frame) = self.frames.pop() else {
+            return;
+        };
+        let start = (frame.start as usize).min(self.len);
+        let end = (frame.end as usize).min(self.len);
+        self.out.push(RawFunction {
+            name: frame.name,
+            start: self.line_index.location(start),
+            end: self.line_index.location(end),
+            kinds: frame.kinds,
+        });
+    }
+}
+
+impl<'a> Visit<'a> for Extractor<'_> {
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        match kind {
+            AstKind::VariableDeclarator(d) => {
+                self.pending_name = d.id.get_identifier_name().map(|n| n.to_string());
+            }
+            AstKind::MethodDefinition(m) => {
+                self.pending_name = m.key.static_name().map(|n| n.into_owned());
+            }
+            AstKind::PropertyDefinition(p) => {
+                self.pending_name = p.key.static_name().map(|n| n.into_owned());
+            }
+            AstKind::ObjectProperty(p) => {
+                self.pending_name = p.key.static_name().map(|n| n.into_owned());
+            }
+            AstKind::Function(f) => {
+                let name =
+                    f.id.as_ref()
+                        .map(|id| id.name.to_string())
+                        .or_else(|| self.pending_name.take())
+                        .unwrap_or_else(|| "<anonymous>".to_string());
+                let span = f.span;
+                self.open(name, span.start, span.end);
+            }
+            AstKind::ArrowFunctionExpression(a) => {
+                let name = self
+                    .pending_name
+                    .take()
+                    .unwrap_or_else(|| "<arrow>".to_string());
+                let span = a.span;
+                self.open(name, span.start, span.end);
+            }
+            _ => {}
+        }
+        let ty = kind.ty() as u16;
+        for frame in &mut self.frames {
+            frame.kinds.push(ty);
+        }
+    }
+
+    fn leave_node(&mut self, kind: AstKind<'a>) {
+        match kind {
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => self.close(),
+            AstKind::VariableDeclarator(_)
+            | AstKind::MethodDefinition(_)
+            | AstKind::PropertyDefinition(_)
+            | AstKind::ObjectProperty(_) => self.pending_name = None,
+            _ => {}
+        }
+        let _ = kind.span();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SRC: &str = "export function total(items) {\n  let sum = 0;\n  for (const it of items) { sum += it.price; }\n  return sum;\n}\nconst double = (x) => x * 2;\nclass Cart {\n  add(item) { this.items.push(item); }\n}\nconst obj = { run() { return 1; }, cb: function () { return 2; } };\n";
+
+    #[test]
+    fn extracts_declarations_arrows_methods_and_properties_with_names() {
+        let fns = extract_functions(SRC, "javascript");
+        let names: Vec<&str> = fns.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["total", "double", "add", "run", "cb"]);
+        let total = &fns[0];
+        assert_eq!((total.start.line, total.end.line), (1, 5));
+        assert!(total.kinds.len() > 20, "{}", total.kinds.len());
+        assert_eq!(total.kinds[0], oxc_ast::AstType::Function as u16);
+    }
+
+    #[test]
+    fn nested_functions_are_emitted_separately_and_contribute_to_the_outer() {
+        let src = "function outer() {\n  const inner = () => 1;\n  return inner();\n}\n";
+        let fns = extract_functions(src, "typescript");
+        assert_eq!(fns.len(), 2);
+        assert_eq!(fns[0].name, "inner"); // closed first
+        assert_eq!(fns[1].name, "outer");
+        assert!(fns[1].kinds.len() > fns[0].kinds.len());
+    }
+
+    #[test]
+    fn unsupported_or_broken_sources_yield_nothing() {
+        assert!(extract_functions("def f():\n  pass\n", "python").is_empty());
+        assert!(extract_functions("function (", "javascript").is_empty());
+        assert!(extract_functions("", "javascript").is_empty());
+    }
+
+    #[test]
+    fn renamed_copies_share_the_same_kind_sequence() {
+        let a = extract_functions("function a(x) { return x + 1; }", "javascript");
+        let b = extract_functions("function b(y) { return y + 1; }", "javascript");
+        assert_eq!(a[0].kinds, b[0].kinds);
+    }
+}

--- a/rust/crates/cpd-tokenizer/src/javascript.rs
+++ b/rust/crates/cpd-tokenizer/src/javascript.rs
@@ -159,7 +159,7 @@ const fn map_kind(kind: Kind) -> TokenKind {
     }
 }
 
-fn source_type_for_format(format: &str) -> SourceType {
+pub(crate) fn source_type_for_format(format: &str) -> SourceType {
     let filename = match format {
         "typescript" => "input.ts",
         "tsx" => "input.tsx",

--- a/rust/crates/cpd-tokenizer/src/lib.rs
+++ b/rust/crates/cpd-tokenizer/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod embedded;
 pub mod formats;
+pub mod functions;
 pub mod generic;
 pub mod javascript;
 pub mod line_index;

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -217,7 +217,7 @@ pub struct Cli {
     #[arg(long, value_name = "N")]
     pub max_gap_lines: Option<usize>,
 
-    /// Report JavaScript/TypeScript function pairs whose AST similarity reaches RATIO (0-1, e.g. 0.85) as near-miss clones (Type-3, "similar")
+    /// Report JavaScript/TypeScript function pairs whose AST similarity reaches RATIO (a number in (0, 1], e.g. 0.85; omit to disable) as near-miss clones (Type-3, "similar")
     #[arg(long, value_name = "RATIO")]
     pub similarity: Option<f32>,
 

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -217,7 +217,7 @@ pub struct Cli {
     #[arg(long, value_name = "N")]
     pub max_gap_lines: Option<usize>,
 
-    /// Report JavaScript/TypeScript function pairs whose AST similarity reaches RATIO (a number in (0, 1], e.g. 0.85; omit to disable) as near-miss clones (Type-3, "similar")
+    /// Report JavaScript/TypeScript function pairs whose AST similarity reaches RATIO as near-miss clones (Type-3, "similar"). A number in (0, 1]; the default 1 means exact matches only, e.g. 0.85 enables it
     #[arg(long, value_name = "RATIO")]
     pub similarity: Option<f32>,
 
@@ -1450,15 +1450,15 @@ mod tests {
         let cli = Cli::parse_from(["cpd", "--similarity", "0.85", "."]);
         assert_eq!(cli.similarity, Some(0.85));
         let opts = crate::options::Options::from_cli_and_config(&cli, &ConfigFile::default());
-        assert_eq!(opts.similarity, Some(0.85));
+        assert_eq!(opts.similarity, 0.85);
 
         let cli = Cli::parse_from(["cpd", "."]);
         let opts = crate::options::Options::from_cli_and_config(&cli, &ConfigFile::default());
-        assert_eq!(opts.similarity, None, "off by default");
+        assert_eq!(opts.similarity, 1.0, "1 = exact matches only, the default");
 
         let v: ConfigFile = serde_json::from_str(r#"{"similarity": 0.9}"#).unwrap();
         let opts = crate::options::Options::from_cli_and_config(&cli, &v);
-        assert_eq!(opts.similarity, Some(0.9));
+        assert_eq!(opts.similarity, 0.9);
     }
 
     #[test]

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -217,6 +217,10 @@ pub struct Cli {
     #[arg(long, value_name = "N")]
     pub max_gap_lines: Option<usize>,
 
+    /// Report JavaScript/TypeScript function pairs whose AST similarity reaches RATIO (0-1, e.g. 0.85) as near-miss clones (Type-3, "similar")
+    #[arg(long, value_name = "RATIO")]
+    pub similarity: Option<f32>,
+
     /// Detection mode: mild, weak, strict
     #[arg(long, short = 'm')]
     pub mode: Option<String>,
@@ -415,6 +419,7 @@ pub struct ConfigFile {
     pub max_lines: Option<usize>,
     #[serde(alias = "max-gap-lines")]
     pub max_gap_lines: Option<usize>,
+    pub similarity: Option<f32>,
     pub mode: Option<String>,
     #[serde(alias = "formats")]
     pub format: Option<Vec<String>>,
@@ -630,6 +635,7 @@ pub(crate) static KNOWN_CONFIG_FIELDS: &[&str] = &[
     "minLines",
     "maxLines",
     "maxGapLines",
+    "similarity",
     "mode",
     "format",
     "formats",
@@ -1437,6 +1443,22 @@ mod tests {
         assert_eq!(opts.max_gap_lines, 3);
         let v: ConfigFile = serde_json::from_str(r#"{"max-gap-lines": 1}"#).unwrap();
         assert_eq!(v.max_gap_lines, Some(1));
+    }
+
+    #[test]
+    fn similarity_flag_and_config() {
+        let cli = Cli::parse_from(["cpd", "--similarity", "0.85", "."]);
+        assert_eq!(cli.similarity, Some(0.85));
+        let opts = crate::options::Options::from_cli_and_config(&cli, &ConfigFile::default());
+        assert_eq!(opts.similarity, Some(0.85));
+
+        let cli = Cli::parse_from(["cpd", "."]);
+        let opts = crate::options::Options::from_cli_and_config(&cli, &ConfigFile::default());
+        assert_eq!(opts.similarity, None, "off by default");
+
+        let v: ConfigFile = serde_json::from_str(r#"{"similarity": 0.9}"#).unwrap();
+        let opts = crate::options::Options::from_cli_and_config(&cli, &v);
+        assert_eq!(opts.similarity, Some(0.9));
     }
 
     #[test]

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -32,7 +32,7 @@ struct MergedConfig {
     min_lines: usize,
     max_lines: Option<usize>,
     max_gap_lines: usize,
-    similarity: Option<f32>,
+    similarity: f32,
     mode: String,
     formats: Vec<String>,
     ignore: Vec<String>,
@@ -200,14 +200,12 @@ fn main() {
     let mut opts = Options::from_cli_and_config(&cli, &config);
 
     // --similarity is a ratio in (0, 1]; anything else is a typo, not a request.
-    if let Some(s) = opts.similarity
-        && !(s > 0.0 && s <= 1.0)
-    {
+    if !(opts.similarity > 0.0 && opts.similarity <= 1.0) {
         eprintln!(
-            "Warning: --similarity: {} is outside (0, 1]; function similarity is disabled",
-            s
+            "Warning: --similarity: {} is outside (0, 1]; using 1 (exact matches only)",
+            opts.similarity
         );
-        opts.similarity = None;
+        opts.similarity = 1.0;
     }
 
     // Warn about --ignore-pattern regexes that fail to compile: the tokenizer

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -31,6 +31,8 @@ struct MergedConfig {
     min_tokens: usize,
     min_lines: usize,
     max_lines: Option<usize>,
+    max_gap_lines: usize,
+    similarity: Option<f32>,
     mode: String,
     formats: Vec<String>,
     ignore: Vec<String>,
@@ -78,6 +80,8 @@ impl MergedConfig {
             min_tokens: opts.min_tokens,
             min_lines: opts.min_lines,
             max_lines: opts.max_lines,
+            max_gap_lines: opts.max_gap_lines,
+            similarity: opts.similarity,
             mode: format!("{:?}", opts.mode).to_lowercase(),
             formats: opts.formats.clone(),
             ignore: opts.ignore.clone(),
@@ -193,7 +197,18 @@ fn main() {
     }
 
     let config = config_result.config;
-    let opts = Options::from_cli_and_config(&cli, &config);
+    let mut opts = Options::from_cli_and_config(&cli, &config);
+
+    // --similarity is a ratio in (0, 1]; anything else is a typo, not a request.
+    if let Some(s) = opts.similarity
+        && !(s > 0.0 && s <= 1.0)
+    {
+        eprintln!(
+            "Warning: --similarity: {} is outside (0, 1]; function similarity is disabled",
+            s
+        );
+        opts.similarity = None;
+    }
 
     // Warn about --ignore-pattern regexes that fail to compile: the tokenizer
     // skips them, so a typo would otherwise disable the pattern with no feedback.
@@ -291,6 +306,7 @@ fn main() {
         min_lines: opts.min_lines,
         max_lines: opts.max_lines,
         max_gap_lines: opts.max_gap_lines,
+        similarity: opts.similarity,
         mode: opts.mode,
         formats: opts.formats.clone(),
         ignore: opts.ignore.clone(),

--- a/rust/crates/cpd/src/mcp.rs
+++ b/rust/crates/cpd/src/mcp.rs
@@ -345,7 +345,9 @@ impl McpServer {
                     extract_functions(&content, &ps.format)
                         .into_iter()
                         .filter_map(|f| {
-                            FunctionSig::build(f.name, f.start, f.end, &f.kinds, &ps.spans)
+                            FunctionSig::build(
+                                f.grammar, f.name, f.start, f.end, &f.kinds, &ps.spans,
+                            )
                         })
                         .collect()
                 } else {
@@ -375,7 +377,7 @@ impl McpServer {
     ) -> Vec<(f32, Value)> {
         let query: Vec<FunctionSig> = extract_functions(code, format)
             .into_iter()
-            .filter_map(|f| FunctionSig::build(f.name, f.start, f.end, &f.kinds, spans))
+            .filter_map(|f| FunctionSig::build(f.grammar, f.name, f.start, f.end, &f.kinds, spans))
             .collect();
         if query.is_empty() {
             return Vec::new();
@@ -515,9 +517,10 @@ impl McpServer {
             payload["similar"] =
                 Value::Array(hits.into_iter().take(limit).map(|(_, v)| v).collect());
             if !supports_functions(format) {
-                payload["similarNote"] = json!(
-                    "function similarity is available for javascript, typescript, jsx and tsx snippets"
-                );
+                payload["similarNote"] = json!(format!(
+                    "function similarity is available for {} snippets",
+                    cpd_tokenizer::functions::supported_function_formats().join(", ")
+                ));
             }
         }
         Ok(payload)

--- a/rust/crates/cpd/src/mcp.rs
+++ b/rust/crates/cpd/src/mcp.rs
@@ -54,10 +54,10 @@ pub struct McpServer {
     scan_roots: Vec<PathBuf>,
     /// Canonicalized isolation groups, for skip_isolated.
     isolated_groups: Vec<Vec<PathBuf>>,
-    /// Function signatures of the JS/TS sources, built on the first
-    /// check_duplication call with a 'similarity' argument and dropped on
-    /// rescan.
-    function_index: OnceLock<Vec<FunctionSource>>,
+    /// LSH index over the functions of the JS/TS sources, built on the first
+    /// check_duplication call with a 'similarity' argument, reused by every
+    /// later query, and dropped on rescan.
+    function_index: OnceLock<SimilarityIndex>,
 }
 
 impl McpServer {
@@ -328,10 +328,10 @@ impl McpServer {
         })
     }
 
-    /// Function signatures of every JS/TS source in the pools. Built once per
+    /// Similarity index over every JS/TS source in the pools. Built once per
     /// scan on demand: prepared sources keep only token spans, so files are
     /// re-read from disk unless the scan already ran with --similarity.
-    fn function_sources(&self) -> &Vec<FunctionSource> {
+    fn similarity_index(&self) -> &SimilarityIndex {
         self.function_index.get_or_init(|| {
             let mut out = Vec::new();
             for ps in self.pools.values().flatten() {
@@ -360,7 +360,7 @@ impl McpServer {
                 }
             }
             out.sort_by(|a, b| a.id.cmp(&b.id));
-            out
+            SimilarityIndex::build(out, self.config.min_tokens, self.config.min_lines)
         })
     }
 
@@ -380,8 +380,8 @@ impl McpServer {
         if query.is_empty() {
             return Vec::new();
         }
-        let sources = self.function_sources();
-        let index = SimilarityIndex::build(sources, self.config.min_tokens, self.config.min_lines);
+        let index = self.similarity_index();
+        let sources = index.sources();
         let mut hits = Vec::new();
         for q in &query {
             for (si, fi, sim) in index.query(q, threshold) {

--- a/rust/crates/cpd/src/mcp.rs
+++ b/rust/crates/cpd/src/mcp.rs
@@ -13,16 +13,19 @@
 
 use cpd_core::detect::{PathFilters, PreparedSource, detect_prepared};
 use cpd_core::models::{CpdClone, Statistics};
+use cpd_core::similarity::{FunctionSig, FunctionSource, SimilarityIndex};
 use cpd_finder::orchestrate::{
     PreparedScan, RunConfig, build_thread_pool, canonicalize_all, prepare_scan_in,
     strip_types_formats,
 };
 use cpd_finder::statistics;
+use cpd_tokenizer::functions::{extract_functions, supports_functions};
 use cpd_tokenizer::tokenizer::{TokenizeOptions, tokenize_to_detection};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 const SNIPPET_ID: &str = "snippet://check";
 /// Default cap on clones returned by check_current_directory — keeps tool
@@ -51,6 +54,10 @@ pub struct McpServer {
     scan_roots: Vec<PathBuf>,
     /// Canonicalized isolation groups, for skip_isolated.
     isolated_groups: Vec<Vec<PathBuf>>,
+    /// Function signatures of the JS/TS sources, built on the first
+    /// check_duplication call with a 'similarity' argument and dropped on
+    /// rescan.
+    function_index: OnceLock<Vec<FunctionSource>>,
 }
 
 impl McpServer {
@@ -75,6 +82,7 @@ impl McpServer {
             file_count: 0,
             scan_roots,
             isolated_groups,
+            function_index: OnceLock::new(),
         };
         server.rescan();
         server
@@ -94,6 +102,7 @@ impl McpServer {
     /// Walk + tokenize the configured paths, refresh the cached pools and
     /// project statistics.
     fn rescan(&mut self) {
+        self.function_index = OnceLock::new();
         let PreparedScan { sources, prepared } = prepare_scan_in(&self.pool, &self.config);
         self.file_count = sources.len();
 
@@ -240,7 +249,20 @@ impl McpServer {
                         "check_duplication requires string arguments 'code' and 'format'",
                     );
                 };
-                match self.check_duplication(code, format, limit) {
+                let similarity = match args.get("similarity") {
+                    None | Some(Value::Null) => None,
+                    Some(v) => match v.as_f64() {
+                        Some(s) if s > 0.0 && s <= 1.0 => Some(s as f32),
+                        _ => {
+                            return err(
+                                id,
+                                INVALID_PARAMS,
+                                "'similarity' must be a number in (0, 1]",
+                            );
+                        }
+                    },
+                };
+                match self.check_duplication(code, format, limit, similarity) {
                     Ok(payload) => ok(id, tool_text(&payload, false)),
                     Err(message) => ok(id, tool_text(&json!({ "error": message }), true)),
                 }
@@ -306,7 +328,91 @@ impl McpServer {
         })
     }
 
-    fn check_duplication(&self, code: &str, format: &str, limit: usize) -> Result<Value, String> {
+    /// Function signatures of every JS/TS source in the pools. Built once per
+    /// scan on demand: prepared sources keep only token spans, so files are
+    /// re-read from disk unless the scan already ran with --similarity.
+    fn function_sources(&self) -> &Vec<FunctionSource> {
+        self.function_index.get_or_init(|| {
+            let mut out = Vec::new();
+            for ps in self.pools.values().flatten() {
+                if !supports_functions(&ps.format) {
+                    continue;
+                }
+                let functions = if ps.functions.is_empty() {
+                    let Ok(content) = std::fs::read_to_string(&ps.id) else {
+                        continue;
+                    };
+                    extract_functions(&content, &ps.format)
+                        .into_iter()
+                        .filter_map(|f| {
+                            FunctionSig::build(f.name, f.start, f.end, &f.kinds, &ps.spans)
+                        })
+                        .collect()
+                } else {
+                    ps.functions.clone()
+                };
+                if !functions.is_empty() {
+                    out.push(FunctionSource {
+                        id: ps.id.clone(),
+                        format: ps.format.clone(),
+                        functions,
+                    });
+                }
+            }
+            out.sort_by(|a, b| a.id.cmp(&b.id));
+            out
+        })
+    }
+
+    /// Structurally similar project functions for every function of the
+    /// snippet, best first. `(similarity, payload)` pairs.
+    fn similar_functions(
+        &self,
+        code: &str,
+        format: &str,
+        spans: &[(cpd_core::models::Location, cpd_core::models::Location)],
+        threshold: f32,
+    ) -> Vec<(f32, Value)> {
+        let query: Vec<FunctionSig> = extract_functions(code, format)
+            .into_iter()
+            .filter_map(|f| FunctionSig::build(f.name, f.start, f.end, &f.kinds, spans))
+            .collect();
+        if query.is_empty() {
+            return Vec::new();
+        }
+        let sources = self.function_sources();
+        let index = SimilarityIndex::build(sources, self.config.min_tokens, self.config.min_lines);
+        let mut hits = Vec::new();
+        for q in &query {
+            for (si, fi, sim) in index.query(q, threshold) {
+                let src = &sources[si];
+                let f = &src.functions[fi];
+                hits.push((
+                    sim,
+                    json!({
+                        "file": self.display_path(&src.id),
+                        "name": f.name,
+                        "fileStartLine": f.start.line,
+                        "fileEndLine": f.end.line,
+                        "snippetName": q.name,
+                        "snippetStartLine": q.start.line,
+                        "snippetEndLine": q.end.line,
+                        "similarity": (f64::from(sim) * 1000.0).round() / 1000.0,
+                    }),
+                ));
+            }
+        }
+        hits.sort_by(|a, b| b.0.total_cmp(&a.0));
+        hits
+    }
+
+    fn check_duplication(
+        &self,
+        code: &str,
+        format: &str,
+        limit: usize,
+        similarity: Option<f32>,
+    ) -> Result<Value, String> {
         let format = self.resolve_format(format)?;
 
         let opts = TokenizeOptions {
@@ -334,6 +440,13 @@ impl McpServer {
 
         let snippet =
             PreparedSource::from_detection_tokens(SNIPPET_ID.into(), format.into(), &det_tokens);
+        let similar = similarity.map(|t| {
+            if supports_functions(format) {
+                self.similar_functions(code, format, &snippet.spans, t)
+            } else {
+                Vec::new()
+            }
+        });
         let mut pool = self
             .pools
             .get(&self.pool_key(format))
@@ -396,6 +509,16 @@ impl McpServer {
             payload["note"] = json!(format!(
                 "match list truncated to {limit}; pass a higher 'limit' for more"
             ));
+        }
+        if let Some(hits) = similar {
+            payload["similarCount"] = json!(hits.len());
+            payload["similar"] =
+                Value::Array(hits.into_iter().take(limit).map(|(_, v)| v).collect());
+            if !supports_functions(format) {
+                payload["similarNote"] = json!(
+                    "function similarity is available for javascript, typescript, jsx and tsx snippets"
+                );
+            }
         }
         Ok(payload)
     }
@@ -490,7 +613,7 @@ fn tool_definitions() -> Value {
     json!([
         {
             "name": "check_duplication",
-            "description": "Check a code snippet for duplications against the scanned project. Returns matching project locations with line ranges, biggest matches first.",
+            "description": "Check a code snippet for duplications against the scanned project. Returns matching project locations with line ranges, biggest matches first. With 'similarity', also returns project functions structurally similar to the snippet's functions (JavaScript/TypeScript), best first.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -500,6 +623,12 @@ fn tool_definitions() -> Value {
                         "type": "integer",
                         "minimum": 0,
                         "description": "Maximum matches to include in the response (default 100); 'count' always carries the untruncated total"
+                    },
+                    "similarity": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "maximum": 1,
+                        "description": "Also find project functions whose AST similarity to the snippet's functions reaches this ratio (e.g. 0.85); JavaScript/TypeScript only"
                     }
                 },
                 "required": ["code", "format"]

--- a/rust/crates/cpd/src/mcp.rs
+++ b/rust/crates/cpd/src/mcp.rs
@@ -249,10 +249,12 @@ impl McpServer {
                         "check_duplication requires string arguments 'code' and 'format'",
                     );
                 };
+                // Absent: the server's --similarity (off at the default 1).
+                // 1 means exact matches only, so it yields no similarity section.
                 let similarity = match args.get("similarity") {
-                    None | Some(Value::Null) => None,
+                    None | Some(Value::Null) => self.config.similarity_threshold(),
                     Some(v) => match v.as_f64() {
-                        Some(s) if s > 0.0 && s <= 1.0 => Some(s as f32),
+                        Some(s) if s > 0.0 && s <= 1.0 => (s < 1.0).then_some(s as f32),
                         _ => {
                             return err(
                                 id,
@@ -631,7 +633,7 @@ fn tool_definitions() -> Value {
                         "type": "number",
                         "exclusiveMinimum": 0,
                         "maximum": 1,
-                        "description": "Also find project functions whose AST similarity to the snippet's functions reaches this ratio (e.g. 0.85); JavaScript/TypeScript only"
+                        "description": "Also find project functions whose AST similarity to the snippet's functions reaches this ratio (e.g. 0.85); 1 means exact matches only (no similarity section); defaults to the server's --similarity; JavaScript/TypeScript only"
                     }
                 },
                 "required": ["code", "format"]

--- a/rust/crates/cpd/src/options.rs
+++ b/rust/crates/cpd/src/options.rs
@@ -13,6 +13,7 @@ pub struct Options {
     pub min_lines: usize,
     pub max_lines: Option<usize>,
     pub max_gap_lines: usize,
+    pub similarity: Option<f32>,
     pub mode: Mode,
     pub formats: Vec<String>,
     pub ignore: Vec<String>,
@@ -109,6 +110,7 @@ impl Options {
             min_lines: cli.min_lines.or(config.min_lines).unwrap_or(5),
             max_lines: cli.max_lines.or(config.max_lines),
             max_gap_lines: cli.max_gap_lines.or(config.max_gap_lines).unwrap_or(0),
+            similarity: cli.similarity.or(config.similarity),
             mode,
             formats: if cli.format.is_empty() {
                 config.format.clone().unwrap_or_default()

--- a/rust/crates/cpd/src/options.rs
+++ b/rust/crates/cpd/src/options.rs
@@ -13,7 +13,9 @@ pub struct Options {
     pub min_lines: usize,
     pub max_lines: Option<usize>,
     pub max_gap_lines: usize,
-    pub similarity: Option<f32>,
+    /// Function-similarity threshold in (0, 1]; 1 (the default) means exact
+    /// matches only, so the similarity pass never runs.
+    pub similarity: f32,
     pub mode: Mode,
     pub formats: Vec<String>,
     pub ignore: Vec<String>,
@@ -110,7 +112,7 @@ impl Options {
             min_lines: cli.min_lines.or(config.min_lines).unwrap_or(5),
             max_lines: cli.max_lines.or(config.max_lines),
             max_gap_lines: cli.max_gap_lines.or(config.max_gap_lines).unwrap_or(0),
-            similarity: cli.similarity.or(config.similarity),
+            similarity: cli.similarity.or(config.similarity).unwrap_or(1.0),
             mode,
             formats: if cli.format.is_empty() {
                 config.format.clone().unwrap_or_default()

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -647,6 +647,12 @@ fn similarity_reports_structurally_similar_functions_only_when_set() {
     assert_eq!(loose[0].0, "similar");
     let sim = loose[0].1.expect("similarity present");
     assert!(sim > 0.7 && sim < 0.9, "got {sim}");
+    let (exact_only, stderr) = scan(&["--similarity", "1"]);
+    assert!(
+        exact_only.is_empty(),
+        "1 is the default and means exact matches only"
+    );
+    assert!(!stderr.contains("Warning"), "1 is valid: {stderr}");
     let (none, stderr) = scan(&["--similarity", "1.5"]);
     assert!(none.is_empty());
     assert!(stderr.contains("Warning: --similarity"), "got: {stderr}");

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -581,6 +581,79 @@ fn max_gap_lines_merges_near_miss_clones_only_when_set() {
     let _ = std::fs::remove_dir_all(&out);
 }
 
+/// Function-level similarity (issue #999, stage 2): a pair with renames and
+/// two inserted statements is invisible to exact detection and to gap
+/// merging, and appears as one `similar` clone only with `--similarity`.
+#[test]
+fn similarity_reports_structurally_similar_functions_only_when_set() {
+    let Some(bin) = maybe_bin() else {
+        return;
+    };
+    let dir = std::env::temp_dir().join(format!("cpd-similarity-{}", std::process::id()));
+    let out = std::env::temp_dir().join(format!("cpd-similarity-report-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("invoice.js"),
+        "export function buildInvoice(order, customer, taxRate) {\n  const lines = [];\n  for (const item of order.items) {\n    const net = item.price * item.quantity;\n    lines.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = lines.reduce((sum, line) => sum + line.net, 0);\n  const tax = Math.round(subtotal * taxRate * 100) / 100;\n  return { number: nextInvoiceNumber(), customer: customer.id, lines, subtotal, tax, total: subtotal + tax };\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("credit-note.js"),
+        "export function buildCreditNote(refund, account, vatRate) {\n  const entries = [];\n  for (const item of refund.items) {\n    if (!item.refundable) continue;\n    const net = item.price * item.quantity;\n    entries.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = entries.reduce((sum, entry) => sum + entry.net, 0);\n  const vat = Math.round(subtotal * vatRate * 100) / 100;\n  logger.info('credit note', { account: account.id, subtotal });\n  return { number: nextCreditNoteNumber(), account: account.id, entries, subtotal, vat, total: subtotal + vat };\n}\n",
+    )
+    .unwrap();
+    let scan = |extra: &[&str]| {
+        let output = Command::new(&bin)
+            .args([
+                "--reporters",
+                "json,silent",
+                "--output",
+                out.to_str().unwrap(),
+            ])
+            .args(extra)
+            .arg(&dir)
+            .output()
+            .expect("failed to run cpd");
+        assert!(output.status.success(), "scan failed: {}", output.status);
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(out.join("jscpd-report.json")).unwrap())
+                .unwrap();
+        let dups = json["duplicates"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| {
+                (
+                    d["kind"].as_str().unwrap().to_string(),
+                    d["similarity"].as_f64(),
+                )
+            })
+            .collect::<Vec<_>>();
+        (dups, String::from_utf8_lossy(&output.stderr).to_string())
+    };
+
+    assert!(scan(&[]).0.is_empty(), "no exact clone");
+    assert!(
+        scan(&["--max-gap-lines", "3"]).0.is_empty(),
+        "no run long enough to merge"
+    );
+    assert!(
+        scan(&["--similarity", "0.85"]).0.is_empty(),
+        "below a strict threshold"
+    );
+    let (loose, _) = scan(&["--similarity", "0.7"]);
+    assert_eq!(loose.len(), 1, "{loose:?}");
+    assert_eq!(loose[0].0, "similar");
+    let sim = loose[0].1.expect("similarity present");
+    assert!(sim > 0.7 && sim < 0.9, "got {sim}");
+    let (none, stderr) = scan(&["--similarity", "1.5"]);
+    assert!(none.is_empty());
+    assert!(stderr.contains("Warning: --similarity"), "got: {stderr}");
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
 // --- snippet regression test (scan root != CWD) --------------------------------
 
 #[test]

--- a/rust/crates/cpd/tests/mcp_stdio.rs
+++ b/rust/crates/cpd/tests/mcp_stdio.rs
@@ -148,6 +148,9 @@ fn mcp_check_duplication_similarity() {
         format!(
             r#"{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"check_duplication","arguments":{{"code":{code},"format":"javascript","similarity":2}}}}}}"#
         ),
+        format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"check_duplication","arguments":{{"code":{code},"format":"javascript","similarity":1}}}}}}"#
+        ),
     ];
     {
         let stdin = child.stdin.as_mut().unwrap();
@@ -163,7 +166,7 @@ fn mcp_check_duplication_similarity() {
         .filter(|l| !l.trim().is_empty())
         .map(|l| serde_json::from_str(l).expect("valid JSON per line"))
         .collect();
-    assert_eq!(responses.len(), 4, "stdout: {stdout}");
+    assert_eq!(responses.len(), 5, "stdout: {stdout}");
     let payload = |i: usize| -> serde_json::Value {
         serde_json::from_str(
             responses[i]["result"]["content"][0]["text"]
@@ -183,6 +186,11 @@ fn mcp_check_duplication_similarity() {
     assert!(sim > 0.7 && sim < 0.9, "got {sim}");
     let strict = payload(2);
     assert_eq!(strict["similarCount"], 0, "{strict}");
+    let exact_only = payload(4);
+    assert!(
+        exact_only.get("similarCount").is_none(),
+        "1 means exact matches only, no similarity section: {exact_only}"
+    );
     assert!(
         responses[3]["error"]["message"]
             .as_str()

--- a/rust/crates/cpd/tests/mcp_stdio.rs
+++ b/rust/crates/cpd/tests/mcp_stdio.rs
@@ -113,6 +113,87 @@ fn mcp_stdio_session_end_to_end() {
     assert!(stderr.contains("scanned"), "startup log goes to stderr");
 }
 
+/// `check_duplication` with a `similarity` argument returns structurally
+/// similar project functions (issue #999, stage 2) and rejects ratios
+/// outside (0, 1].
+#[test]
+fn mcp_check_duplication_similarity() {
+    let dir = std::env::temp_dir().join(format!("cpd-mcp-similarity-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("invoice.js"),
+        "export function buildInvoice(order, customer, taxRate) {\n  const lines = [];\n  for (const item of order.items) {\n    const net = item.price * item.quantity;\n    lines.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = lines.reduce((sum, line) => sum + line.net, 0);\n  const tax = Math.round(subtotal * taxRate * 100) / 100;\n  return { number: nextInvoiceNumber(), customer: customer.id, lines, subtotal, tax, total: subtotal + tax };\n}\n",
+    )
+    .unwrap();
+    let snippet = "export function buildCreditNote(refund, account, vatRate) {\n  const entries = [];\n  for (const item of refund.items) {\n    if (!item.refundable) continue;\n    const net = item.price * item.quantity;\n    entries.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = entries.reduce((sum, entry) => sum + entry.net, 0);\n  const vat = Math.round(subtotal * vatRate * 100) / 100;\n  logger.info('credit note', { account: account.id, subtotal });\n  return { number: nextCreditNoteNumber(), account: account.id, entries, subtotal, vat, total: subtotal + vat };\n}\n";
+    let mut child = Command::new(cpd_bin())
+        .args(["--mcp"])
+        .arg(&dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cpd --mcp");
+    let code = serde_json::to_string(snippet).unwrap();
+    let requests = [
+        r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}"#.to_string(),
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.to_string(),
+        format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"check_duplication","arguments":{{"code":{code},"format":"javascript","similarity":0.7}}}}}}"#
+        ),
+        format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"check_duplication","arguments":{{"code":{code},"format":"javascript","similarity":0.95}}}}}}"#
+        ),
+        format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"check_duplication","arguments":{{"code":{code},"format":"javascript","similarity":2}}}}}}"#
+        ),
+    ];
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        for req in &requests {
+            writeln!(stdin, "{req}").unwrap();
+        }
+    }
+    let output = child.wait_with_output().expect("cpd --mcp must exit");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let responses: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("valid JSON per line"))
+        .collect();
+    assert_eq!(responses.len(), 4, "stdout: {stdout}");
+    let payload = |i: usize| -> serde_json::Value {
+        serde_json::from_str(
+            responses[i]["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap()
+    };
+    let loose = payload(1);
+    assert_eq!(loose["count"], 0, "no exact match: {loose}");
+    assert_eq!(loose["similarCount"], 1, "{loose}");
+    let hit = &loose["similar"][0];
+    assert!(hit["file"].as_str().unwrap().ends_with("invoice.js"));
+    assert_eq!(hit["name"], "buildInvoice");
+    assert_eq!(hit["snippetName"], "buildCreditNote");
+    let sim = hit["similarity"].as_f64().unwrap();
+    assert!(sim > 0.7 && sim < 0.9, "got {sim}");
+    let strict = payload(2);
+    assert_eq!(strict["similarCount"], 0, "{strict}");
+    assert!(
+        responses[3]["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("similarity"),
+        "out-of-range ratio is a parameter error: {}",
+        responses[3]
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn mcp_parse_error_is_reported_not_fatal() {
     let dir = fixture_dir();


### PR DESCRIPTION
Stage 2 of #999. Builds on #1020 (which builds on #1019); their commits are included, so merge those first and this diff shrinks to its own commit.

## Behaviour

`--similarity RATIO` (config `similarity`, Action input `similarity`), **default `1`, which means exact matches only**: the function extractor and the index only run for a value strictly between 0 and 1, so a `jscpd` invocation without the option behaves exactly as before. Every function declaration, function expression, method and arrow function in a JavaScript/TypeScript/JSX/TSX file is summarized by the bag of 4-grams over the pre-order sequence of its AST node *types* (oxc visitor). Bags are indexed with MinHash (64 hashes, 16 bands × 4 rows), and candidate pairs are scored with the weighted Jaccard index; pairs at or above `RATIO` become `similar` clones with a `similarity` value and fragments spanning the whole functions.

- names and literal values are not part of the summary: a renamed copy scores 1.0, one inserted line ≈ 0.9, two inserted statements plus renames ≈ 0.75
- functions must clear `--min-tokens` / `--min-lines`; nested functions are never paired with their parent; a pair already covered (≥ 90 % of both functions' lines) by an exact, renamed or merged clone is not reported again
- values outside `(0, 1]` print a warning and fall back to `1`; formats without an extractor are a silent no-op (documented)
- default runs never extract functions or build the index

```
$ jscpd fixtures/type3-demo/similar-functions --similarity 0.7
Clone found (javascript, similar ~0.75)
 - credit-note.js [1:8 - 19:2] (19 lines, 126 tokens)
   invoice.js [1:8 - 17:2]
Found 1 clones.
```

## Telling the two near-miss mechanisms apart

Gap-merged and AST-similar clones score on different scales (matched tokens over a span vs. structural Jaccard of whole functions), so every `similar` clone now records its method. Console: `Clone found (javascript, similar (gap) ~0.91)` / `similar (ast) ~0.75`; `ai`: `[~0.91 gap]` / `[~0.75 ast]`; JSON: `"method": "gap" | "ast"`; SARIF: `similarity_method` property. Exact and renamed clones are unchanged.

## Reporting across all reporters (the #999 "Reporting" list, completed)

| Reporter | Renamed / similar clone |
|---|---|
| `console`, `console-full` | `Clone found (javascript, renamed)` / `Clone found (javascript, similar (gap) ~0.91)` |
| `ai` | `… (renamed)` / `… [~0.91 gap]` |
| `json` | `"kind"`, `"similarity"`, `"method"`; statistics gain `renamedClones` / `similarClones` |
| `xml` | `kind`, `similarity`, `method` attributes on `<duplication>` (non-exact only, default XML unchanged) |
| `html` | label badge next to the locations |
| `sarif` | `jscpd/similar-code` / `jscpd/near-miss-code` with `similarity` and `similarity_method` properties |
| `codeclimate` | matching `check_name` |
| `xcode` | `[renamed]` / `[similar (gap) ~0.91]` suffix |
| `openmetrics` | `jscpd_renamed_clones`, `jscpd_similar_clones` gauges |
| MCP tools | `kind`, `similarity`, `method` on every clone and snippet match; `check_duplication` takes `similarity` |

`csv`, `markdown`, `badge`, `threshold` aggregate counts only and are unchanged. Every addition is additive; a default run's output is identical to before except for the two always-present OpenMetrics gauges (at `0`) and the `kind: "exact"` JSON field already introduced in #1019.

## Extending to other languages

Extraction is a plug-in: `cpd_tokenizer::functions::FunctionExtractor` (a grammar id, the formats it serves, and an `extract` that opens a `RawFunction` at every function-like node and appends each visited node's type id to the open functions). `OxcExtractor` is the only entry in the static `EXTRACTORS` registry today. Every signature carries its grammar id and the scorer refuses pairs across grammars, so a tree-sitter-backed extractor for Python, Java, Go, … is a self-contained addition: implement the trait, add it to the registry, done. The scoring in `cpd_core::similarity`, the CLI, the MCP tool and the reporters need no change; `supports_functions` / `supported_function_formats` read the registry.

## MCP

`check_duplication(code, format, limit?, similarity?)`: with `similarity`, the response adds `similarCount` and `similar[]` (file, name, line ranges, snippet function, similarity) for each function of the snippet, best first. The project function index is built lazily on the first such call and dropped on rescan; if the scan itself ran with `--similarity`, the signatures from the scan are reused. Ratios outside `(0, 1]` are a parameter error. This is the "find snippets similar to this one" ask from #727.

## Fixtures

`fixtures/type3-demo/similar-functions/`: `invoice.js` vs `credit-note.js`, every name changed plus two inserted statements. Default, `--max-gap-lines 3` and `--similarity 0.85` report nothing; `--similarity 0.7` reports one similar clone at 0.75. The README also shows `--similarity 0.9` on `type2-demo/identifiers` scoring 1.00, and the combined `--max-gap-lines 2 --similarity 0.7` run on the whole directory (3 clones: merged clones cover the functions, so only this pair adds one).

## Tests

- tokenizer: extraction of declarations, arrows, methods and property functions with inferred names; nested functions; unsupported/broken sources; renamed copies share a node sequence
- core: shingles, bag Jaccard, MinHash, token-range mapping, edited-copy detection vs unrelated structure, nested/min-size/covered skips, query ordering
- CLI: flag, config key, default `1`; integration also checks that `--similarity 1` reports nothing and prints no warning
- integration: default / gap merge / strict threshold empty, 0.7 reports one similar clone in (0.7, 0.9), 1.5 warns
- MCP stdio: `similarity` 0.7 returns `buildInvoice` for `buildCreditNote`, 0.95 returns none, 2 is rejected

Also fixes the `--debug` config output, which was missing `max_gap_lines` (found in the #1020 review).

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` clean.

## Not in this PR

The #1020 review findings on the gap-merge pass (chain search, token bound / similarity floor, N+2 gap measurement, ordering, statistics) are still open and belong there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1021)
<!-- Reviewable:end -->

<!-- brian settings start --><!--{}--><!-- brian settings end -->



