### PR TITLE
docs: add CITATION.cff and a Citation section

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+# Citation metadata (https://citation-file-format.github.io). GitHub renders
+# it as the "Cite this repository" button. `version` and `date-released`
+# follow rust/package.json and are kept in step by rust/scripts/sync-version.mjs.
+cff-version: 1.2.0
+message: "If you use jscpd in research, please cite it as below."
+type: software
+title: "jscpd: copy/paste detector for programming source code"
+abstract: >-
+  Language-aware copy/paste detector for 224 programming languages and
+  formats. Finds exact (Type-1), renamed (Type-2) and near-miss (Type-3)
+  code clones with a Rabin-Karp token search and syntax-tree function
+  similarity, and reports them in 15 formats including JSON, HTML and SARIF.
+authors:
+  - family-names: Kucherenko
+    given-names: Andrey
+    email: kucherenko.andrey@gmail.com
+version: 5.2.0
+date-released: 2026-09-08
+license: MIT
+repository-code: "https://github.com/kucherenko/jscpd"
+url: "https://jscpd.dev"
+keywords:
+  - code-clone-detection
+  - copy-paste-detection
+  - duplicate-code
+  - static-analysis
+  - code-quality
+  - rust

--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ After installation, ask your agent to "find and fix code duplication" and it wil
 
 See [AI-Ready docs](docs/ai-ready.md) for full details.
 
+## Citation
+
+If jscpd is part of your research, cite it via the repository's [`CITATION.cff`](CITATION.cff) (GitHub's "Cite this repository" button produces BibTeX and APA) or with:
+
+```bibtex
+@software{jscpd,
+  title        = {jscpd: copy/paste detector for programming source code},
+  author       = {Kucherenko, Andrey},
+  year         = {2026},
+  version      = {5.2.0},
+  license      = {MIT},
+  url          = {https://github.com/kucherenko/jscpd},
+}
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, test policy, and pull request requirements. In short:

--- a/rust/scripts/sync-version.mjs
+++ b/rust/scripts/sync-version.mjs
@@ -148,6 +148,25 @@ function toPep440(version) {
 }
 const pypiVersion = toPep440(npmVersion);
 
+// Sync CITATION.cff: `version` follows the engine version, and `date-released`
+// is set to today's UTC date whenever the version changes, so a release commit
+// carries the right citation metadata without a manual edit.
+{
+  const citationPath = path.join(root, "..", "CITATION.cff");
+  const citation = fs.readFileSync(citationPath, "utf8");
+  const current = /^version: (.*)$/m.exec(citation)?.[1];
+  if (current !== npmVersion) {
+    const today = new Date().toISOString().slice(0, 10);
+    const updated = citation
+      .replace(/^version: .*$/m, `version: ${npmVersion}`)
+      .replace(/^date-released: .*$/m, `date-released: ${today}`);
+    fs.writeFileSync(citationPath, updated);
+    console.log(`Updated ../CITATION.cff to ${npmVersion} (released ${today})`);
+  } else {
+    console.log(`No change ../CITATION.cff (${npmVersion})`);
+  }
+}
+
 // Sync the repository-root pyproject.toml. It is a private project whose only
 // job is to make `pre-commit` (language: python, see .pre-commit-hooks.yaml)
 // install the `jscpd` binary from PyPI when a project points its hook at this
@@ -173,6 +192,13 @@ const pypiVersion = toPep440(npmVersion);
       if (version !== npmVersion) {
         problems.push(`${rel}: ${dep} pinned to ${version}, expected ${npmVersion}`);
       }
+    }
+  }
+  {
+    const citation = fs.readFileSync(path.join(root, "..", "CITATION.cff"), "utf8");
+    const version = /^version: (.*)$/m.exec(citation)?.[1];
+    if (version !== npmVersion) {
+      problems.push(`../CITATION.cff: version is ${version}, expected ${npmVersion}`);
     }
   }
   {


### PR DESCRIPTION
Adds `CITATION.cff` (CFF 1.2.0, validated with `cffconvert --validate`) so GitHub shows the "Cite this repository" button with BibTeX and APA output, plus a Citation section in the README with a ready-made `@software` entry.

`sync-version.mjs` now keeps the file's `version` in step with `rust/package.json`, stamps `date-released` with the current UTC date whenever the version changes, and verifies the version alongside the other manifests, so release commits carry correct citation metadata without a manual edit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1051)
<!-- Reviewable:end -->
