### PR TITLE
fix(detect): grow an open clone only while its own anchor continues

### DIFF
--- a/fixtures/nway-demo/README.md
+++ b/fixtures/nway-demo/README.md
@@ -1,0 +1,46 @@
+# N-way copies
+
+The same block in three or more places is reported as pairs anchored on the
+copy that was scanned first: with the block in `a`, `b` and `c` the report
+holds `a ↔ b` and `a ↔ c`. This directory holds the shapes where that pairing
+used to go wrong. Commands run from the repository root at default
+thresholds; the `Found N clones.` line is the console reporter's.
+
+| Directory | Shape | Expected |
+|-----------|-------|----------|
+| `lost-pair/` | a copy, two renamed copies, a copy followed by more code | 3 clones |
+
+## `lost-pair/` — a third file must not steal the anchor
+
+`duration.js` holds `parseDuration`. `timeouts.js` holds the same body twice
+under other names, so its windows around the second `export function` are
+stored without matching anything. `uptime.js` holds `parseDuration` followed
+by another function. While `uptime.js` is scanned, the clone anchored on
+`duration.js` covers the body, and the next window (`… } export function`)
+matches the window `timeouts.js` stored earlier. Extending on that stored
+window would stretch the anchored fragment past the end of `duration.js`, and
+the clone was silently dropped ([#1033](https://github.com/kucherenko/jscpd/issues/1033)).
+A clone now grows only while its own anchor keeps matching, so all three
+pairs are reported and each covers identical tokens on both sides.
+
+```bash
+jscpd fixtures/nway-demo/lost-pair
+# Clone found (javascript)
+#  - duration.js [1:30 - 9:2] (9 lines, 107 tokens)
+#    timeouts.js [1:29 - 9:2]
+# Clone found (javascript)
+#  - duration.js [1:30 - 9:2] (9 lines, 107 tokens)
+#    timeouts.js [11:30 - 19:2]
+# Clone found (javascript)
+#  - duration.js [1:1 - 9:2] (9 lines, 110 tokens)
+#    uptime.js [1:1 - 9:2]
+# Found 3 clones.
+```
+
+The two `timeouts.js` pairs start after the function name because the names
+differ; with `--ignore-identifiers` they are reported from line 1 as
+`renamed`, and a fourth `renamed` pair appears for the `… } export function`
+tail shared by `timeouts.js` and `uptime.js` (`Found 4 clones.`). Scan order
+decides the anchor, not whether a pair is found: with the files renamed so
+that `uptime.js` is scanned first, the report still holds three pairs, now
+anchored on `uptime.js`.

--- a/fixtures/nway-demo/lost-pair/duration.js
+++ b/fixtures/nway-demo/lost-pair/duration.js
@@ -1,0 +1,9 @@
+export function parseDuration(text) {
+  const match = /^(\d+)\s*(ms|s|m|h|d)$/.exec(String(text).trim());
+  if (!match) {
+    throw new RangeError('unsupported duration: ' + text);
+  }
+  const amount = Number(match[1]);
+  const unit = { ms: 1, s: 1000, m: 60000, h: 3600000, d: 86400000 }[match[2]];
+  return { amount, unit: match[2], millis: amount * unit, text: amount + match[2] };
+}

--- a/fixtures/nway-demo/lost-pair/timeouts.js
+++ b/fixtures/nway-demo/lost-pair/timeouts.js
@@ -1,0 +1,19 @@
+export function parseTimeout(text) {
+  const match = /^(\d+)\s*(ms|s|m|h|d)$/.exec(String(text).trim());
+  if (!match) {
+    throw new RangeError('unsupported duration: ' + text);
+  }
+  const amount = Number(match[1]);
+  const unit = { ms: 1, s: 1000, m: 60000, h: 3600000, d: 86400000 }[match[2]];
+  return { amount, unit: match[2], millis: amount * unit, text: amount + match[2] };
+}
+
+export function parseInterval(text) {
+  const match = /^(\d+)\s*(ms|s|m|h|d)$/.exec(String(text).trim());
+  if (!match) {
+    throw new RangeError('unsupported duration: ' + text);
+  }
+  const amount = Number(match[1]);
+  const unit = { ms: 1, s: 1000, m: 60000, h: 3600000, d: 86400000 }[match[2]];
+  return { amount, unit: match[2], millis: amount * unit, text: amount + match[2] };
+}

--- a/fixtures/nway-demo/lost-pair/uptime.js
+++ b/fixtures/nway-demo/lost-pair/uptime.js
@@ -1,0 +1,14 @@
+export function parseDuration(text) {
+  const match = /^(\d+)\s*(ms|s|m|h|d)$/.exec(String(text).trim());
+  if (!match) {
+    throw new RangeError('unsupported duration: ' + text);
+  }
+  const amount = Number(match[1]);
+  const unit = { ms: 1, s: 1000, m: 60000, h: 3600000, d: 86400000 }[match[2]];
+  return { amount, unit: match[2], millis: amount * unit, text: amount + match[2] };
+}
+
+export function formatDuration(parsed) {
+  const seconds = Math.round(parsed.millis / 1000);
+  return seconds >= 60 ? Math.floor(seconds / 60) + 'm ' + (seconds % 60) + 's' : seconds + 's';
+}

--- a/rust/crates/cpd-core/src/detect.rs
+++ b/rust/crates/cpd-core/src/detect.rs
@@ -295,45 +295,70 @@ fn detect_in_group(
                 token_start,
             };
 
-            match store.get(&window_hash).copied() {
-                Some(stored) if windows_match(stored, current, prepared, min_tokens) => {
-                    if open_clone.is_none() {
+            let stored = store
+                .get(&window_hash)
+                .copied()
+                .filter(|stored| windows_match(*stored, current, prepared, min_tokens));
+
+            // An open clone grows only while its own anchor keeps matching
+            // (issue #1033). The store may hold a *different* occurrence for
+            // this window — one stored by a third file whose text continues
+            // the same way — and extending on that would stretch the anchored
+            // fragment past what the anchor file contains: the clone is then
+            // dropped by `flush_clone` when the anchor runs out of tokens, or
+            // reported longer than the real common region when it does not.
+            let anchor_continues = open_clone.as_ref().is_some_and(|oc| {
+                let anchor = Occurrence {
+                    source_id: oc.stored_occurrence.source_id,
+                    token_start: oc.stored_occurrence.token_start
+                        + (token_start - oc.current_start),
+                };
+                windows_match(anchor, current, prepared, min_tokens)
+            });
+
+            if anchor_continues {
+                if let Some(oc) = open_clone.as_mut() {
+                    oc.match_len += 1;
+                }
+            } else {
+                // The anchor stopped (or nothing was open): flush, then start a
+                // new clone on whatever the store matched, if anything.
+                flush_clone(
+                    open_clone.take(),
+                    file_idx,
+                    prepared,
+                    min_lines,
+                    filters,
+                    &mut clones,
+                );
+                match stored {
+                    Some(stored) => {
                         open_clone = Some(OpenClone {
                             stored_occurrence: stored,
                             current_start: token_start,
                             match_len: min_tokens,
                         });
-                    } else if let Some(ref mut oc) = open_clone {
-                        // Enlarge: the next window also matches — extend by one token.
-                        oc.match_len += 1;
                     }
-                    remember_repeated_window(
-                        &mut repeated_windows,
-                        window_hash,
-                        stored,
-                        SECONDARY_OCCURRENCE_CAP,
-                    );
-                    remember_repeated_window(
-                        &mut repeated_windows,
-                        window_hash,
-                        current,
-                        SECONDARY_OCCURRENCE_CAP,
-                    );
-                    // Do NOT update store — keep the first occurrence so the enlargement
-                    // stays consistent across the contiguous match region.
+                    None => {
+                        store.insert(window_hash, current);
+                    }
                 }
-                _ => {
-                    // Match broke (or no entry). Flush whatever was open.
-                    flush_clone(
-                        open_clone.take(),
-                        file_idx,
-                        prepared,
-                        min_lines,
-                        filters,
-                        &mut clones,
-                    );
-                    store.insert(window_hash, current);
-                }
+            }
+            if let Some(stored) = stored {
+                remember_repeated_window(
+                    &mut repeated_windows,
+                    window_hash,
+                    stored,
+                    SECONDARY_OCCURRENCE_CAP,
+                );
+                remember_repeated_window(
+                    &mut repeated_windows,
+                    window_hash,
+                    current,
+                    SECONDARY_OCCURRENCE_CAP,
+                );
+                // The store keeps the first occurrence so the enlargement stays
+                // consistent across the contiguous match region.
             }
         }
 
@@ -1442,6 +1467,106 @@ mod tests {
             1,
             "identical token streams in one pool must match across formats"
         );
+    }
+
+    /// Issue #1033: three files, scanned in this order.
+    ///   a: X
+    ///   b: X' T X'' where X' and X'' are X with a different first token
+    ///   c: X T Z
+    /// While scanning b, the windows spanning "tail of X + T" match nothing
+    /// and are stored. While scanning c, the clone anchored on a covers X;
+    /// the next window (tail of X + T) matches b's stored occurrence, and a
+    /// blind extension would stretch the fragment past a's last token and
+    /// drop the clone. The anchor check keeps a↔c at exactly |X| tokens.
+    #[test]
+    fn open_clone_extends_only_while_its_anchor_continues() {
+        let min_tokens = 5;
+        let x: Vec<u64> = (100..112).collect(); // 12 tokens
+        let t: Vec<u64> = vec![900, 901, 902, 903, 904, 905];
+        let z: Vec<u64> = vec![700, 701, 702, 703, 704, 705, 706];
+        let renamed = |first: u64| {
+            let mut v = x.clone();
+            v[0] = first;
+            v
+        };
+        let stream = |parts: &[&[u64]]| -> Vec<u64> { parts.concat() };
+        let a = stream(&[&x]);
+        let b = stream(&[&renamed(1), &t, &renamed(2)]);
+        let c = stream(&[&x, &t, &z]);
+        let streams: Vec<(&str, Vec<u64>)> =
+            vec![("a", a.clone()), ("b", b.clone()), ("c", c.clone())];
+        let to_prepared = |id: &str, hashes: Vec<u64>| {
+            let spans = (0..hashes.len())
+                .map(|i| {
+                    let loc = Location {
+                        line: i as u32 + 1,
+                        column: 1,
+                        offset: i as u32,
+                    };
+                    (loc.clone(), loc)
+                })
+                .collect();
+            PreparedSource {
+                id: id.to_string(),
+                format: "javascript".to_string(),
+                hashes,
+                spans,
+                raw_hashes: Vec::new(),
+                functions: Vec::new(),
+            }
+        };
+        let group = vec![
+            to_prepared("a", a),
+            to_prepared("b", b),
+            to_prepared("c", c),
+        ];
+        let clones = detect_prepared(vec![group], min_tokens, 0, &PathFilters::default());
+        let a_c: Vec<&CpdClone> = clones
+            .iter()
+            .filter(|cl| cl.fragment_a.source_id == "a" && cl.fragment_b.source_id == "c")
+            .collect();
+        assert_eq!(
+            a_c.len(),
+            1,
+            "a↔c must be reported once, got {:?}",
+            clones
+                .iter()
+                .map(|cl| (
+                    cl.fragment_a.source_id.as_str(),
+                    cl.fragment_a.range,
+                    cl.fragment_b.source_id.as_str(),
+                    cl.fragment_b.range,
+                    cl.token_count
+                ))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            a_c[0].token_count,
+            x.len() as u32,
+            "exactly X, not X plus T"
+        );
+        assert_eq!(a_c[0].fragment_a.range, [0, x.len() as u32 - 1]);
+        assert_eq!(a_c[0].fragment_b.range, [0, x.len() as u32 - 1]);
+        // Every reported pair covers identical token runs on both sides.
+        let run = |frag: &Fragment| -> &[u64] {
+            let hashes = &streams
+                .iter()
+                .find(|(id, _)| *id == frag.source_id)
+                .unwrap()
+                .1;
+            &hashes[frag.range[0] as usize..=frag.range[1] as usize]
+        };
+        for cl in &clones {
+            assert_eq!(
+                run(&cl.fragment_a),
+                run(&cl.fragment_b),
+                "{}{:?} and {}{:?} must hold the same tokens",
+                cl.fragment_a.source_id,
+                cl.fragment_a.range,
+                cl.fragment_b.source_id,
+                cl.fragment_b.range
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #1033. First of the three PRs planned for #1000.

## Bug

In `detect_in_group` an open clone was enlarged whenever the next window matched *any* stored occurrence. When a third file had stored a window that continues the same text (its own copy followed by different code), the fragment anchored on the first file was stretched past what that file contains. `flush_clone` then either dropped the clone (anchor out of tokens) or emitted a pair with mismatched ends: `fixtures/haxe` had `file1.hx [1:1 - 62:76]` against `file2.hx [1:1 - 62:2]`, whose texts differ.

## Fix

On each window the match asks first whether the anchor continues at the same offset (`windows_match` against `Occurrence { anchor.source_id, anchor.token_start + offset }`, bounds-checked). If it does, the clone grows regardless of what the store holds for that hash; if it does not, the clone is flushed and a new one starts on the occurrence the store matched, if any. Secondary-pass bookkeeping is unchanged.

## Effect on the fixtures corpus

Every `*-demo` directory's output is byte-identical before and after (checked with a script over 42 scans, including the flag variants in the READMEs). The whole-corpus scan goes from 231 to 245 clones:

- 14 recovered pairs among identical files, e.g. `folder1/file_1.js ↔ javascript/file_2.{js,cjs,mjs}` (169 tokens each), `clike/file1.c ↔ folder1/file2.c` (258 tokens);
- identical `file2.cts`/`file2.mts`/`file2.ts` now match to the end of file (`[109:38 - 376:4]`, 1035 tokens, was cut at 209:24);
- the misaligned haxe pair is replaced by two token-identical pairs (`[1:1 - 47:9]` and `[82:17 - 103:2] ↔ [41:17 - 62:2]`).

## Tests

- `open_clone_extends_only_while_its_anchor_continues`: three token streams in the #1033 shape; asserts a↔c has exactly |X| tokens and that every reported pair covers identical token runs on both sides. Fails on the old logic, passes with the fix.
- `fixtures/nway-demo/lost-pair` with a README: three files, `Found 3 clones.` (was 2, with the 110-token `duration.js ↔ uptime.js` pair missing).

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1034)
<!-- Reviewable:end -->
