### PR TITLE
fix(tokenizer): keep oxc tokens for JS/TS files with recoverable parse errors

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -350,6 +350,8 @@ Scoring needs a syntax tree, and today only JavaScript/TypeScript have one (oxc)
 
 ## Format Support
 
+JavaScript, TypeScript, JSX and TSX are tokenized by the [oxc](https://oxc.rs) lexer; a parse diagnostic (a redeclaration, a recoverable syntax error) does not change the token stream, so such files still match files that parse cleanly. Only a source the parser gives up on entirely falls back to a word-split tokenizer, and that file then matches only other fallback-tokenized files. See [`fixtures/parse-errors-demo`](../fixtures/parse-errors-demo/README.md).
+
 jscpd supports **224 formats**. Use `cpd --list` to see the full list, or see [FORMATS.md](../FORMATS.md) for names, file extensions and descriptions.
 
 ### Cross-Format Detection

--- a/fixtures/parse-errors-demo/README.md
+++ b/fixtures/parse-errors-demo/README.md
@@ -1,0 +1,39 @@
+# JavaScript files with parse errors
+
+`valid.js` and `redeclared.js` share the same function. `redeclared.js` also
+declares `saveProfile` a second time, which the oxc parser reports as a
+redeclaration error. Before the fix for #1023 a JavaScript or TypeScript file
+with any parse diagnostic was handed to the word-split fallback tokenizer,
+so its tokens never matched an oxc-tokenized file: only the self-clone inside
+`redeclared.js` was reported and both cross-file clones vanished.
+
+Tokens come from the lexer, not the parser, so a recoverable diagnostic now
+keeps the oxc token stream. Only a parser that gives up entirely (or yields
+no tokens) still falls back. Commands run from the repository root at
+default thresholds.
+
+```bash
+jscpd fixtures/parse-errors-demo
+# Clone found (javascript)
+#  - redeclared.js [1:1 - 6:88] (6 lines, 84 tokens)
+#    redeclared.js [16:1 - 21:88]
+# Clone found (javascript)
+#  - redeclared.js [1:1 - 6:88] (6 lines, 84 tokens)
+#    valid.js [1:1 - 6:88]
+# Clone found (javascript)
+#  - redeclared.js [7:72 - 12:2] (6 lines, 76 tokens)
+#    valid.js [6:86 - 11:2]
+# Found 3 clones.
+
+jscpd fixtures/parse-errors-demo --max-gap-lines 1
+# Clone found (javascript)
+#  - redeclared.js [1:1 - 6:88] (6 lines, 84 tokens)
+#    redeclared.js [16:1 - 21:88]
+# Clone found (javascript, similar (gap) ~0.92)
+#  - redeclared.js [1:1 - 12:2] (12 lines, 158 tokens)
+#    valid.js [1:1 - 11:2]
+# Found 2 clones.
+```
+
+Before the fix the first command printed only the self-clone (`Found 1
+clones.`, with 86 tokens from the fallback tokenizer instead of 84).

--- a/fixtures/parse-errors-demo/redeclared.js
+++ b/fixtures/parse-errors-demo/redeclared.js
@@ -1,0 +1,23 @@
+export async function saveProfile(profile, store, clock) {
+  const record = toRecord(profile);
+  record.updatedAt = clock.now();
+  record.version = (record.version || 0) + 1;
+  record.normalizedEmail = profile.email.trim().toLowerCase();
+  record.displayName = [profile.firstName, profile.lastName].filter(Boolean).join(" ");
+  if (!record.id) throw new Error("cannot save a profile without an id");
+  await store.put("profiles", record.id, record);
+  await audit("save-profile", record.id, record.version, clock.now());
+  await notify(profile.email, "profile-updated", { version: record.version });
+  return { id: record.id, version: record.version, updatedAt: record.updatedAt };
+}
+
+// A second declaration of the same export: a parse error for oxc, but the
+// tokens are the same, so the file must still be compared with valid.js.
+export async function saveProfile(profile, store, clock) {
+  const record = toRecord(profile);
+  record.updatedAt = clock.now();
+  record.version = (record.version || 0) + 1;
+  record.normalizedEmail = profile.email.trim().toLowerCase();
+  record.displayName = [profile.firstName, profile.lastName].filter(Boolean).join(" ");
+  return null;
+}

--- a/fixtures/parse-errors-demo/valid.js
+++ b/fixtures/parse-errors-demo/valid.js
@@ -1,0 +1,11 @@
+export async function saveProfile(profile, store, clock) {
+  const record = toRecord(profile);
+  record.updatedAt = clock.now();
+  record.version = (record.version || 0) + 1;
+  record.normalizedEmail = profile.email.trim().toLowerCase();
+  record.displayName = [profile.firstName, profile.lastName].filter(Boolean).join(" ");
+  await store.put("profiles", record.id, record);
+  await audit("save-profile", record.id, record.version, clock.now());
+  await notify(profile.email, "profile-updated", { version: record.version });
+  return { id: record.id, version: record.version, updatedAt: record.updatedAt };
+}

--- a/rust/crates/cpd-tokenizer/src/functions.rs
+++ b/rust/crates/cpd-tokenizer/src/functions.rs
@@ -105,7 +105,9 @@ fn extract_with_oxc(source: &str, format: &str) -> Vec<RawFunction> {
     let allocator = Allocator::new();
     let source_type = crate::javascript::source_type_for_format(format);
     let parsed = Parser::new(&allocator, source, source_type).parse();
-    if !parsed.diagnostics.is_empty() {
+    // Recoverable diagnostics leave a usable (possibly partial) AST; only a
+    // parser that gave up yields nothing (issue #1023).
+    if parsed.panicked {
         return Vec::new();
     }
     let line_index = LineIndex::new(source.as_bytes());
@@ -258,10 +260,21 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_or_broken_sources_yield_nothing() {
+    fn unsupported_or_empty_sources_yield_nothing() {
         assert!(extract_functions("def f():\n  pass\n", "python").is_empty());
-        assert!(extract_functions("function (", "javascript").is_empty());
         assert!(extract_functions("", "javascript").is_empty());
+    }
+
+    #[test]
+    fn redeclared_functions_are_still_extracted() {
+        let src = "function f(a) { return a + 1; }\nfunction f(b) { return b + 1; }\n";
+        let fns = extract_functions(src, "javascript");
+        assert_eq!(
+            fns.len(),
+            2,
+            "a redeclaration diagnostic must not drop the file"
+        );
+        assert_eq!(fns[0].kinds, fns[1].kinds);
     }
 
     #[test]

--- a/rust/crates/cpd-tokenizer/src/javascript.rs
+++ b/rust/crates/cpd-tokenizer/src/javascript.rs
@@ -179,8 +179,10 @@ pub fn tokenize_js(source: &str, format: &str) -> Vec<Token> {
 /// the token stream (cross-format detection). Token locations still reference
 /// the original source. Never panics.
 ///
-/// Sources that fail to parse fall back to the word-split tokenizer WITHOUT
-/// stripping — they simply won't cross-match JavaScript files.
+/// Sources the parser gives up on fall back to the word-split tokenizer
+/// WITHOUT stripping — they simply won't cross-match JavaScript files.
+/// Recoverable errors keep the oxc token stream (and best-effort stripping
+/// from the partial AST).
 pub fn tokenize_js_stripped(source: &str, format: &str) -> Vec<Token> {
     tokenize_js_impl(source, format, true)
 }
@@ -213,7 +215,13 @@ fn parse_with_oxc(source: &str, format: &str, strip_types: bool) -> Option<Vec<T
         .with_config(TokensParserConfig)
         .parse();
 
-    if !parser_return.diagnostics.is_empty() {
+    // Parse diagnostics (redeclarations, recoverable syntax errors) do not
+    // touch the token stream: tokens come from the lexer. Only a parser that
+    // gave up, or one that produced no tokens, sends the file to the
+    // word-split fallback. Anything else would tokenize a file with one
+    // error differently from every other file, so it could never match
+    // them (issue #1023).
+    if parser_return.panicked || parser_return.tokens.is_empty() {
         return None;
     }
 
@@ -270,6 +278,39 @@ fn parse_with_oxc(source: &str, format: &str, strip_types: bool) -> Option<Vec<T
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #1023: a redeclaration is a parse diagnostic, not a lexing
+    /// failure, so the file must keep the oxc token stream and stay
+    /// comparable with files that parse cleanly.
+    #[test]
+    fn parse_diagnostics_keep_the_oxc_token_stream() {
+        let clean = "export function save(row, db) {\n  db.put(row.id, row);\n  return row;\n}\n";
+        let twice = format!("{clean}\n{clean}");
+        let a = tokenize_js(clean, "javascript");
+        let b = tokenize_js(&twice, "javascript");
+        assert!(a.len() > 10);
+        assert_eq!(b.len(), a.len() * 2, "both copies lexed by oxc");
+        assert_eq!(
+            a.iter().map(|t| (&t.kind, &t.value)).collect::<Vec<_>>(),
+            b[..a.len()]
+                .iter()
+                .map(|t| (&t.kind, &t.value))
+                .collect::<Vec<_>>(),
+            "the first copy must tokenize exactly like the clean file"
+        );
+        assert_eq!(
+            b[0].kind,
+            TokenKind::Keyword,
+            "`export` classified by oxc, not word-split"
+        );
+    }
+
+    #[test]
+    fn empty_and_unlexable_sources_still_fall_back_safely() {
+        assert!(tokenize_js("", "javascript").is_empty());
+        // A stray token soup parses with errors but lexes fine: still tokens.
+        assert!(!tokenize_js("function (", "javascript").is_empty());
+    }
 
     #[test]
     fn valid_js_produces_tokens() {

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -660,6 +660,73 @@ fn similarity_reports_structurally_similar_functions_only_when_set() {
     let _ = std::fs::remove_dir_all(&out);
 }
 
+/// Issue #1023: a JS file with a redeclaration error used to fall back to the
+/// word-split tokenizer and could no longer match any oxc-tokenized file, so
+/// every a↔b clone vanished and only b's self-clone remained.
+#[test]
+fn js_file_with_parse_diagnostics_still_matches_other_files() {
+    let Some(bin) = maybe_bin() else {
+        return;
+    };
+    let dir = std::env::temp_dir().join(format!("cpd-1023-{}", std::process::id()));
+    let out = std::env::temp_dir().join(format!("cpd-1023-report-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let p = "export function saveUser(user, db) {\n  const row = toRow(user);\n  row.updatedAt = Date.now();\n  row.version = (row.version || 0) + 1;\n";
+    let q = "  db.put('users', row.id, row);\n  audit('save', row.id, row.version);\n  notify(user.email, 'profile-updated');\n  return row;\n}\n";
+    std::fs::write(dir.join("a.js"), format!("{p}{q}")).unwrap();
+    // b: P, an inserted line, Q, then a second copy of P (a redeclaration).
+    std::fs::write(
+        dir.join("b.js"),
+        format!("{p}  if (!row.id) throw new Error('missing id');\n{q}\n{p}  return null;\n}}\n"),
+    )
+    .unwrap();
+    let output = Command::new(&bin)
+        .args([
+            "--min-tokens",
+            "15",
+            "--min-lines",
+            "2",
+            "--reporters",
+            "json,silent",
+        ])
+        .args(["--output", out.to_str().unwrap()])
+        .arg(&dir)
+        .output()
+        .expect("failed to run cpd");
+    assert!(output.status.success());
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("jscpd-report.json")).unwrap())
+            .unwrap();
+    let pairs: Vec<(String, String)> = json["duplicates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| {
+            let name = |v: &serde_json::Value| {
+                v["name"]
+                    .as_str()
+                    .unwrap()
+                    .rsplit('/')
+                    .next()
+                    .unwrap()
+                    .to_string()
+            };
+            (name(&d["firstFile"]), name(&d["secondFile"]))
+        })
+        .collect();
+    let cross = pairs.iter().filter(|(x, y)| x != y).count();
+    assert!(
+        cross >= 2,
+        "a↔b clones for both halves must survive b's redeclaration: {pairs:?}"
+    );
+    // b's own repeated half now pairs with a's copy instead (the primary pass
+    // keeps the first stored occurrence); grouping all copies is #221.
+    assert!(pairs.len() >= 3, "{pairs:?}");
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
 // --- snippet regression test (scan root != CWD) --------------------------------
 
 #[test]


### PR DESCRIPTION
Closes #1023.

## Root cause

Not the detector. `parse_with_oxc` returned `None` on *any* parser diagnostic, so the file went to the word-split fallback tokenizer. The reported scenario (a second copy of a function in `b.js`) is a redeclaration error for oxc; `b.js` was then tokenized differently from `a.js` and could never match it. Its self-clone survived because both copies lived in the same fallback-tokenized file. Any JS/TS file with a recoverable syntax error had the same blind spot.

## Fix

Tokens come from the lexer, not the parser. `parse_with_oxc` now falls back only when the parser `panicked` or produced no tokens; recoverable diagnostics keep the oxc token stream (and best-effort type stripping from the partial AST in cross-format mode). `extract_functions` for `--similarity` follows the same rule.

```
$ jscpd fixtures/parse-errors-demo        # before: Found 1 clones. (self-clone only)
Clone found (javascript)  redeclared.js [1:1 - 6:88] ↔ redeclared.js [16:1 - 21:88]
Clone found (javascript)  redeclared.js [1:1 - 6:88] ↔ valid.js [1:1 - 6:88]
Clone found (javascript)  redeclared.js [7:72 - 12:2] ↔ valid.js [6:86 - 11:2]
Found 3 clones.
```

## Tests and fixtures

- tokenizer: a redeclared file tokenizes its first copy exactly like the clean file, with oxc kinds (`export` is a `Keyword`, not a word); empty input still yields nothing
- functions: redeclared functions are both extracted with identical node sequences
- integration: the #1023 scenario reports both a↔b halves
- `fixtures/parse-errors-demo/` with a README showing before/after output; the smoke corpus gains 3 clones
- docs: a note under Format Support on when the fallback tokenizer applies

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` clean.

## Behaviour change to be aware of

Files with recoverable parse errors that previously matched only each other (via the fallback) now match oxc-tokenized files and no longer match fallback-tokenized ones. Clone counts on codebases with such files will change; that is the correction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1024)
<!-- Reviewable:end -->

<!-- brian settings start --><!--{}--><!-- brian settings end -->