### PR TITLE
fix(tokenizer): markdown has no comment style

### DIFF
--- a/rust/crates/cpd-finder/tests/fixtures/markdown_comment_style/first.md
+++ b/rust/crates/cpd-finder/tests/fixtures/markdown_comment_style/first.md
@@ -1,0 +1,6 @@
+# Contributing guide
+
+The quick brown fox jumps over the lazy dog while the sun sets slowly.
+Institutional memory outlives any single meeting when the work happens in the open.
+Asynchronous updates let contributors participate across every time zone without friction.
+Write down decisions where future readers can find them without asking anyone.

--- a/rust/crates/cpd-finder/tests/fixtures/markdown_comment_style/second.md
+++ b/rust/crates/cpd-finder/tests/fixtures/markdown_comment_style/second.md
@@ -1,0 +1,8 @@
+# Maintainer notes
+
+Leave the dated notes out with `--ignore docs/**` on the command line.
+
+The quick brown fox jumps over the lazy dog while the sun sets slowly.
+Institutional memory outlives any single meeting when the work happens in the open.
+Asynchronous updates let contributors participate across every time zone without friction.
+Write down decisions where future readers can find them without asking anyone.

--- a/rust/crates/cpd-finder/tests/markdown_comment_style_integration.rs
+++ b/rust/crates/cpd-finder/tests/markdown_comment_style_integration.rs
@@ -1,0 +1,30 @@
+// Regression test: Markdown prose had no arm in `comment_style`, so it fell to
+// the C style. A `/*` that prose can hold — inside a glob such as `docs/**`, or
+// in a code span — then opened a block comment that never closed, and every
+// later clone in that file went unreported.
+
+use cpd_finder::orchestrate::{RunConfig, run};
+use cpd_tokenizer::tokenizer::Mode;
+use std::path::PathBuf;
+
+fn fixtures(dir: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{dir}"))
+}
+
+#[test]
+fn prose_after_a_glob_is_still_matched() {
+    let result = run(&RunConfig {
+        paths: vec![fixtures("markdown_comment_style")],
+        min_tokens: 20,
+        min_lines: 2,
+        mode: Mode::Mild,
+        no_gitignore: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    assert!(
+        result.clones.iter().any(|c| c.format == "markdown"),
+        "the shared paragraph must be reported, even though `docs/**` sits above it"
+    );
+}

--- a/rust/crates/cpd-tokenizer/src/generic.rs
+++ b/rust/crates/cpd-tokenizer/src/generic.rs
@@ -17,8 +17,7 @@ enum CommentStyle {
     Semicolon,
     /// Single-line `'`
     VisualBasic,
-    /// No comments (fallback for unrecognised formats)
-    #[allow(dead_code)]
+    /// No comments
     None,
 }
 
@@ -45,6 +44,13 @@ fn comment_style(format: &str) -> CommentStyle {
         }
 
         "vb" | "vbs" | "basic" | "vbnet" | "visual-basic" => CommentStyle::VisualBasic,
+
+        // Markdown has no comment of its own. CommonMark defines only the HTML
+        // comment, as HTML block type 2. Without this arm Markdown prose falls
+        // to the C style below, and then a `/*` that prose can hold — inside a
+        // glob such as `docs/**`, or in a code span — opens a block comment
+        // that never closes. Every later clone in that file goes unreported.
+        "markdown" | "md" => CommentStyle::None,
 
         _ => CommentStyle::CStyle,
     }
@@ -454,6 +460,30 @@ mod tests {
         let tokens = tokenize_generic("/* block */\nint x = 1;\n", "c");
         let has_comment = tokens.iter().any(|t| t.kind == TokenKind::Comment);
         assert!(has_comment);
+    }
+
+    #[test]
+    fn markdown_has_no_block_comment() {
+        // A glob in prose holds `/*`. Markdown has no block comment, so the
+        // text after it must stay ordinary code tokens.
+        let tokens = tokenize_generic("Ignore `docs/**` here.\nThe next line.\n", "markdown");
+        let has_comment = tokens.iter().any(|t| t.kind == TokenKind::Comment);
+        assert!(
+            !has_comment,
+            "Markdown has no block comment, so `/*` must not open one"
+        );
+        let last = tokens.last().expect("at least one token");
+        assert_eq!(
+            last.start.line, 2,
+            "text after `/*` must still produce tokens"
+        );
+    }
+
+    #[test]
+    fn markdown_has_no_line_comment() {
+        let tokens = tokenize_generic("A URL like https://example.com/x\n", "markdown");
+        let has_comment = tokens.iter().any(|t| t.kind == TokenKind::Comment);
+        assert!(!has_comment, "`//` must not open a comment in Markdown");
     }
 
     #[test]


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Bug fix (tokenizer), with unit and integration tests.

* **What is the current behavior?**

`comment_style()` in `rust/crates/cpd-tokenizer/src/generic.rs` has no arm for `"markdown"` / `"md"`, so Markdown falls through to `_ => CommentStyle::CStyle`.

Markdown prose routinely contains the C comment openers: `/*` (a glob such as `docs/**`, a code span, or plain prose) and `//` (any URL). Under the C-style fallback a stray `/*` opens a block comment that never closes for the rest of the file, and `//` opens a line comment. Everything after the opener is dropped from tokenization, with no signal — the file is still reported as analyzed and its token total still looks plausible.

Two files sharing a paragraph therefore go undetected as a clone if a `/*` or `//` appears anywhere earlier in either file:

```
$ jscpd . --min-tokens 20 --min-lines 2
No duplicates found.
markdown | 2 files | 14 lines | 416 tokens | 0 clones

$ # same two files, minus one line holding `docs/**`
Clone found (markdown)
 - first.md:markdown [3:1 - 6:79] (4 lines, 54 tokens)
   second.md:markdown [4:1 - 7:79]
```

This compounds with the prose-tokenization fix from #883 (already merged), which routes the Markdown prose body through `tokenize_generic(.., "markdown")`, so prose-only `.md` files are the most exposed.

* **What is the new behavior (if this is a feature change)?**

Markdown gets `CommentStyle::None`:

- Adds a `"markdown" | "md" => CommentStyle::None` arm to `comment_style()`.
- Drops the now-unused `#[allow(dead_code)]` on `CommentStyle::None`.
- Adds two unit tests in `cpd-tokenizer`: `markdown_has_no_block_comment`, `markdown_has_no_line_comment`.
- Adds a `cpd-finder` integration test `prose_after_a_glob_is_still_matched`, with fixtures under `rust/crates/cpd-finder/tests/fixtures/markdown_comment_style/`.

CommonMark defines no comment syntax of its own. Its only comment is the HTML comment (HTML block type 2), which is neither `/* */` nor `//`, so Markdown should not inherit C's comment style.

* **Other information**:

Verification was run on this branch, rebased onto this same `master`, in the cloud environment where the branch was prepared (rustc 1.97.1) — all green:

- `cargo fmt --all --check`
- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

The rebase onto current `master` was redone locally and is clean (the change touches `generic.rs` and adds new test files only), but the machine that pushed it has no Rust toolchain, so the four commands were not re-run there — CI covers that.

Closes #1025

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1026)
<!-- Reviewable:end -->
