### PR TITLE
feat(cli): non-zero exit for unknown format, missing path, failed reporter; add --fail-on-empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ jscpd v5 is a Rust engine that ships as a self-contained binary — no runtime r
 - **Clone kinds in every reporter** — `exact`, `renamed` or `similar` in the console, JSON (`kind`, `similarity`, `method`), XML, HTML, Xcode, SARIF (`jscpd/duplicate-code`, `jscpd/renamed-code`, `jscpd/similar-code`) and Code Climate output; default runs report only `exact` clones and are unchanged
 - **15 reporters**: `console`, `console-full`, `json`, `xml`, `csv`, `html`, `markdown`, `badge`, `sarif`, `codeclimate`, `openmetrics`, `ai`, `xcode`, `threshold`, `silent`
 - **Clone baseline** — gate CI on *new* duplication only. `--baseline .jscpd-baseline.json` with `--fail-on-new-clones[=N]` tolerates legacy clones and fails the build on regressions; `--baseline-from-ref origin/main` does the same without a committed file (see [docs](docs/rust.md#baseline))
+- **Exit codes you can gate on** — an unknown `--format`, a missing scan path and a reporter that cannot write its file exit 1 instead of passing with an empty report; `--fail-on-empty` fails a scan that analyzed no files (see [Exit codes](docs/rust.md#exit-codes))
 - **GitLab-ready reporters** — `codeclimate` (`gl-code-quality-report.json`) and `openmetrics` (`jscpd-metrics.txt`) plug into `artifacts:reports`
 - **Git blame** with side-by-side author comparison (`--blame --reporters console-full`)
 - **`--summary`** — codebase summary: top files and folders by tokens, lines, size, and a complexity estimate — refactoring hotspots straight from the scan (see [docs](docs/rust.md#summary))

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ inputs:
     description: "Exit 1 when new clones are found (requires baseline or baseline-from-ref). Use 'true' for zero tolerance, or an integer N to allow up to N new clones"
     required: false
     default: ""
+  fail-on-empty:
+    description: "Exit 1 when the scan analyzes no files: the paths exist but nothing matched the format, ignore or pattern filters"
+    required: false
+    default: "false"
   baseline-from-ref:
     description: "Compare against an ephemeral baseline built from a git ref's tree (e.g. origin/main); needs the ref fetched (fetch-depth: 0). Conflicts with baseline"
     required: false
@@ -280,6 +284,7 @@ runs:
         INPUT_BASELINE: ${{ inputs.baseline }}
         INPUT_UPDATE_BASELINE: ${{ inputs.update-baseline }}
         INPUT_FAIL_ON_NEW_CLONES: ${{ inputs.fail-on-new-clones }}
+        INPUT_FAIL_ON_EMPTY: ${{ inputs.fail-on-empty }}
         INPUT_BASELINE_FROM_REF: ${{ inputs.baseline-from-ref }}
         INPUT_BLAME: ${{ inputs.blame }}
         INPUT_EXIT_CODE: ${{ inputs.exit-code }}
@@ -405,6 +410,9 @@ runs:
         # Boolean flags
         if [ "$INPUT_SKIP_LOCAL" = "true" ]; then
           ARGS+=("--skip-local")
+        fi
+        if [ "$INPUT_FAIL_ON_EMPTY" = "true" ]; then
+          ARGS+=("--fail-on-empty")
         fi
         if [ "$INPUT_IGNORE_CASE" = "true" ]; then
           ARGS+=("--ignore-case")

--- a/docs/ci-and-hooks.md
+++ b/docs/ci-and-hooks.md
@@ -56,6 +56,7 @@ The workflow fails if more than 5% of the code is duplicated.
 | `baseline` | Path to a clone baseline file; clones absent from it are reported as new | — |
 | `update-baseline` | Rewrite the baseline file from the current run (requires `baseline`) | `false` |
 | `fail-on-new-clones` | Exit 1 on new clones (`true`, or an integer N to allow up to N) | — |
+| `fail-on-empty` | Exit 1 when the scan analyzes no files (paths exist but nothing matched the filters) | `false` |
 | `baseline-from-ref` | Compare against an ephemeral baseline built from a git ref (needs `fetch-depth: 0`) | — |
 | `blame` | Enrich clones with git blame data | `false` |
 | `exit-code` | Exit with code when duplicates found (`true` or integer) | — |

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -98,6 +98,7 @@ cpd [OPTIONS] [PATH]...
 | `--baseline` | | Clone baseline file (e.g. `.jscpd-baseline.json`): clones whose fingerprint is absent from it are reported as new. See [Baseline](#baseline) | — |
 | `--update-baseline` | | Rewrite the baseline file from the current run, creating it if missing (requires `--baseline`) | off |
 | `--fail-on-new-clones` | | Exit 1 when more than N new clones are found (`--fail-on-new-clones` alone means N=0; requires `--baseline` or `--baseline-from-ref`) | — |
+| `--fail-on-empty` | | Exit 1 when the scan analyzes no files: the paths exist but nothing matched the `--format`, `--ignore` and `--pattern` filters, or every file was below `--min-tokens`. See [Exit codes](#exit-codes) | off |
 | `--baseline-from-ref` | | Compare against an ephemeral baseline built from a git ref's tree (e.g. `origin/main`). Conflicts with `--baseline` | — |
 | `--sarif-error-tokens` | | Report SARIF results as `error` for clones with at least this many tokens (smaller clones stay `warning`). When overall duplication exceeds `--threshold`, all SARIF results become `error` regardless of size. | — (all `warning`) |
 | `--min-duplicated-lines` | | Minimum percentage of duplication to report (0-100) | 0 |
@@ -209,6 +210,17 @@ With `--blame --reporters console-full`, clones are displayed with a side-by-sid
 ```
 
 `==` means both lines were written by the same author; `<=` means different authors (potential copy).
+
+### Exit codes
+
+| Code | When |
+|------|------|
+| 0 | The scan ran and no gate fired; clones may still have been found and reported |
+| 1 | `--threshold` exceeded; `--fail-on-new-clones` exceeded; `--fail-on-empty` and no file was analyzed; a reporter failed to write its output; a scan path does not exist; `--format` names a format that is not supported; an invalid flag combination or an unreadable `--config` file |
+| N | `--exit-code N` (default 1) when at least one clone was found |
+| 2 | Command-line parse errors: an unknown flag or a missing value |
+
+A scan that analyzes no files, because the paths exist but nothing matched the `--format`, `--ignore` and `--pattern` filters or every file was below `--min-tokens`, prints `Warning: jscpd analyzed no files` and still exits 0, so an intentionally empty tree does not break a pipeline. `--fail-on-empty` (config key `failOnEmpty`) turns that into an error for CI jobs where an empty result means a misconfigured scan. Reports are written before the check, so the empty report is still there to inspect. Unknown reporter names remain a warning. See [`fixtures/fail-on-empty-demo`](../fixtures/fail-on-empty-demo/README.md) for a runnable example.
 
 ### Examples
 

--- a/fixtures/fail-on-empty-demo/README.md
+++ b/fixtures/fail-on-empty-demo/README.md
@@ -1,0 +1,82 @@
+# fail-on-empty demo
+
+Shows the exit codes jscpd uses when a scan cannot mean what a green run
+usually means: nothing was analyzed, a path is missing, a format name is
+wrong, or a reporter could not write its file (issue #1047). All commands run
+from the repository root at default thresholds.
+
+| Directory | Contents | Default scan | With `--fail-on-empty` |
+|-----------|----------|--------------|------------------------|
+| `code/` | Two JavaScript files sharing a discount loop | `Found 1 clones.`, exit 0 | same, exit 0 |
+| `nothing/` | One JavaScript file holding only comments | `Found 0 clones.` plus a warning, exit 0 | `ERROR`, exit 1 |
+
+## `code/`: a normal scan
+
+`pricing.js` and `invoice.js` both contain the same tier table and discount
+loop, so the default scan reports one clone. `--fail-on-empty` changes nothing
+here because files were analyzed.
+
+```bash
+jscpd fixtures/fail-on-empty-demo/code
+# Clone found (javascript)
+#  - invoice.js [4:53 - 18:62] (15 lines, 119 tokens)
+#    pricing.js [4:56 - 18:62]
+# Found 1 clones.
+
+jscpd fixtures/fail-on-empty-demo/code --fail-on-empty
+# Found 1 clones.
+# (exit 0)
+```
+
+## `nothing/`: the path exists, nothing gets analyzed
+
+`only-comments.js` contains comments only. JavaScript comments produce no
+detection tokens, so the file is below `--min-tokens` and the scan analyzes
+zero files. By default that is a warning and the run still exits 0, so an
+intentionally empty tree does not break a pipeline. `--fail-on-empty` (config
+key `failOnEmpty`) turns it into an error for CI jobs where an empty result
+means a misconfigured scan. Reports are written before the check runs.
+
+```bash
+jscpd fixtures/fail-on-empty-demo/nothing
+# Found 0 clones.
+# Warning: jscpd analyzed no files: check the paths and the --format, --ignore and --pattern filters
+# (exit 0)
+
+jscpd fixtures/fail-on-empty-demo/nothing --fail-on-empty
+# Found 0 clones.
+# ERROR: jscpd analyzed no files (--fail-on-empty): check the paths and the --format, --ignore and --pattern filters
+# (exit 1)
+```
+
+## Errors that exit 1 on their own
+
+These do not need a flag. Each one used to write an empty report and exit 0.
+
+```bash
+# A format name that is not in `jscpd --list`
+jscpd fixtures/fail-on-empty-demo/code --format nosuchlang
+# Error: --format: 'nosuchlang' is not a supported format (run with --list to see supported formats)
+# (exit 1)
+
+# A scan path that does not exist
+jscpd fixtures/fail-on-empty-demo/missing
+# Error: path does not exist: fixtures/fail-on-empty-demo/missing
+# (exit 1)
+
+# A reporter that cannot write its output (here the output directory is a file)
+jscpd fixtures/fail-on-empty-demo/code --reporters json --output fixtures/fail-on-empty-demo/code/pricing.js/report
+# Reporter 'json' error: I/O error in reporter: Not a directory (os error 20)
+# ERROR: a reporter failed to write its output (see the message above)
+# (exit 1)
+```
+
+Formats introduced with `--formats-exts` or `--formats-names` are accepted by
+`--format`; only names that exist nowhere are rejected.
+
+## Whole directory
+
+```bash
+jscpd fixtures/fail-on-empty-demo
+# Found 1 clones.
+```

--- a/fixtures/fail-on-empty-demo/code/invoice.js
+++ b/fixtures/fail-on-empty-demo/code/invoice.js
@@ -1,0 +1,23 @@
+// Invoice totals for the demo shop. The discount loop is a copy of the one in
+// pricing.js, which is the clone the demo commands report.
+
+export function invoiceLine(quantity, unitPrice, sku) {
+  const tiers = [
+    { minQuantity: 500, discount: 0.18 },
+    { minQuantity: 200, discount: 0.12 },
+    { minQuantity: 50, discount: 0.07 },
+    { minQuantity: 10, discount: 0.03 },
+  ];
+  const subtotal = quantity * unitPrice;
+  for (const tier of tiers) {
+    if (quantity >= tier.minQuantity) {
+      const saved = subtotal * tier.discount;
+      return { subtotal, discount: saved, total: subtotal - saved, tier: tier.minQuantity };
+    }
+  }
+  return { subtotal, discount: 0, total: subtotal, tier: null, sku };
+}
+
+export function formatLine(line) {
+  return `${line.sku}: ${line.total.toFixed(2)}`;
+}

--- a/fixtures/fail-on-empty-demo/code/pricing.js
+++ b/fixtures/fail-on-empty-demo/code/pricing.js
@@ -1,0 +1,23 @@
+// Pricing rules for the demo shop. The tier table below is duplicated in
+// invoice.js so the demo has a clone at default thresholds.
+
+export function applyVolumeDiscount(quantity, unitPrice) {
+  const tiers = [
+    { minQuantity: 500, discount: 0.18 },
+    { minQuantity: 200, discount: 0.12 },
+    { minQuantity: 50, discount: 0.07 },
+    { minQuantity: 10, discount: 0.03 },
+  ];
+  const subtotal = quantity * unitPrice;
+  for (const tier of tiers) {
+    if (quantity >= tier.minQuantity) {
+      const saved = subtotal * tier.discount;
+      return { subtotal, discount: saved, total: subtotal - saved, tier: tier.minQuantity };
+    }
+  }
+  return { subtotal, discount: 0, total: subtotal, tier: null };
+}
+
+export function roundToCents(amount) {
+  return Math.round(amount * 100) / 100;
+}

--- a/fixtures/fail-on-empty-demo/nothing/only-comments.js
+++ b/fixtures/fail-on-empty-demo/nothing/only-comments.js
@@ -1,0 +1,4 @@
+// This file exists so the directory is not empty, but it holds no code.
+// JavaScript comments produce no detection tokens, so jscpd analyzes zero
+// files here: the path exists, the scan runs, and the result is empty.
+// That is the situation --fail-on-empty turns into an error.

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -281,6 +281,12 @@ pub struct Cli {
     #[arg(long, value_name = "N", num_args(0..=1), default_missing_value = "0")]
     pub fail_on_new_clones: Option<u64>,
 
+    /// Exit 1 when the scan analyzes no files: the paths exist but nothing
+    /// matched the --format, --ignore and --pattern filters, or every file
+    /// was below --min-tokens
+    #[arg(long)]
+    pub fail_on_empty: bool,
+
     /// Compare against an ephemeral baseline built from a git ref's tree
     /// (e.g. origin/main): the base ref is scanned with the same
     /// configuration and clones absent from it are reported as new
@@ -436,6 +442,8 @@ pub struct ConfigFile {
     pub baseline: Option<String>,
     #[serde(alias = "fail-on-new-clones")]
     pub fail_on_new_clones: Option<u64>,
+    #[serde(alias = "fail-on-empty")]
+    pub fail_on_empty: Option<bool>,
     #[serde(alias = "baseline-from-ref")]
     pub baseline_from_ref: Option<String>,
     pub blame: Option<bool>,
@@ -648,6 +656,7 @@ pub(crate) static KNOWN_CONFIG_FIELDS: &[&str] = &[
     "sarifErrorTokens",
     "baseline",
     "failOnNewClones",
+    "failOnEmpty",
     "baselineFromRef",
     "blame",
     "noGitignore",
@@ -2615,6 +2624,19 @@ mod tests {
     #[test]
     fn scan_known_fields_formats_is_known() {
         assert_no_unknown_diagnostics(serde_json::json!({"formats": ["typescript"]}), "formats");
+    }
+
+    #[test]
+    fn scan_known_fields_fail_on_empty_is_known() {
+        assert_no_unknown_diagnostics(serde_json::json!({"failOnEmpty": true}), "failOnEmpty");
+    }
+
+    #[test]
+    fn fail_on_empty_cli_flag() {
+        let cli = Cli::parse_from(["cpd", "--fail-on-empty", "."]);
+        assert!(cli.fail_on_empty);
+        let cli = Cli::parse_from(["cpd", "."]);
+        assert!(!cli.fail_on_empty);
     }
 
     // debug flag

--- a/rust/crates/cpd/src/main.rs
+++ b/rust/crates/cpd/src/main.rs
@@ -45,6 +45,7 @@ struct MergedConfig {
     baseline: Option<String>,
     update_baseline: bool,
     fail_on_new_clones: Option<u64>,
+    fail_on_empty: bool,
     baseline_from_ref: Option<String>,
     blame: bool,
     no_gitignore: bool,
@@ -97,6 +98,7 @@ impl MergedConfig {
                 .map(|p| p.to_string_lossy().to_string()),
             update_baseline: opts.update_baseline,
             fail_on_new_clones: opts.fail_on_new_clones,
+            fail_on_empty: opts.fail_on_empty,
             baseline_from_ref: opts.baseline_from_ref.clone(),
             blame: opts.blame,
             no_gitignore: opts.no_gitignore,
@@ -221,18 +223,28 @@ fn main() {
         }
     }
 
-    // Warn about unknown format names in --format: a typo like 'cs' would
-    // otherwise silently match 0 files and report a clean scan (#964).
-    // Custom formats introduced via --formats-exts are legal.
+    // Reject unknown format names in --format: a typo like 'cs' would
+    // otherwise match 0 files and report a clean scan with exit 0 (#964,
+    // #1047). Custom formats introduced via --formats-exts or --formats-names
+    // are legal.
     if !opts.formats.is_empty() {
         let known = cpd_tokenizer::formats::list_formats();
-        for format in &opts.formats {
-            if !known.contains(&format.as_str()) && !opts.formats_exts.contains_key(format) {
-                eprintln!(
-                    "Warning: --format: '{}' is not a supported format, no files will match it (run with --list to see supported formats)",
-                    format
-                );
-            }
+        let unknown: Vec<&str> = opts
+            .formats
+            .iter()
+            .map(String::as_str)
+            .filter(|f| {
+                !known.contains(f)
+                    && !opts.formats_exts.contains_key(*f)
+                    && !opts.formats_names.contains_key(*f)
+            })
+            .collect();
+        if !unknown.is_empty() {
+            eprintln!(
+                "Error: --format: '{}' is not a supported format (run with --list to see supported formats)",
+                unknown.join("', '")
+            );
+            std::process::exit(1);
         }
     }
 
@@ -287,6 +299,16 @@ fn main() {
     } else {
         opts.paths.clone()
     };
+
+    // A scan path that does not exist is an error, not an empty scan (#1047):
+    // the walker would otherwise skip it and report a clean run with exit 0.
+    let missing: Vec<&std::path::PathBuf> = paths.iter().filter(|p| !p.exists()).collect();
+    if !missing.is_empty() {
+        for p in &missing {
+            eprintln!("Error: path does not exist: {}", p.display());
+        }
+        std::process::exit(1);
+    }
 
     // If --absolute, canonicalize all paths
     let paths: Vec<std::path::PathBuf> = if opts.absolute {
@@ -498,9 +520,12 @@ fn main() {
         .partition(|r| is_console_reporter(r));
 
     let mut threshold_exceeded = false;
+    let mut reporter_failed = false;
 
-    let run_batch = |names: &[String]| -> bool {
+    // Returns (threshold exceeded, a reporter failed).
+    let run_batch = |names: &[String]| -> (bool, bool) {
         let mut threshold_exceeded = false;
+        let mut failed = false;
         for reporter_name in names {
             let reporter =
                 match create_reporter(normalize_reporter_name(reporter_name), &reporter_opts) {
@@ -526,16 +551,22 @@ fn main() {
                 }
                 Err(e) => {
                     eprintln!("Reporter '{}' error: {}", reporter_name, e);
+                    failed = true;
                 }
             }
         }
-        threshold_exceeded
+        (threshold_exceeded, failed)
     };
 
-    threshold_exceeded |= run_batch(&console_names);
-    threshold_exceeded |= run_batch(&file_names);
+    let mut batches: Vec<&[String]> = vec![&console_names, &file_names];
+    let threshold_batch = ["threshold".to_string()];
     if has_threshold {
-        threshold_exceeded |= run_batch(&["threshold".to_string()]);
+        batches.push(&threshold_batch);
+    }
+    for batch in batches {
+        let (exceeded, failed) = run_batch(batch);
+        threshold_exceeded |= exceeded;
+        reporter_failed |= failed;
     }
 
     // Print execution time if not silent
@@ -574,6 +605,29 @@ fn main() {
                 prefix, suffix
             );
         }
+    }
+
+    // Empty scans (#1047): every path exists, but nothing was analyzed — the
+    // --format, --ignore or --pattern filters matched no file, or every file
+    // was below --min-tokens. Warn by default so an intentionally empty tree
+    // still passes; --fail-on-empty makes it fatal for CI jobs where an empty
+    // result means a misconfigured scan. Reports were already written above,
+    // so a CI job can still inspect them.
+    let empty_scan = statistics.total.sources == 0;
+    if empty_scan && opts.fail_on_empty {
+        eprintln!(
+            "ERROR: jscpd analyzed no files (--fail-on-empty): check the paths and the --format, --ignore and --pattern filters"
+        );
+    } else if empty_scan {
+        eprintln!(
+            "Warning: jscpd analyzed no files: check the paths and the --format, --ignore and --pattern filters"
+        );
+    }
+    if reporter_failed {
+        eprintln!("ERROR: a reporter failed to write its output (see the message above)");
+    }
+    if reporter_failed || (empty_scan && opts.fail_on_empty) {
+        std::process::exit(1);
     }
 
     // Exit code logic

--- a/rust/crates/cpd/src/options.rs
+++ b/rust/crates/cpd/src/options.rs
@@ -28,6 +28,7 @@ pub struct Options {
     pub baseline: Option<PathBuf>,
     pub update_baseline: bool,
     pub fail_on_new_clones: Option<u64>,
+    pub fail_on_empty: bool,
     pub baseline_from_ref: Option<String>,
     pub blame: bool,
     pub no_gitignore: bool,
@@ -154,6 +155,7 @@ impl Options {
                 .or_else(|| config.baseline.clone().map(PathBuf::from)),
             update_baseline: cli.update_baseline,
             fail_on_new_clones: cli.fail_on_new_clones.or(config.fail_on_new_clones),
+            fail_on_empty: cli.fail_on_empty || config.fail_on_empty.unwrap_or(false),
             baseline_from_ref: cli
                 .baseline_from_ref
                 .clone()

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -137,13 +137,36 @@ fn root_config_wins_over_dot_config_subfolder() {
 }
 
 #[test]
-fn unknown_format_prints_warning() {
+fn unknown_format_is_an_error() {
+    // #964 made this a warning; #1047 makes it fatal, because a scan that
+    // matches no files otherwise reports a clean run with exit 0.
     let output = run_cpd(["--format", "zzzznotalang", "--reporters", "silent", "."])
         .expect("cpd binary must exist");
     let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
     assert!(
-        stderr.contains("'zzzznotalang' is not a supported format"),
-        "unknown --format must print warning, got stderr: {}",
+        stderr.contains("Error: --format: 'zzzznotalang' is not a supported format"),
+        "unknown --format must be an error, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn custom_format_from_formats_names_is_accepted() {
+    let output = run_cpd([
+        "--format",
+        "zzzzcustom",
+        "--formats-names",
+        "zzzzcustom:Zzzzfile",
+        "--reporters",
+        "silent",
+        ".",
+    ])
+    .expect("cpd binary must exist");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("not a supported format"),
+        "a format introduced by --formats-names must be accepted, got stderr: {}",
         stderr
     );
 }
@@ -1960,5 +1983,162 @@ fn help_usage_line_uses_invoked_binary_name() {
     assert!(
         stdout.contains("Usage: cpd"),
         "cpd --help usage line should name cpd, got: {stdout}"
+    );
+}
+
+// ── exit codes (#1047) ───────────────────────────────────────────────────
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("cpd-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A JavaScript file whose only content is comments: JS comments produce no
+/// detection tokens, so the directory exists but nothing gets analyzed.
+fn write_comment_only_js(dir: &std::path::Path) {
+    std::fs::write(
+        dir.join("only-comments.js"),
+        "// nothing to analyze here\n// just comments\n// and more comments\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn nonexistent_path_is_an_error() {
+    let missing = std::env::temp_dir().join(format!("cpd-missing-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&missing);
+    let output = run_cpd([
+        missing.as_os_str(),
+        std::ffi::OsStr::new("--reporters"),
+        std::ffi::OsStr::new("silent"),
+    ])
+    .expect("cpd binary must exist");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("Error: path does not exist:"),
+        "missing path must be an error, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn empty_scan_warns_and_exits_zero() {
+    let dir = scratch_dir("empty-warn");
+    write_comment_only_js(&dir);
+    let output = run_cpd([
+        dir.as_os_str(),
+        std::ffi::OsStr::new("--reporters"),
+        std::ffi::OsStr::new("silent"),
+    ])
+    .expect("cpd binary must exist");
+    std::fs::remove_dir_all(&dir).ok();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("Warning: jscpd analyzed no files"),
+        "empty scan must warn, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn fail_on_empty_exits_one_when_nothing_analyzed() {
+    let dir = scratch_dir("empty-fail");
+    write_comment_only_js(&dir);
+    let output = run_cpd([
+        dir.as_os_str(),
+        std::ffi::OsStr::new("--fail-on-empty"),
+        std::ffi::OsStr::new("--reporters"),
+        std::ffi::OsStr::new("silent"),
+    ])
+    .expect("cpd binary must exist");
+    std::fs::remove_dir_all(&dir).ok();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("ERROR: jscpd analyzed no files (--fail-on-empty)"),
+        "got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn fail_on_empty_from_config_file() {
+    let dir = scratch_dir("empty-config");
+    write_comment_only_js(&dir);
+    let config = dir.join("jscpd.json");
+    std::fs::write(&config, r#"{"failOnEmpty": true}"#).unwrap();
+    let output = run_cpd([
+        dir.as_os_str(),
+        std::ffi::OsStr::new("--config"),
+        config.as_os_str(),
+        std::ffi::OsStr::new("--reporters"),
+        std::ffi::OsStr::new("silent"),
+    ])
+    .expect("cpd binary must exist");
+    std::fs::remove_dir_all(&dir).ok();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
+    assert!(
+        !stderr.contains("unknown field"),
+        "failOnEmpty must be a known config key, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn fail_on_empty_passes_when_files_are_analyzed() {
+    let dir = scratch_dir("empty-pass");
+    let body: String = (0..12)
+        .map(|i| {
+            format!("function f{i}(a, b) {{\n  const x{i} = a * {i} + b;\n  return x{i} - a;\n}}\n")
+        })
+        .collect();
+    std::fs::write(dir.join("code.js"), body).unwrap();
+    let output = run_cpd([
+        dir.as_os_str(),
+        std::ffi::OsStr::new("--fail-on-empty"),
+        std::ffi::OsStr::new("--reporters"),
+        std::ffi::OsStr::new("silent"),
+    ])
+    .expect("cpd binary must exist");
+    std::fs::remove_dir_all(&dir).ok();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "stderr: {}", stderr);
+    assert!(
+        !stderr.contains("analyzed no files"),
+        "got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn reporter_write_failure_exits_one() {
+    let dir = scratch_dir("reporter-fail");
+    write_comment_only_js(&dir);
+    // A regular file where the output directory should be: creating the
+    // directory fails on every platform, so the json reporter cannot write.
+    let blocker = dir.join("blocker");
+    std::fs::write(&blocker, "not a directory").unwrap();
+    let out_dir = blocker.join("report");
+    let output = run_cpd([
+        dir.as_os_str(),
+        std::ffi::OsStr::new("--reporters"),
+        std::ffi::OsStr::new("json"),
+        std::ffi::OsStr::new("--output"),
+        out_dir.as_os_str(),
+    ])
+    .expect("cpd binary must exist");
+    std::fs::remove_dir_all(&dir).ok();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("Reporter 'json' error:")
+            && stderr.contains("ERROR: a reporter failed to write its output"),
+        "got stderr: {}",
+        stderr
     );
 }


### PR DESCRIPTION
Closes #1047.

## What changes

Four situations used to write an empty report and exit 0, so a CI job that checks only the exit code saw a green run:

| Situation | Before | Now |
|-----------|--------|-----|
| `--format nosuchlang` | warning, empty report, exit 0 | `Error: --format: 'nosuchlang' is not a supported format`, exit 1. Names from `--formats-exts` / `--formats-names` stay accepted |
| Scan path does not exist | empty report, exit 0 | `Error: path does not exist: <path>`, exit 1, before anything runs |
| Reporter cannot write its file | `Reporter 'json' error: ...`, exit 0 | same line, then `ERROR: a reporter failed to write its output`, exit 1; other reporters still run first |
| Nothing analyzed (paths exist, filters matched nothing, or all files below `--min-tokens`) | silent, exit 0 | `Warning: jscpd analyzed no files`, exit 0; with **`--fail-on-empty`** (config `failOnEmpty`, action input `fail-on-empty`) exit 1. Reports are written before the check |

Unknown reporter names remain a warning. Clap usage errors remain exit 2. `--threshold`, `--fail-on-new-clones` and `--exit-code` are unchanged.

## Docs

- `docs/rust.md`: new **Exit codes** section (0 / 1 / N / 2 table) and an option row for `--fail-on-empty`
- `docs/ci-and-hooks.md`: action input row; `action.yml`: `fail-on-empty` input
- README: one feature bullet
- jscpd.dev configuration table and CI tips: separate PR on the site repo

## Fixtures

`fixtures/fail-on-empty-demo/`, README quotes every command with its output and exit code.

| Directory | Contents | Default scan | With `--fail-on-empty` |
|-----------|----------|--------------|------------------------|
| `code/` | two JS files sharing a discount loop | `Found 1 clones.`, exit 0 | same |
| `nothing/` | one JS file holding only comments | `Found 0 clones.` + warning, exit 0 | `ERROR`, exit 1 |

The README also runs the unknown-format, missing-path and unwritable-output cases. Corpus delta for the smoke job: +1 clone, +4 analyzed files (2 javascript, 1 markdown, 1 bash from the README fences); the demo files pair only with each other.

## Tests

`unknown_format_prints_warning` becomes `unknown_format_is_an_error`; new integration tests cover `--formats-names` acceptance, the missing path, the empty-scan warning, `--fail-on-empty` (flag, config key, and a non-empty scan that passes) and the reporter failure. `cargo nextest run -p jscpd`: 531 passed. `cargo clippy --all-targets -D warnings` clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1049)
<!-- Reviewable:end -->
