### PR TITLE
docs(readme): mention --skip-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ jscpd v5 is a Rust engine that ships as a self-contained binary — no runtime r
 - **`--summary`** — codebase summary: top files and folders by tokens, lines, size, and a complexity estimate — refactoring hotspots straight from the scan (see [docs](docs/rust.md#summary))
 - **`--mcp`** — built-in MCP server over stdio with fully described tools: point your AI assistant at the binary and it can check snippets for duplication against your codebase, or find structurally similar functions with a `similarity` argument (see [docs](docs/ai-ready.md#stdio-transport-rust-v5))
 - **AI reporter** — token-efficient output for LLM pipelines (~79% fewer tokens than console)
-- **`--skip-isolated`** — ignore duplication between monorepo folders owned by different teams
+- **`--skip-local`** — report only clones that cross the scan roots: with `jscpd packages/api packages/web --skip-local`, pairs inside one of the two trees are dropped and only api-to-web duplication remains
+- **`--skip-isolated`** — ignore duplication between monorepo folders owned by different teams (`--skip-isolated "packages/team-a|packages/team-b"`)
 - **`--workers`** — control parallelism for file tokenization and detection (default: all CPU cores)
 - **Config discovery** — `.jscpd.json`, `.config/jscpd.json`, or the `jscpd` key in `package.json`
 - **Quiet in pipelines** — tips and sponsor lines print only on an interactive terminal; `--no-tips`, `CI` or `JSCPD_NO_TIPS` switch them off everywhere


### PR DESCRIPTION
Follow-up to #1035, which was merged before this commit reached its branch. Adds a `--skip-local` bullet to the feature list next to `--skip-isolated`: the flag keeps only clones that cross the scan roots given on the command line (verified on the binary: two roots without the flag report 5 clones, with it 0). The `--skip-isolated` bullet gains its example argument.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1036)
<!-- Reviewable:end -->
