### PR TITLE
feat(history): dedupe the test scaffolding grown by --history and --fail-on-empty

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -189,7 +189,7 @@ jscpd src --history-since 2026-01-01             # every commit since a date, up
 jscpd src --history main --history-since 2026-06-01 --history-every 5 --history-limit 12
 ```
 
-The console reporter appends a block with a bar chart of the duplication percentage (its y-axis spans the series' own min and max, so small drifts stay visible), the table, the change from the previous point (red when duplication rose, green when it fell), the overall trend, and, when `--threshold` is set and the latest value sits below it, the headroom:
+The `console` and `console-full` reporters append a block with a bar chart of the duplication percentage (its y-axis spans the series' own min and max, so small drifts stay visible), the table, the change from the previous point (red when duplication rose, green when it fell), the overall trend, and, when `--threshold` is set and the latest value sits below it, the headroom:
 
 ```
 History (since 2026-01-01: 4 commits + working tree)

--- a/rust/crates/cpd-core/src/models.rs
+++ b/rust/crates/cpd-core/src/models.rs
@@ -159,7 +159,61 @@ pub struct CpdClone {
     pub unmatched_lines: [u32; 2],
 }
 
+impl Location {
+    pub fn new(line: u32, column: u32, offset: u32) -> Self {
+        Self {
+            line,
+            column,
+            offset,
+        }
+    }
+}
+
+impl Fragment {
+    /// A fragment with no scan root and no blame data, the shape detection
+    /// produces before enrichment.
+    pub fn new(
+        source_id: impl Into<String>,
+        start: Location,
+        end: Location,
+        range: [u32; 2],
+    ) -> Self {
+        Self {
+            source_id: source_id.into(),
+            source_root: None,
+            start,
+            end,
+            range,
+            blame: None,
+        }
+    }
+
+    pub fn with_blame(mut self, blame: BlameEntry) -> Self {
+        self.blame = Some(blame);
+        self
+    }
+}
+
 impl CpdClone {
+    /// An exact clone with no baseline, similarity or gap metadata.
+    pub fn exact(
+        format: impl Into<String>,
+        fragment_a: Fragment,
+        fragment_b: Fragment,
+        token_count: u32,
+    ) -> Self {
+        Self {
+            format: format.into(),
+            fragment_a,
+            fragment_b,
+            token_count,
+            is_new: false,
+            kind: CloneKind::default(),
+            similarity: None,
+            similarity_method: None,
+            unmatched_lines: [0, 0],
+        }
+    }
     /// `similarity` rounded to three decimals as an f64, the form reporters
     /// print (an f32 widened to JSON would print as `0.8510638475418091`).
     pub fn similarity_rounded(&self) -> Option<f64> {
@@ -294,25 +348,8 @@ mod tests {
             author: "Alice".to_string(),
             timestamp: 1700000000,
         };
-        let frag = Fragment {
-            source_id: "a.js".to_string(),
-            source_root: None,
-            start: loc.clone(),
-            end: loc.clone(),
-            range: [0, 10],
-            blame: Some(blame),
-        };
-        let clone = CpdClone {
-            format: "javascript".to_string(),
-            fragment_a: frag.clone(),
-            fragment_b: frag,
-            token_count: 50,
-            is_new: false,
-            kind: Default::default(),
-            similarity: None,
-            similarity_method: None,
-            unmatched_lines: [0, 0],
-        };
+        let frag = Fragment::new("a.js", loc.clone(), loc, [0, 10]).with_blame(blame);
+        let clone = CpdClone::exact("javascript", frag.clone(), frag, 50);
         let json = serde_json::to_string(&clone).unwrap();
         assert!(json.contains("abc123"));
         assert!(json.contains("fragment_a"));

--- a/rust/crates/cpd-finder/tests/common/mod.rs
+++ b/rust/crates/cpd-finder/tests/common/mod.rs
@@ -1,0 +1,35 @@
+//! Helpers shared by the integration tests in this directory. Each test
+//! binary compiles this module on its own, so unused items are expected.
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Fresh, empty temp directory named `cpd-<prefix>-<suffix>`.
+pub fn temp_dir(prefix: &str, suffix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("cpd-{prefix}-{suffix}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A function long enough to clear the default thresholds when copied.
+pub fn duplicate_js() -> &'static str {
+    r#"function isDuplicate(a, b, c, d, e) {
+    const result = a + b + c;
+    if (result > d) {
+        return result * e;
+    }
+    return result;
+}
+
+function anotherFunc(x, y) {
+    return x + y;
+}
+"#
+}
+
+/// `tests/fixtures/<dir>` of this crate.
+pub fn fixtures(dir: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{dir}"))
+}

--- a/rust/crates/cpd-finder/tests/cross_formats_integration.rs
+++ b/rust/crates/cpd-finder/tests/cross_formats_integration.rs
@@ -5,11 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod common;
+
 fn setup_temp_dir(suffix: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!("cpd-cross-formats-{}", suffix));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-    dir
+    common::temp_dir("cross-formats", suffix)
 }
 
 /// Typed TypeScript source and its untyped JavaScript twin. The bodies are

--- a/rust/crates/cpd-finder/tests/markdown_comment_style_integration.rs
+++ b/rust/crates/cpd-finder/tests/markdown_comment_style_integration.rs
@@ -5,11 +5,9 @@
 
 use cpd_finder::orchestrate::{RunConfig, run};
 use cpd_tokenizer::tokenizer::Mode;
-use std::path::PathBuf;
 
-fn fixtures(dir: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{dir}"))
-}
+mod common;
+use common::fixtures;
 
 #[test]
 fn prose_after_a_glob_is_still_matched() {

--- a/rust/crates/cpd-finder/tests/markdown_prose_integration.rs
+++ b/rust/crates/cpd-finder/tests/markdown_prose_integration.rs
@@ -6,9 +6,8 @@ use cpd_finder::orchestrate::{RunConfig, run};
 use cpd_tokenizer::tokenizer::Mode;
 use std::path::PathBuf;
 
-fn fixtures(dir: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{dir}"))
-}
+mod common;
+use common::fixtures;
 
 fn config(paths: Vec<PathBuf>, formats: Vec<String>) -> RunConfig {
     RunConfig {

--- a/rust/crates/cpd-finder/tests/skip_isolated_integration.rs
+++ b/rust/crates/cpd-finder/tests/skip_isolated_integration.rs
@@ -5,27 +5,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod common;
+
 fn setup_temp_dir(suffix: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!("cpd-skip-isolated-{}", suffix));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-    dir
+    common::temp_dir("skip-isolated", suffix)
 }
 
-fn duplicate_js() -> &'static str {
-    r#"function isDuplicate(a, b, c, d, e) {
-    const result = a + b + c;
-    if (result > d) {
-        return result * e;
-    }
-    return result;
-}
-
-function anotherFunc(x, y) {
-    return x + y;
-}
-"#
-}
+use common::duplicate_js;
 
 fn config(paths: Vec<PathBuf>, skip_isolated: Vec<Vec<PathBuf>>) -> RunConfig {
     RunConfig {

--- a/rust/crates/cpd-finder/tests/skip_isolated_integration.rs
+++ b/rust/crates/cpd-finder/tests/skip_isolated_integration.rs
@@ -13,6 +13,15 @@ fn setup_temp_dir(suffix: &str) -> PathBuf {
 
 use common::duplicate_js;
 
+/// Scan `dir` with `a` and `b` forming one isolation group.
+fn run_isolating(dir: &Path, a: &Path, b: &Path) -> cpd_finder::orchestrate::RunResult {
+    run(&config(
+        vec![dir.to_path_buf()],
+        vec![vec![a.to_path_buf(), b.to_path_buf()]],
+    ))
+    .unwrap()
+}
+
 fn config(paths: Vec<PathBuf>, skip_isolated: Vec<Vec<PathBuf>>) -> RunConfig {
     RunConfig {
         paths,
@@ -40,11 +49,7 @@ fn clones_across_isolated_folders_are_skipped() {
     let dir_b = dir.join("packages/business_b");
     write_pair(&dir_a, &dir_b);
 
-    let result = run(&config(
-        vec![dir.clone()],
-        vec![vec![dir_a.clone(), dir_b.clone()]],
-    ))
-    .unwrap();
+    let result = run_isolating(&dir, &dir_a, &dir_b);
     assert!(
         result.clones.is_empty(),
         "clones across two folders of one isolation group must be skipped"
@@ -62,11 +67,7 @@ fn clones_inside_one_isolated_folder_survive() {
     fs::write(dir_a.join("file_a.js"), duplicate_js()).unwrap();
     fs::write(dir_a.join("file_b.js"), duplicate_js()).unwrap();
 
-    let result = run(&config(
-        vec![dir.clone()],
-        vec![vec![dir_a.clone(), dir_b.clone()]],
-    ))
-    .unwrap();
+    let result = run_isolating(&dir, &dir_a, &dir_b);
     assert!(
         !result.clones.is_empty(),
         "clones inside a single isolated folder must be kept"

--- a/rust/crates/cpd-finder/tests/skip_local_integration.rs
+++ b/rust/crates/cpd-finder/tests/skip_local_integration.rs
@@ -5,26 +5,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod common;
+
 fn setup_temp_dir(suffix: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!("cpd-skip-local-{}", suffix));
-    fs::create_dir_all(&dir).unwrap();
-    dir
+    common::temp_dir("skip-local", suffix)
 }
 
-fn duplicate_js() -> &'static str {
-    r#"function isDuplicate(a, b, c, d, e) {
-    const result = a + b + c;
-    if (result > d) {
-        return result * e;
-    }
-    return result;
-}
-
-function anotherFunc(x, y) {
-    return x + y;
-}
-"#
-}
+use common::duplicate_js;
 
 fn skip_local_config(paths: Vec<PathBuf>) -> RunConfig {
     RunConfig {

--- a/rust/crates/cpd-reporter/src/codeclimate.rs
+++ b/rust/crates/cpd-reporter/src/codeclimate.rs
@@ -155,11 +155,11 @@ impl Reporter for CodeClimateReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::ReportContext;
     use crate::reporter::ReporterOptions;
-    use crate::shared::fixtures::{empty_ctx, make_clone_with_lines, stats_with_pct, tmp_dir};
+    use crate::shared::fixtures::{
+        empty_ctx, make_clone_with_lines, report_to_file, stats_with_pct, tmp_dir,
+    };
     use crate::{assert_empty_report_ok, assert_reporter_name};
-    use std::time::Duration;
 
     assert_reporter_name!(
         codeclimate_reporter_name,
@@ -173,19 +173,14 @@ mod tests {
         threshold: Option<f64>,
         total_pct: f64,
     ) -> Value {
-        let dir = tmp_dir("codeclimate");
-        let mut opts = ReporterOptions::new(dir.clone());
-        opts.threshold = threshold;
-        let reporter = CodeClimateReporter::new(&opts);
-        let stats = stats_with_pct(total_pct, total_pct as u64);
-        let ctx = ReportContext {
-            stats: &stats,
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
-        reporter.report(clones, &ctx, &dir).unwrap();
-        let content = std::fs::read_to_string(dir.join("gl-code-quality-report.json")).unwrap();
+        let content = report_to_file(
+            "codeclimate",
+            "gl-code-quality-report.json",
+            clones,
+            &stats_with_pct(total_pct, total_pct as u64),
+            |opts| opts.threshold = threshold,
+            CodeClimateReporter::new,
+        );
         serde_json::from_str(&content).unwrap()
     }
 

--- a/rust/crates/cpd-reporter/src/console.rs
+++ b/rust/crates/cpd-reporter/src/console.rs
@@ -55,12 +55,7 @@ impl Reporter for ConsoleReporter {
                 )
             );
         });
-        if let Some(summary) = ctx.summary {
-            crate::summary_render::print_summary(summary, &self.style);
-        }
-        if let Some(history) = ctx.history {
-            crate::history_render::print_history(history, &self.style);
-        }
+        crate::shared::print_appendices(ctx, &self.style);
         Ok(())
     }
 }
@@ -81,12 +76,8 @@ mod tests {
     fn non_empty_clones_does_not_panic() {
         let opts = ReporterOptions::new(PathBuf::from("/tmp"));
         let reporter = ConsoleReporter::new(&opts);
-        let ctx = ReportContext {
-            stats: &one_clone_stats(),
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
+        let stats = one_clone_stats();
+        let ctx = ReportContext::new(&stats, Duration::ZERO);
         assert!(
             reporter
                 .report(

--- a/rust/crates/cpd-reporter/src/console_full.rs
+++ b/rust/crates/cpd-reporter/src/console_full.rs
@@ -151,9 +151,7 @@ impl Reporter for ConsoleFullReporter {
                 println!();
             },
         );
-        if let Some(summary) = ctx.summary {
-            crate::summary_render::print_summary(summary, &self.style);
-        }
+        crate::shared::print_appendices(ctx, &self.style);
         Ok(())
     }
 }
@@ -182,25 +180,8 @@ mod tests {
             author: "Alice".to_string(),
             timestamp: 1700000000,
         };
-        let frag = Fragment {
-            source_id: "a.js".to_string(),
-            source_root: None,
-            start: loc.clone(),
-            end: loc,
-            range: [0, 10],
-            blame: Some(blame),
-        };
-        CpdClone {
-            format: "javascript".to_string(),
-            fragment_a: frag.clone(),
-            fragment_b: frag,
-            token_count: 50,
-            is_new: false,
-            kind: Default::default(),
-            similarity: None,
-            similarity_method: None,
-            unmatched_lines: [0, 0],
-        }
+        let frag = Fragment::new("a.js", loc.clone(), loc, [0, 10]).with_blame(blame);
+        CpdClone::exact("javascript", frag.clone(), frag, 50)
     }
 
     fn make_clone_no_blame() -> CpdClone {
@@ -209,37 +190,16 @@ mod tests {
             column: 0,
             offset: 0,
         };
-        let frag = Fragment {
-            source_id: "b.js".to_string(),
-            source_root: None,
-            start: loc.clone(),
-            end: loc,
-            range: [0, 10],
-            blame: None,
-        };
-        CpdClone {
-            format: "javascript".to_string(),
-            fragment_a: frag.clone(),
-            fragment_b: frag,
-            token_count: 30,
-            is_new: false,
-            kind: Default::default(),
-            similarity: None,
-            similarity_method: None,
-            unmatched_lines: [0, 0],
-        }
+        let frag = Fragment::new("b.js", loc.clone(), loc, [0, 10]);
+        CpdClone::exact("javascript", frag.clone(), frag, 30)
     }
 
     #[test]
     fn non_empty_clones_does_not_panic() {
         let opts = ReporterOptions::new(PathBuf::from("/tmp"));
         let reporter = ConsoleFullReporter::new(&opts);
-        let ctx = ReportContext {
-            stats: &one_clone_stats(),
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
+        let stats = one_clone_stats();
+        let ctx = ReportContext::new(&stats, Duration::ZERO);
         let result = reporter.report(&[make_clone_no_blame()], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok());
     }
@@ -248,12 +208,8 @@ mod tests {
         let mut opts = ReporterOptions::new(PathBuf::from("/tmp"));
         opts.blame = blame;
         let reporter = ConsoleFullReporter::new(&opts);
-        let ctx = ReportContext {
-            stats: &one_clone_stats(),
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
+        let stats = one_clone_stats();
+        let ctx = ReportContext::new(&stats, Duration::ZERO);
         let result = reporter.report(&[make_clone_with_blame()], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok());
     }

--- a/rust/crates/cpd-reporter/src/csv_reporter.rs
+++ b/rust/crates/cpd-reporter/src/csv_reporter.rs
@@ -57,19 +57,20 @@ impl Reporter for CsvReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::ReportContext;
-    use crate::shared::fixtures::{one_clone_stats, tmp_dir};
+    use crate::shared::fixtures::{one_clone_stats, report_to_file_timed};
     use std::path::PathBuf;
     use std::time::Duration;
 
     fn run_csv_report() -> String {
-        let dir = tmp_dir("csv");
-        let opts = ReporterOptions::new(dir.clone());
-        let reporter = CsvReporter::new(&opts);
-        let stats = one_clone_stats();
-        let ctx = ReportContext::new(&stats, Duration::from_millis(100));
-        reporter.report(&[], &ctx, &dir).unwrap();
-        std::fs::read_to_string(dir.join("jscpd-report.csv")).unwrap()
+        report_to_file_timed(
+            "csv",
+            "jscpd-report.csv",
+            &[],
+            &one_clone_stats(),
+            Duration::from_millis(100),
+            |_| {},
+            CsvReporter::new,
+        )
     }
 
     #[test]

--- a/rust/crates/cpd-reporter/src/html.rs
+++ b/rust/crates/cpd-reporter/src/html.rs
@@ -157,24 +157,18 @@ impl Reporter for HtmlReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::ReportContext;
-    use crate::reporter::ReporterOptions;
-    use crate::shared::fixtures::{empty_stats, tmp_dir};
+    use crate::shared::fixtures::{empty_stats, report_to_file, tmp_dir};
     use cpd_core::models::{CpdClone, Fragment, Location, Statistics};
-    use std::time::Duration;
 
     fn run_html_report(clones: &[CpdClone], stats: &Statistics) -> String {
-        let dir = tmp_dir("html");
-        let opts = ReporterOptions::new(dir.clone());
-        let reporter = HtmlReporter::new(&opts);
-        let ctx = ReportContext {
+        report_to_file(
+            "html",
+            "jscpd-report.html",
+            clones,
             stats,
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
-        reporter.report(clones, &ctx, &dir).unwrap();
-        std::fs::read_to_string(dir.join("jscpd-report.html")).unwrap()
+            |_| {},
+            HtmlReporter::new,
+        )
     }
 
     #[test]

--- a/rust/crates/cpd-reporter/src/json_reporter.rs
+++ b/rust/crates/cpd-reporter/src/json_reporter.rs
@@ -145,13 +145,11 @@ impl Reporter for JsonReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::ReportContext;
     use crate::reporter::ReporterOptions;
     use crate::shared::fixtures::{
-        empty_ctx, empty_stats, make_clone, make_clone_with_locations, tmp_dir,
+        empty_ctx, empty_stats, make_clone, make_clone_with_locations, report_to_file, tmp_dir,
     };
     use cpd_core::models::{BlameEntry, Location, Statistics};
-    use std::time::Duration;
 
     #[test]
     fn json_output_is_valid_json() {
@@ -167,13 +165,7 @@ mod tests {
     }
 
     fn run_json_report(clones: &[CpdClone], blame: bool) -> String {
-        let dir = tmp_dir("json");
-        let mut opts = ReporterOptions::new(dir.clone());
-        opts.blame = blame;
-        let reporter = JsonReporter::new(&opts);
-        let ctx = empty_ctx();
-        reporter.report(clones, &ctx, &dir).unwrap();
-        std::fs::read_to_string(dir.join("jscpd-report.json")).unwrap()
+        run_json_report_with_stats(clones, &empty_stats(), blame)
     }
 
     #[test]
@@ -225,18 +217,14 @@ mod tests {
     }
 
     fn run_json_report_with_stats(clones: &[CpdClone], stats: &Statistics, blame: bool) -> String {
-        let dir = tmp_dir("json");
-        let mut opts = ReporterOptions::new(dir.clone());
-        opts.blame = blame;
-        let reporter = JsonReporter::new(&opts);
-        let ctx = ReportContext {
+        report_to_file(
+            "json",
+            "jscpd-report.json",
+            clones,
             stats,
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
-        reporter.report(clones, &ctx, &dir).unwrap();
-        std::fs::read_to_string(dir.join("jscpd-report.json")).unwrap()
+            |opts| opts.blame = blame,
+            JsonReporter::new,
+        )
     }
 
     fn parse_json_report(content: &str) -> serde_json::Value {

--- a/rust/crates/cpd-reporter/src/openmetrics.rs
+++ b/rust/crates/cpd-reporter/src/openmetrics.rs
@@ -201,8 +201,7 @@ impl Reporter for OpenMetricsReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::ReportContext;
-    use crate::shared::fixtures::{one_clone_stats, tmp_dir};
+    use crate::shared::fixtures::{one_clone_stats, report_to_file_timed, tmp_dir};
     use crate::{assert_empty_report_ok, assert_reporter_name};
     use std::time::Duration;
 
@@ -214,13 +213,15 @@ mod tests {
     assert_empty_report_ok!(openmetrics_empty_clones_ok, OpenMetricsReporter);
 
     fn run_openmetrics_report() -> String {
-        let dir = tmp_dir("openmetrics");
-        let opts = ReporterOptions::new(dir.clone());
-        let reporter = OpenMetricsReporter::new(&opts);
-        let stats = one_clone_stats();
-        let ctx = ReportContext::new(&stats, Duration::from_millis(1500));
-        reporter.report(&[], &ctx, &dir).unwrap();
-        std::fs::read_to_string(dir.join("jscpd-metrics.txt")).unwrap()
+        report_to_file_timed(
+            "openmetrics",
+            "jscpd-metrics.txt",
+            &[],
+            &one_clone_stats(),
+            Duration::from_millis(1500),
+            |_| {},
+            OpenMetricsReporter::new,
+        )
     }
 
     #[test]

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -336,6 +336,23 @@ mod tests {
         }
     }
 
+    /// Rule ids declared by the run, in order.
+    fn rule_ids(parsed: &serde_json::Value) -> Vec<String> {
+        parsed["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r["id"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    /// `properties` of the first result of a report over `clones`.
+    fn first_result_properties(clones: &[CpdClone]) -> serde_json::Value {
+        let content = run_sarif_report(clones, false);
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        parsed["runs"][0]["results"][0]["properties"].clone()
+    }
+
     fn run_sarif_report(clones: &[CpdClone], blame: bool) -> String {
         let dir = tmp_dir("sarif");
         let mut opts = ReporterOptions::new(dir.clone());
@@ -370,11 +387,10 @@ mod tests {
         let results = parsed["runs"][0]["results"].as_array().unwrap();
         assert_eq!(results[0]["ruleId"], "jscpd/renamed-code");
         assert_eq!(results[1]["ruleId"], "jscpd/duplicate-code");
-        let rules = parsed["runs"][0]["tool"]["driver"]["rules"]
-            .as_array()
-            .unwrap();
-        assert_eq!(rules.len(), 2);
-        assert_eq!(rules[1]["id"], "jscpd/renamed-code");
+        assert_eq!(
+            rule_ids(&parsed),
+            ["jscpd/duplicate-code", "jscpd/renamed-code"]
+        );
     }
 
     #[test]
@@ -389,11 +405,10 @@ mod tests {
         assert_eq!(result["ruleId"], "jscpd/similar-code");
         assert_eq!(result["properties"]["similarity"], 0.9);
         assert_eq!(result["properties"]["similarity_method"], "ast");
-        let rules = parsed["runs"][0]["tool"]["driver"]["rules"]
-            .as_array()
-            .unwrap();
-        assert_eq!(rules.len(), 2);
-        assert_eq!(rules[1]["id"], "jscpd/similar-code");
+        assert_eq!(
+            rule_ids(&parsed),
+            ["jscpd/duplicate-code", "jscpd/similar-code"]
+        );
     }
 
     #[test]
@@ -502,9 +517,7 @@ mod tests {
         clone.fragment_a.source_id = "nonexistent-a.rs".to_string();
         clone.fragment_b.source_id = "nonexistent-b.rs".to_string();
 
-        let content = run_sarif_report(&[clone], false);
-        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-        let properties = &parsed["runs"][0]["results"][0]["properties"];
+        let properties = first_result_properties(&[clone]);
         assert!(
             properties["clone_hash"].is_null(),
             "clone_hash must not be present when snippet is empty"
@@ -513,10 +526,7 @@ mod tests {
 
     #[test]
     fn sarif_result_includes_token_count_property() {
-        let clone = make_clone();
-        let content = run_sarif_report(&[clone], false);
-        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-        let properties = &parsed["runs"][0]["results"][0]["properties"];
+        let properties = first_result_properties(&[make_clone()]);
 
         assert!(
             properties["token_count"].is_number(),

--- a/rust/crates/cpd-reporter/src/sarif.rs
+++ b/rust/crates/cpd-reporter/src/sarif.rs
@@ -281,11 +281,9 @@ impl Reporter for SarifReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::ReportContext;
     use crate::reporter::ReporterOptions;
-    use crate::shared::fixtures::{empty_ctx, stats_with_pct, tmp_dir};
+    use crate::shared::fixtures::{empty_ctx, report_to_file, stats_with_pct, tmp_dir};
     use cpd_core::models::{BlameEntry, CpdClone, Fragment, Location};
-    use std::time::Duration;
 
     fn make_clone() -> CpdClone {
         let loc = Location {
@@ -305,22 +303,9 @@ mod tests {
         };
         CpdClone {
             format: "rust".to_string(),
-            fragment_a: Fragment {
-                source_id: "src/foo.rs".to_string(),
-                source_root: None,
-                start: loc.clone(),
-                end: end.clone(),
-                range: [0, 100],
-                blame: Some(blame),
-            },
-            fragment_b: Fragment {
-                source_id: "src/bar.rs".to_string(),
-                source_root: None,
-                start: loc,
-                end,
-                range: [0, 100],
-                blame: None,
-            },
+            fragment_a: Fragment::new("src/foo.rs", loc.clone(), end.clone(), [0, 100])
+                .with_blame(blame),
+            fragment_b: Fragment::new("src/bar.rs", loc, end, [0, 100]),
             token_count: 80,
             is_new: false,
             kind: Default::default(),
@@ -549,20 +534,17 @@ mod tests {
         threshold: Option<f64>,
         total_pct: f64,
     ) -> String {
-        let dir = tmp_dir("sarif");
-        let mut opts = ReporterOptions::new(dir.clone());
-        opts.sarif_error_tokens = error_tokens;
-        opts.threshold = threshold;
-        let reporter = SarifReporter::new(&opts);
-        let stats = stats_with_pct(total_pct, total_pct as u64);
-        let ctx = ReportContext {
-            stats: &stats,
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
-        reporter.report(clones, &ctx, &dir).unwrap();
-        let content = std::fs::read_to_string(dir.join("jscpd-report.sarif")).unwrap();
+        let content = report_to_file(
+            "sarif",
+            "jscpd-report.sarif",
+            clones,
+            &stats_with_pct(total_pct, total_pct as u64),
+            |opts| {
+                opts.sarif_error_tokens = error_tokens;
+                opts.threshold = threshold;
+            },
+            SarifReporter::new,
+        );
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
         parsed["runs"][0]["results"][0]["level"]
             .as_str()

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -493,6 +493,18 @@ pub fn write_report_file<C: AsRef<[u8]>>(
     Ok(path)
 }
 
+/// Print the opt-in blocks that follow a console-style report: the
+/// `--summary` tables and the `--history` chart. Shared by every reporter that
+/// writes to stdout so the two features render the same everywhere.
+pub fn print_appendices(ctx: &crate::context::ReportContext, style: &Style) {
+    if let Some(summary) = ctx.summary {
+        crate::summary_render::print_summary(summary, style);
+    }
+    if let Some(history) = ctx.history {
+        crate::history_render::print_history(history, style);
+    }
+}
+
 /// Build a minimal Statistics total with the given duplication percentage and duplicated lines.
 pub fn stats_with_pct(pct: f64, lines: u64) -> Statistics {
     Statistics {
@@ -551,6 +563,26 @@ pub mod fixtures {
                 assert_eq!($crate::reporter::Reporter::name(&reporter), $expected);
             }
         };
+    }
+
+    /// Run a file-writing reporter over `clones` with `stats` into a fresh
+    /// temp dir and return the content of `file_name`. `configure` adjusts the
+    /// options before `make` builds the reporter from them.
+    pub fn report_to_file<R: crate::reporter::Reporter>(
+        prefix: &str,
+        file_name: &str,
+        clones: &[CpdClone],
+        stats: &Statistics,
+        configure: impl FnOnce(&mut crate::reporter::ReporterOptions),
+        make: impl FnOnce(&crate::reporter::ReporterOptions) -> R,
+    ) -> String {
+        let dir = tmp_dir(prefix);
+        let mut opts = crate::reporter::ReporterOptions::new(dir.clone());
+        configure(&mut opts);
+        let reporter = make(&opts);
+        let ctx = ReportContext::new(stats, Duration::ZERO);
+        reporter.report(clones, &ctx, &dir).unwrap();
+        std::fs::read_to_string(dir.join(file_name)).unwrap()
     }
 
     /// Leaked empty statistics for tests that need a `ReportContext<'static>`.

--- a/rust/crates/cpd-reporter/src/shared.rs
+++ b/rust/crates/cpd-reporter/src/shared.rs
@@ -576,13 +576,50 @@ pub mod fixtures {
         configure: impl FnOnce(&mut crate::reporter::ReporterOptions),
         make: impl FnOnce(&crate::reporter::ReporterOptions) -> R,
     ) -> String {
+        report_to_file_timed(
+            prefix,
+            file_name,
+            clones,
+            stats,
+            Duration::ZERO,
+            configure,
+            make,
+        )
+    }
+
+    /// [`report_to_file`] with an explicit detection duration, for reporters
+    /// that print the elapsed time.
+    pub fn report_to_file_timed<R: crate::reporter::Reporter>(
+        prefix: &str,
+        file_name: &str,
+        clones: &[CpdClone],
+        stats: &Statistics,
+        duration: Duration,
+        configure: impl FnOnce(&mut crate::reporter::ReporterOptions),
+        make: impl FnOnce(&crate::reporter::ReporterOptions) -> R,
+    ) -> String {
         let dir = tmp_dir(prefix);
         let mut opts = crate::reporter::ReporterOptions::new(dir.clone());
         configure(&mut opts);
         let reporter = make(&opts);
-        let ctx = ReportContext::new(stats, Duration::ZERO);
+        let ctx = ReportContext::new(stats, duration);
         reporter.report(clones, &ctx, &dir).unwrap();
         std::fs::read_to_string(dir.join(file_name)).unwrap()
+    }
+
+    /// Run a stdout reporter over an empty clone list with `stats` and return
+    /// its result, for reporters that write nothing to disk.
+    pub fn report_result<R: crate::reporter::Reporter>(
+        stats: &Statistics,
+        configure: impl FnOnce(&mut crate::reporter::ReporterOptions),
+        make: impl FnOnce(&crate::reporter::ReporterOptions) -> R,
+    ) -> Result<(), crate::reporter::ReporterError> {
+        let dir = PathBuf::from("/tmp");
+        let mut opts = crate::reporter::ReporterOptions::new(dir.clone());
+        configure(&mut opts);
+        let reporter = make(&opts);
+        let ctx = ReportContext::new(stats, Duration::ZERO);
+        reporter.report(&[], &ctx, &dir)
     }
 
     /// Leaked empty statistics for tests that need a `ReportContext<'static>`.

--- a/rust/crates/cpd-reporter/src/silent.rs
+++ b/rust/crates/cpd-reporter/src/silent.rs
@@ -39,12 +39,9 @@ impl Reporter for SilentReporter {
 mod tests {
     use super::*;
     use crate::assert_reporter_name;
-    use crate::context::ReportContext;
-    use crate::reporter::ReporterOptions;
+    use crate::shared::fixtures::{report_result, stats_with_pct};
     use cpd_core::models::{StatRow, Statistics};
     use std::collections::HashMap;
-    use std::path::PathBuf;
-    use std::time::Duration;
 
     fn any_stats() -> Statistics {
         Statistics {
@@ -68,36 +65,16 @@ mod tests {
 
     #[test]
     fn silent_always_ok_with_high_duplication() {
-        let opts = ReporterOptions::new(PathBuf::from("/tmp"));
-        let reporter = SilentReporter::new(&opts);
-        let stats = any_stats();
-        let ctx = ReportContext::new(&stats, Duration::ZERO);
-        let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
-        assert!(result.is_ok());
+        assert!(report_result(&any_stats(), |_| {}, SilentReporter::new).is_ok());
     }
 
     #[test]
     fn silent_prints_summary() {
-        let mut opts = ReporterOptions::new(PathBuf::from("/tmp"));
-        opts.no_colors = true;
-        let reporter = SilentReporter::new(&opts);
-        let stats = Statistics {
-            total: StatRow {
-                lines: 100,
-                tokens: 500,
-                sources: 5,
-                clones: 2,
-                duplicated_lines: 20,
-                duplicated_tokens: 100,
-                percentage: 20.0,
-                percentage_tokens: 20.0,
-                ..StatRow::default()
-            },
-            formats: HashMap::new(),
-            detection_date: "2026-01-01T00:00:00Z".to_string(),
-        };
-        let ctx = ReportContext::new(&stats, Duration::ZERO);
-        let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
+        let result = report_result(
+            &stats_with_pct(20.0, 20),
+            |opts| opts.no_colors = true,
+            SilentReporter::new,
+        );
         assert!(result.is_ok());
     }
 }

--- a/rust/crates/cpd-reporter/src/silent.rs
+++ b/rust/crates/cpd-reporter/src/silent.rs
@@ -70,12 +70,8 @@ mod tests {
     fn silent_always_ok_with_high_duplication() {
         let opts = ReporterOptions::new(PathBuf::from("/tmp"));
         let reporter = SilentReporter::new(&opts);
-        let ctx = ReportContext {
-            stats: &any_stats(),
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
+        let stats = any_stats();
+        let ctx = ReportContext::new(&stats, Duration::ZERO);
         let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok());
     }
@@ -100,12 +96,7 @@ mod tests {
             formats: HashMap::new(),
             detection_date: "2026-01-01T00:00:00Z".to_string(),
         };
-        let ctx = ReportContext {
-            stats: &stats,
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
+        let ctx = ReportContext::new(&stats, Duration::ZERO);
         let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
         assert!(result.is_ok());
     }

--- a/rust/crates/cpd-reporter/src/threshold.rs
+++ b/rust/crates/cpd-reporter/src/threshold.rs
@@ -41,6 +41,7 @@ impl Reporter for ThresholdReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shared::fixtures::report_result;
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -92,30 +93,14 @@ mod tests {
 
     #[test]
     fn threshold_ok_with_no_threshold_set() {
-        let opts = ReporterOptions::new(PathBuf::from("/tmp"));
-        let reporter = ThresholdReporter::new(&opts);
-        let ctx = ReportContext {
-            stats: &stats_with_pct(99.9, 99),
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
-        let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
+        let result = report_result(&stats_with_pct(99.9, 99), |_| {}, ThresholdReporter::new);
         assert!(result.is_ok(), "no threshold must always return Ok");
     }
 
     #[test]
     fn silent_always_ok() {
         use crate::silent::SilentReporter;
-        let opts = ReporterOptions::new(PathBuf::from("/tmp"));
-        let reporter = SilentReporter::new(&opts);
-        let ctx = ReportContext {
-            stats: &stats_with_pct(100.0, 100),
-            duration: Duration::ZERO,
-            summary: None,
-            history: None,
-        };
-        let result = reporter.report(&[], &ctx, &PathBuf::from("/tmp"));
+        let result = report_result(&stats_with_pct(100.0, 100), |_| {}, SilentReporter::new);
         assert!(result.is_ok(), "silent reporter must always return Ok");
     }
 }

--- a/rust/crates/cpd-reporter/tests/blame_integration.rs
+++ b/rust/crates/cpd-reporter/tests/blame_integration.rs
@@ -43,31 +43,13 @@ fn make_clone_with_blame() -> CpdClone {
         author: "Bob Smith".to_string(),
         timestamp: 1700000000,
     };
-    CpdClone {
-        format: "javascript".to_string(),
-        fragment_a: Fragment {
-            source_id: "src/foo.js".to_string(),
-            source_root: None,
-            start: loc.clone(),
-            end: end_loc.clone(),
-            range: [0, 100],
-            blame: Some(blame.clone()),
-        },
-        fragment_b: Fragment {
-            source_id: "src/bar.js".to_string(),
-            source_root: None,
-            start: loc,
-            end: end_loc,
-            range: [0, 100],
-            blame: Some(blame),
-        },
-        token_count: 50,
-        is_new: false,
-        kind: Default::default(),
-        similarity: None,
-        similarity_method: None,
-        unmatched_lines: [0, 0],
-    }
+    CpdClone::exact(
+        "javascript",
+        Fragment::new("src/foo.js", loc.clone(), end_loc.clone(), [0, 100])
+            .with_blame(blame.clone()),
+        Fragment::new("src/bar.js", loc, end_loc, [0, 100]).with_blame(blame),
+        50,
+    )
 }
 
 fn make_clone_no_blame() -> CpdClone {
@@ -76,31 +58,12 @@ fn make_clone_no_blame() -> CpdClone {
         column: 0,
         offset: 0,
     };
-    CpdClone {
-        format: "javascript".to_string(),
-        fragment_a: Fragment {
-            source_id: "a.js".to_string(),
-            source_root: None,
-            start: loc.clone(),
-            end: loc.clone(),
-            range: [0, 10],
-            blame: None,
-        },
-        fragment_b: Fragment {
-            source_id: "b.js".to_string(),
-            source_root: None,
-            start: loc.clone(),
-            end: loc,
-            range: [0, 10],
-            blame: None,
-        },
-        token_count: 10,
-        is_new: false,
-        kind: Default::default(),
-        similarity: None,
-        similarity_method: None,
-        unmatched_lines: [0, 0],
-    }
+    CpdClone::exact(
+        "javascript",
+        Fragment::new("a.js", loc.clone(), loc.clone(), [0, 10]),
+        Fragment::new("b.js", loc.clone(), loc, [0, 10]),
+        10,
+    )
 }
 
 fn run_blame_reporter(
@@ -114,12 +77,8 @@ fn run_blame_reporter(
     opts.blame = blame;
     let reporter =
         create_reporter(name, &opts).unwrap_or_else(|| panic!("{} reporter must exist", name));
-    let ctx = ReportContext {
-        stats: &make_stats(),
-        duration: Duration::ZERO,
-        summary: None,
-        history: None,
-    };
+    let stats = make_stats();
+    let ctx = ReportContext::new(&stats, Duration::ZERO);
     reporter.report(&[clone], &ctx, &dir).unwrap();
     (dir, reporter)
 }

--- a/rust/crates/cpd-reporter/tests/reporters_integration.rs
+++ b/rust/crates/cpd-reporter/tests/reporters_integration.rs
@@ -122,47 +122,15 @@ fn make_test_clone_with_real_files(dir: &Path) -> CpdClone {
     std::fs::write(&file_a, &code).expect("write a.js");
     std::fs::write(&file_b, &code).expect("write b.js");
 
-    CpdClone {
-        format: "javascript".to_string(),
-        fragment_a: Fragment {
-            source_id: file_a.to_string_lossy().into_owned(),
-            source_root: None,
-            start: Location {
-                line: 1,
-                column: 0,
-                offset: 0,
-            },
-            end: Location {
-                line: 4,
-                column: 1,
-                offset: code.len() as u32,
-            },
-            range: [0, 100],
-            blame: None,
-        },
-        fragment_b: Fragment {
-            source_id: file_b.to_string_lossy().into_owned(),
-            source_root: None,
-            start: Location {
-                line: 1,
-                column: 0,
-                offset: 0,
-            },
-            end: Location {
-                line: 4,
-                column: 1,
-                offset: code.len() as u32,
-            },
-            range: [0, 100],
-            blame: None,
-        },
-        token_count: 50,
-        is_new: false,
-        kind: Default::default(),
-        similarity: None,
-        similarity_method: None,
-        unmatched_lines: [0, 0],
-    }
+    let fragment = |file: &Path| {
+        Fragment::new(
+            file.to_string_lossy().into_owned(),
+            Location::new(1, 0, 0),
+            Location::new(4, 1, code.len() as u32),
+            [0, 100],
+        )
+    };
+    CpdClone::exact("javascript", fragment(&file_a), fragment(&file_b), 50)
 }
 
 fn assert_file_exists(output_dir: &Path, filename: &str) {

--- a/rust/crates/cpd-tokenizer/src/embedded.rs
+++ b/rust/crates/cpd-tokenizer/src/embedded.rs
@@ -1,3 +1,43 @@
+use cpd_core::models::Token;
+
+use crate::markdown::tokens_to_detection;
+use crate::tokenizer::{Mode, TokenMap, TokenizeOptions};
+
+/// Detection tokens for a container file (Razor, Vue, Svelte, Astro) that
+/// holds no embedded blocks: the whole source is plain HTML, one map or none.
+pub(crate) fn html_only_maps(source: &str, options: &TokenizeOptions) -> Vec<TokenMap> {
+    let tokens = crate::generic::tokenize_generic(source, "html");
+    let detection = tokens_to_detection(tokens, options);
+    if detection.is_empty() {
+        Vec::new()
+    } else {
+        vec![TokenMap {
+            format: "html".to_string(),
+            tokens: detection,
+        }]
+    }
+}
+
+/// Display-path tokens for embedded blocks: each `(format, content,
+/// start_line)` block is tokenized as its own format with line numbers
+/// shifted to the block's position in the host file.
+pub(crate) fn tokenize_blocks_shifted<'a>(
+    blocks: impl IntoIterator<Item = (&'a str, &'a str, u32)>,
+    mode: Mode,
+) -> Vec<Token> {
+    let mut all_tokens = Vec::new();
+    for (format, content, start_line) in blocks {
+        let mut block_tokens = crate::tokenizer::tokenize(format, content, mode);
+        let line_offset = start_line.saturating_sub(1);
+        for token in &mut block_tokens {
+            token.start.line += line_offset;
+            token.end.line += line_offset;
+        }
+        all_tokens.extend(block_tokens);
+    }
+    all_tokens
+}
+
 pub fn blank_ranges_preserve_newlines(source: &str, ranges: &[[usize; 2]]) -> String {
     let mut src_bytes = source.as_bytes().to_vec();
     let mut sorted: Vec<[usize; 2]> = ranges.to_vec();

--- a/rust/crates/cpd-tokenizer/src/razor.rs
+++ b/rust/crates/cpd-tokenizer/src/razor.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use cpd_core::models::{DetectionToken, Token};
 
-use crate::embedded::blank_ranges_preserve_newlines;
+use crate::embedded::{blank_ranges_preserve_newlines, html_only_maps, tokenize_blocks_shifted};
 use crate::line_index::LineIndex;
 use crate::markdown::{offset_detection_tokens, tokens_to_detection};
 use crate::tokenizer::{Mode, TokenMap, TokenizeOptions, tokenize_format_to_detection};
@@ -147,16 +147,7 @@ pub fn tokenize_razor_maps(source: &str, options: &TokenizeOptions) -> Vec<Token
 
     if blocks.is_empty() {
         // Pure HTML, no code blocks or @ directives
-        let tokens = crate::generic::tokenize_generic(source, "html");
-        let detection = tokens_to_detection(tokens, options);
-        return if detection.is_empty() {
-            Vec::new()
-        } else {
-            vec![TokenMap {
-                format: "html".to_string(),
-                tokens: detection,
-            }]
-        };
+        return html_only_maps(source, options);
     }
 
     let blank_ranges: Vec<[usize; 2]> = blocks
@@ -217,16 +208,12 @@ pub fn tokenize_razor(source: &str, mode: Mode) -> Vec<Token> {
     // Tokenize HTML skeleton with Razor code blanked out to avoid duplicate code tokens.
     all_tokens.extend(crate::generic::tokenize_generic(&sanitized, "html"));
 
-    for block in &blocks {
-        let mut block_tokens = crate::tokenizer::tokenize("csharp", &block.content, mode);
-
-        let line_offset = block.start_line.saturating_sub(1);
-        for token in &mut block_tokens {
-            token.start.line += line_offset;
-            token.end.line += line_offset;
-        }
-        all_tokens.extend(block_tokens);
-    }
+    all_tokens.extend(tokenize_blocks_shifted(
+        blocks
+            .iter()
+            .map(|b| ("csharp", b.content.as_str(), b.start_line)),
+        mode,
+    ));
 
     all_tokens
 }

--- a/rust/crates/cpd-tokenizer/src/sfc.rs
+++ b/rust/crates/cpd-tokenizer/src/sfc.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use cpd_core::models::{DetectionToken, Token};
 
-use crate::embedded::blank_ranges_preserve_newlines;
+use crate::embedded::{blank_ranges_preserve_newlines, html_only_maps, tokenize_blocks_shifted};
 use crate::line_index::LineIndex;
 use crate::markdown::{offset_detection_tokens, tokens_to_detection};
 use crate::tokenizer::{Mode, TokenMap, TokenizeOptions, tokenize_format_to_detection};
@@ -36,16 +36,7 @@ pub fn tokenize_sfc_maps(
 
     let blocks = find_sfc_blocks(source, file_format);
     if blocks.is_empty() {
-        let tokens = crate::generic::tokenize_generic(source, "html");
-        let detection = tokens_to_detection(tokens, options);
-        return if detection.is_empty() {
-            Vec::new()
-        } else {
-            vec![TokenMap {
-                format: "html".to_string(),
-                tokens: detection,
-            }]
-        };
+        return html_only_maps(source, options);
     }
 
     let blank_ranges: Vec<[usize; 2]> = blocks
@@ -342,20 +333,12 @@ fn find_display_block(
 
 pub fn tokenize_sfc(source: &str, file_format: &str, mode: Mode) -> Vec<Token> {
     let blocks = extract_blocks(source, file_format);
-    let mut all_tokens = Vec::new();
-
-    for block in &blocks {
-        let mut block_tokens =
-            crate::tokenizer::tokenize(&block.block_format, &block.content, mode);
-        let line_offset = block.start_line.saturating_sub(1);
-        for token in &mut block_tokens {
-            token.start.line += line_offset;
-            token.end.line += line_offset;
-        }
-        all_tokens.extend(block_tokens);
-    }
-
-    all_tokens
+    tokenize_blocks_shifted(
+        blocks
+            .iter()
+            .map(|b| (b.block_format.as_str(), b.content.as_str(), b.start_line)),
+        mode,
+    )
 }
 
 #[cfg(test)]

--- a/rust/crates/cpd/src/cli.rs
+++ b/rust/crates/cpd/src/cli.rs
@@ -1943,13 +1943,16 @@ mod tests {
         }
     }
 
+    /// `--cross-formats javascript,typescript` on the CLI, merged with `config`.
+    fn cross_formats_with(config: ConfigFile) -> Vec<Vec<String>> {
+        let cli = Cli::parse_from(["cpd", "--cross-formats", "javascript,typescript", "."]);
+        crate::options::Options::from_cli_and_config(&cli, &config).cross_formats
+    }
+
     #[test]
     fn cross_formats_propagates_to_options() {
-        let cli = Cli::parse_from(["cpd", "--cross-formats", "javascript,typescript", "."]);
-        let config = ConfigFile::default();
-        let opts = crate::options::Options::from_cli_and_config(&cli, &config);
         assert_eq!(
-            opts.cross_formats,
+            cross_formats_with(ConfigFile::default()),
             vec![vec!["javascript".to_string(), "typescript".to_string()]]
         );
     }
@@ -1960,10 +1963,8 @@ mod tests {
             cross_formats: Some("css,scss".to_string()),
             ..Default::default()
         };
-        let cli = Cli::parse_from(["cpd", "--cross-formats", "javascript,typescript", "."]);
-        let opts = crate::options::Options::from_cli_and_config(&cli, &config);
         assert_eq!(
-            opts.cross_formats,
+            cross_formats_with(config),
             vec![vec!["javascript".to_string(), "typescript".to_string()]]
         );
     }

--- a/rust/crates/cpd/src/mcp.rs
+++ b/rust/crates/cpd/src/mcp.rs
@@ -749,15 +749,21 @@ pub fn serve(config: RunConfig) -> i32 {
 mod tests {
     use super::*;
 
-    /// Build a server over a temp dir with two duplicate JS files.
-    fn test_server() -> McpServer {
+    /// Fresh temp dir unique across parallel tests.
+    fn scratch_dir(prefix: &str) -> std::path::PathBuf {
         static COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
         let dir = std::env::temp_dir().join(format!(
-            "cpd-mcp-test-{}-{}",
+            "{prefix}-{}-{}",
             std::process::id(),
             COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
         ));
         std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Build a server over a temp dir with two duplicate JS files.
+    fn test_server() -> McpServer {
+        let dir = scratch_dir("cpd-mcp-test");
         let body = "function add(a, b) {\n  const sum = a + b;\n  console.log('sum', sum);\n  return sum;\n}\nfunction sub(a, b) {\n  const d = a - b;\n  console.log('diff', d);\n  return d;\n}\n";
         std::fs::write(dir.join("one.js"), body).unwrap();
         std::fs::write(dir.join("two.js"), body).unwrap();
@@ -942,13 +948,7 @@ mod tests {
     fn clone_lists_are_sorted_biggest_first() {
         // Two clone pairs of different sizes: the big pair must come first
         // regardless of path order (small files sort earlier alphabetically).
-        static COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-        let dir = std::env::temp_dir().join(format!(
-            "cpd-mcp-sort-{}-{}",
-            std::process::id(),
-            COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = scratch_dir("cpd-mcp-sort");
         let small =
             "function s(a, b) {\n  const r = a * b + a;\n  console.log('r', r);\n  return r;\n}\n";
         let big = "function big(a, b, c) {\n  const x = a + b * c;\n  const y = x * x - a;\n  const z = y + b - c;\n  console.log('x', x);\n  console.log('y', y);\n  console.log('z', z);\n  return x + y + z;\n}\n";

--- a/rust/crates/cpd/tests/common/mod.rs
+++ b/rust/crates/cpd/tests/common/mod.rs
@@ -1,0 +1,9 @@
+//! Fixtures shared by the integration test binaries of this crate. Each
+//! binary compiles this module on its own, so unused items are expected.
+#![allow(dead_code)]
+
+/// A function and a structurally similar rewrite of it (other names, one
+/// extra statement, one extra call): no exact clone, but `--similarity 0.7`
+/// matches them. Used by the CLI and the MCP tests.
+pub const INVOICE_JS: &str = "export function buildInvoice(order, customer, taxRate) {\n  const lines = [];\n  for (const item of order.items) {\n    const net = item.price * item.quantity;\n    lines.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = lines.reduce((sum, line) => sum + line.net, 0);\n  const tax = Math.round(subtotal * taxRate * 100) / 100;\n  return { number: nextInvoiceNumber(), customer: customer.id, lines, subtotal, tax, total: subtotal + tax };\n}\n";
+pub const CREDIT_NOTE_JS: &str = "export function buildCreditNote(refund, account, vatRate) {\n  const entries = [];\n  for (const item of refund.items) {\n    if (!item.refundable) continue;\n    const net = item.price * item.quantity;\n    entries.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = entries.reduce((sum, entry) => sum + entry.net, 0);\n  const vat = Math.round(subtotal * vatRate * 100) / 100;\n  logger.info('credit note', { account: account.id, subtotal });\n  return { number: nextCreditNoteNumber(), account: account.id, entries, subtotal, vat, total: subtotal + vat };\n}\n";

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -1,5 +1,7 @@
 // rust/crates/cpd/tests/integration.rs
 
+mod common;
+
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Output;
@@ -691,16 +693,8 @@ fn similarity_reports_structurally_similar_functions_only_when_set() {
     let out = std::env::temp_dir().join(format!("cpd-similarity-report-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        dir.join("invoice.js"),
-        "export function buildInvoice(order, customer, taxRate) {\n  const lines = [];\n  for (const item of order.items) {\n    const net = item.price * item.quantity;\n    lines.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = lines.reduce((sum, line) => sum + line.net, 0);\n  const tax = Math.round(subtotal * taxRate * 100) / 100;\n  return { number: nextInvoiceNumber(), customer: customer.id, lines, subtotal, tax, total: subtotal + tax };\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("credit-note.js"),
-        "export function buildCreditNote(refund, account, vatRate) {\n  const entries = [];\n  for (const item of refund.items) {\n    if (!item.refundable) continue;\n    const net = item.price * item.quantity;\n    entries.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = entries.reduce((sum, entry) => sum + entry.net, 0);\n  const vat = Math.round(subtotal * vatRate * 100) / 100;\n  logger.info('credit note', { account: account.id, subtotal });\n  return { number: nextCreditNoteNumber(), account: account.id, entries, subtotal, vat, total: subtotal + vat };\n}\n",
-    )
-    .unwrap();
+    std::fs::write(dir.join("invoice.js"), common::INVOICE_JS).unwrap();
+    std::fs::write(dir.join("credit-note.js"), common::CREDIT_NOTE_JS).unwrap();
     let scan = |extra: &[&str]| {
         let (json, stderr) = scan_json(&dir, &out, extra);
         let dups = json["duplicates"]

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -103,15 +103,115 @@ fn run_cpd_in_dir(dir: &std::path::Path) -> Option<Output> {
     )
 }
 
+/// Two files sharing one small function: the smallest clone that clears
+/// `--min-tokens 10`, used by the reporter and path-handling tests below.
+const GREET_DUP: &str = "function greet(name) {\n  const message = \"Hello, \" + name + \"!\";\n  console.log(message);\n  console.log(\"Welcome to the system\");\n  console.log(\"Have a nice day now\");\n  return message;\n}\n";
+
+fn write_greet_pair(dir: &std::path::Path) {
+    std::fs::write(dir.join("a.js"), GREET_DUP).expect("write a.js");
+    std::fs::write(dir.join("b.js"), GREET_DUP).expect("write b.js");
+}
+
+/// Fresh temp root named after `name` with `subdir` (or the root itself when
+/// empty) holding the greet pair. Returns (root, scan dir).
+fn greet_root(name: &str, subdir: &str) -> (PathBuf, PathBuf) {
+    let root = std::env::temp_dir().join(format!("cpd-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let dir = if subdir.is_empty() {
+        root.clone()
+    } else {
+        root.join(subdir)
+    };
+    std::fs::create_dir_all(&dir).expect("create scan dir");
+    write_greet_pair(&dir);
+    (root, dir)
+}
+
+/// Run cpd with `args` from `cwd` and assert it exited successfully.
+fn run_ok_in(cwd: &std::path::Path, args: &[&str]) -> Output {
+    let output = Command::new(cpd_bin())
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("failed to run cpd");
+    assert!(
+        output.status.success(),
+        "cpd must succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn read_json(path: &std::path::Path) -> serde_json::Value {
+    let content = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("{} must exist: {e}", path.display()));
+    serde_json::from_str(&content).expect("valid JSON")
+}
+
+/// Scan `dir` with `args` plus the json+silent reporters writing to `out`;
+/// returns the parsed report and stderr.
+fn scan_json(
+    dir: &std::path::Path,
+    out: &std::path::Path,
+    args: &[&str],
+) -> (serde_json::Value, String) {
+    let output = Command::new(cpd_bin())
+        .args(args)
+        .args([
+            "--reporters",
+            "json,silent",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .arg(dir)
+        .output()
+        .expect("failed to run cpd");
+    assert!(output.status.success(), "scan failed: {}", output.status);
+    (
+        read_json(&out.join("jscpd-report.json")),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+/// Run cpd on a scratch directory with `args`, delete the directory, and
+/// return the exit code with stderr.
+fn run_scratch(dir: &std::path::Path, args: &[&str]) -> (Option<i32>, String) {
+    let mut full: Vec<std::ffi::OsString> = vec![dir.as_os_str().to_owned()];
+    full.extend(args.iter().map(std::ffi::OsString::from));
+    let output = run_cpd(full).expect("cpd binary must exist");
+    std::fs::remove_dir_all(dir).ok();
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+/// Temp dir named `name` holding the given (relative path, content) files.
+fn config_dir(name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("cpd-{name}-{}", std::process::id()));
+    for (rel, content) in files {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+    dir
+}
+
+/// Run cpd inside `dir` (config auto-discovery), delete it, return stderr.
+fn stderr_in_dir(dir: &std::path::Path) -> String {
+    let output = run_cpd_in_dir(dir).expect("cpd binary must exist");
+    std::fs::remove_dir_all(dir).ok();
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
 #[test]
 fn dot_config_subfolder_is_discovered() {
-    let dir = std::env::temp_dir().join(format!("cpd-dotconfig-{}", std::process::id()));
-    std::fs::create_dir_all(dir.join(".config")).unwrap();
-    std::fs::write(dir.join(".config/jscpd.json"), r#"{"minTokens": 42}"#).unwrap();
+    let dir = config_dir(
+        "dotconfig",
+        &[(".config/jscpd.json", r#"{"minTokens": 42}"#)],
+    );
 
-    let output = run_cpd_in_dir(&dir).expect("cpd binary must exist");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    std::fs::remove_dir_all(&dir).ok();
+    let stderr = stderr_in_dir(&dir);
     assert!(
         stderr.contains("Using config from .config/jscpd.json"),
         "must discover .config/jscpd.json, got stderr: {}",
@@ -121,14 +221,15 @@ fn dot_config_subfolder_is_discovered() {
 
 #[test]
 fn root_config_wins_over_dot_config_subfolder() {
-    let dir = std::env::temp_dir().join(format!("cpd-dotconfig-prec-{}", std::process::id()));
-    std::fs::create_dir_all(dir.join(".config")).unwrap();
-    std::fs::write(dir.join(".jscpd.json"), r#"{"minTokens": 42}"#).unwrap();
-    std::fs::write(dir.join(".config/jscpd.json"), r#"{"minTokens": 99}"#).unwrap();
+    let dir = config_dir(
+        "dotconfig-prec",
+        &[
+            (".jscpd.json", r#"{"minTokens": 42}"#),
+            (".config/jscpd.json", r#"{"minTokens": 99}"#),
+        ],
+    );
 
-    let output = run_cpd_in_dir(&dir).expect("cpd binary must exist");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    std::fs::remove_dir_all(&dir).ok();
+    let stderr = stderr_in_dir(&dir);
     assert!(
         stderr.contains("Using config from .jscpd.json"),
         "root .jscpd.json must take precedence, got stderr: {}",
@@ -471,9 +572,9 @@ fn config_ignore_pattern_without_glob_chars_is_applied() {
 /// while an exact copy in the same run stays `kind: exact`.
 #[test]
 fn ignore_identifiers_reports_renamed_and_exact_kinds() {
-    let Some(bin) = maybe_bin() else {
+    if maybe_bin().is_none() {
         return;
-    };
+    }
     let dir = std::env::temp_dir().join(format!("cpd-type2-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -490,24 +591,11 @@ fn ignore_identifiers_reports_renamed_and_exact_kinds() {
     // would show up as exact clones.
     let out = std::env::temp_dir().join(format!("cpd-type2-report-{}", std::process::id()));
     let scan = |extra: &[&str]| {
-        let output = Command::new(&bin)
-            .args([
-                "--min-tokens",
-                "20",
-                "--min-lines",
-                "3",
-                "--reporters",
-                "json,silent",
-            ])
-            .args(["--output", out.to_str().unwrap()])
-            .args(extra)
-            .arg(&dir)
-            .output()
-            .expect("failed to run cpd");
-        assert!(output.status.success(), "scan failed: {}", output.status);
-        let json: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(out.join("jscpd-report.json")).unwrap())
-                .unwrap();
+        let (json, _) = scan_json(
+            &dir,
+            &out,
+            &[&["--min-tokens", "20", "--min-lines", "3"][..], extra].concat(),
+        );
         let mut kinds: Vec<String> = json["duplicates"]
             .as_array()
             .unwrap()
@@ -537,9 +625,9 @@ fn ignore_identifiers_reports_renamed_and_exact_kinds() {
 /// with `--max-gap-lines 1`.
 #[test]
 fn max_gap_lines_merges_near_miss_clones_only_when_set() {
-    let Some(bin) = maybe_bin() else {
+    if maybe_bin().is_none() {
         return;
-    };
+    }
     let dir = std::env::temp_dir().join(format!("cpd-type3-{}", std::process::id()));
     let out = std::env::temp_dir().join(format!("cpd-type3-report-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
@@ -553,24 +641,11 @@ fn max_gap_lines_merges_near_miss_clones_only_when_set() {
     )
     .unwrap();
     let scan = |extra: &[&str]| {
-        let output = Command::new(&bin)
-            .args([
-                "--min-tokens",
-                "15",
-                "--min-lines",
-                "2",
-                "--reporters",
-                "json,silent",
-            ])
-            .args(["--output", out.to_str().unwrap()])
-            .args(extra)
-            .arg(&dir)
-            .output()
-            .expect("failed to run cpd");
-        assert!(output.status.success(), "scan failed: {}", output.status);
-        let json: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(out.join("jscpd-report.json")).unwrap())
-                .unwrap();
+        let (json, _) = scan_json(
+            &dir,
+            &out,
+            &[&["--min-tokens", "15", "--min-lines", "2"][..], extra].concat(),
+        );
         json["duplicates"]
             .as_array()
             .unwrap()
@@ -609,9 +684,9 @@ fn max_gap_lines_merges_near_miss_clones_only_when_set() {
 /// merging, and appears as one `similar` clone only with `--similarity`.
 #[test]
 fn similarity_reports_structurally_similar_functions_only_when_set() {
-    let Some(bin) = maybe_bin() else {
+    if maybe_bin().is_none() {
         return;
-    };
+    }
     let dir = std::env::temp_dir().join(format!("cpd-similarity-{}", std::process::id()));
     let out = std::env::temp_dir().join(format!("cpd-similarity-report-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
@@ -627,21 +702,7 @@ fn similarity_reports_structurally_similar_functions_only_when_set() {
     )
     .unwrap();
     let scan = |extra: &[&str]| {
-        let output = Command::new(&bin)
-            .args([
-                "--reporters",
-                "json,silent",
-                "--output",
-                out.to_str().unwrap(),
-            ])
-            .args(extra)
-            .arg(&dir)
-            .output()
-            .expect("failed to run cpd");
-        assert!(output.status.success(), "scan failed: {}", output.status);
-        let json: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(out.join("jscpd-report.json")).unwrap())
-                .unwrap();
+        let (json, stderr) = scan_json(&dir, &out, extra);
         let dups = json["duplicates"]
             .as_array()
             .unwrap()
@@ -653,7 +714,7 @@ fn similarity_reports_structurally_similar_functions_only_when_set() {
                 )
             })
             .collect::<Vec<_>>();
-        (dups, String::from_utf8_lossy(&output.stderr).to_string())
+        (dups, stderr)
     };
 
     assert!(scan(&[]).0.is_empty(), "no exact clone");
@@ -754,29 +815,17 @@ fn js_file_with_parse_diagnostics_still_matches_other_files() {
 
 #[test]
 fn report_snippets_populated_when_scan_root_differs_from_cwd() {
-    let bin = match maybe_bin() {
-        Some(b) => b,
-        None => return,
-    };
+    if maybe_bin().is_none() {
+        return;
+    }
 
-    let root = std::env::temp_dir().join(format!("cpd-snippet-test-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    let pkg = root.join("pkg");
-    std::fs::create_dir_all(&pkg).expect("create pkg dir");
-
-    let dup = "function greet(name) {\n  \
-        const message = \"Hello, \" + name + \"!\";\n  \
-        console.log(message);\n  \
-        console.log(\"Welcome to the system\");\n  \
-        console.log(\"Have a nice day now\");\n  \
-        return message;\n}\n";
-    std::fs::write(pkg.join("a.js"), dup).expect("write a.js");
-    std::fs::write(pkg.join("b.js"), dup).expect("write b.js");
+    let (root, _) = greet_root("snippet-test", "pkg");
 
     let out = root.join("report");
 
-    let output = Command::new(&bin)
-        .args([
+    run_ok_in(
+        &root,
+        &[
             "pkg",
             "--min-tokens",
             "10",
@@ -784,14 +833,7 @@ fn report_snippets_populated_when_scan_root_differs_from_cwd() {
             "json,html",
             "--output",
             out.to_str().unwrap(),
-        ])
-        .current_dir(&root)
-        .output()
-        .expect("failed to run cpd");
-    assert!(
-        output.status.success(),
-        "cpd must succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        ],
     );
 
     let marker = "Welcome to the system";
@@ -824,29 +866,17 @@ fn report_snippets_populated_when_scan_root_differs_from_cwd() {
 
 #[test]
 fn sarif_includes_original_uri_base_ids() {
-    let bin = match maybe_bin() {
-        Some(b) => b,
-        None => return,
-    };
+    if maybe_bin().is_none() {
+        return;
+    }
 
-    let root = std::env::temp_dir().join(format!("cpd-sarif-root-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    let pkg = root.join("pkg");
-    std::fs::create_dir_all(&pkg).expect("create pkg dir");
-
-    let dup = "function greet(name) {\n  \
-        const message = \"Hello, \" + name + \"!\";\n  \
-        console.log(message);\n  \
-        console.log(\"Welcome to the system\");\n  \
-        console.log(\"Have a nice day now\");\n  \
-        return message;\n}\n";
-    std::fs::write(pkg.join("a.js"), dup).expect("write a.js");
-    std::fs::write(pkg.join("b.js"), dup).expect("write b.js");
+    let (root, _) = greet_root("sarif-root", "pkg");
 
     let out = root.join("report");
 
-    let output = Command::new(&bin)
-        .args([
+    run_ok_in(
+        &root,
+        &[
             "pkg",
             "--min-tokens",
             "10",
@@ -854,18 +884,10 @@ fn sarif_includes_original_uri_base_ids() {
             "sarif",
             "--output",
             out.to_str().unwrap(),
-        ])
-        .current_dir(&root)
-        .output()
-        .expect("failed to run cpd");
-    assert!(
-        output.status.success(),
-        "cpd must succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        ],
     );
 
-    let sarif = std::fs::read_to_string(out.join("jscpd-report.sarif")).expect("sarif exists");
-    let parsed: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+    let parsed = read_json(&out.join("jscpd-report.sarif"));
     let run = &parsed["runs"][0];
 
     assert!(
@@ -895,28 +917,16 @@ fn sarif_includes_original_uri_base_ids() {
 
 #[test]
 fn codeclimate_reporter_writes_code_quality_report() {
-    let bin = match maybe_bin() {
-        Some(b) => b,
-        None => return,
-    };
+    if maybe_bin().is_none() {
+        return;
+    }
 
-    let root = std::env::temp_dir().join(format!("cpd-codeclimate-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    let src = root.join("src");
-    std::fs::create_dir_all(&src).expect("create src dir");
-
-    let dup = "function greet(name) {\n  \
-        const message = \"Hello, \" + name + \"!\";\n  \
-        console.log(message);\n  \
-        console.log(\"Welcome to the system\");\n  \
-        console.log(\"Have a nice day now\");\n  \
-        return message;\n}\n";
-    std::fs::write(src.join("a.js"), dup).expect("write a.js");
-    std::fs::write(src.join("b.js"), dup).expect("write b.js");
+    let (root, _) = greet_root("codeclimate", "src");
 
     let out = root.join("report");
-    let output = Command::new(&bin)
-        .args([
+    run_ok_in(
+        &root,
+        &[
             "src",
             "--min-tokens",
             "10",
@@ -924,14 +934,7 @@ fn codeclimate_reporter_writes_code_quality_report() {
             "codeclimate",
             "--output",
             out.to_str().unwrap(),
-        ])
-        .current_dir(&root)
-        .output()
-        .expect("failed to run cpd");
-    assert!(
-        output.status.success(),
-        "cpd must succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        ],
     );
 
     let report = std::fs::read_to_string(out.join("gl-code-quality-report.json"))
@@ -977,19 +980,7 @@ fn sarif_error_tokens_flag_controls_result_level() {
         None => return,
     };
 
-    let root = std::env::temp_dir().join(format!("cpd-sarif-level-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    let src = root.join("src");
-    std::fs::create_dir_all(&src).expect("create src dir");
-
-    let dup = "function greet(name) {\n  \
-        const message = \"Hello, \" + name + \"!\";\n  \
-        console.log(message);\n  \
-        console.log(\"Welcome to the system\");\n  \
-        console.log(\"Have a nice day now\");\n  \
-        return message;\n}\n";
-    std::fs::write(src.join("a.js"), dup).expect("write a.js");
-    std::fs::write(src.join("b.js"), dup).expect("write b.js");
+    let (root, _) = greet_root("sarif-level", "src");
 
     let run_and_get_level = |extra_args: &[&str]| -> String {
         let out = root.join("report");
@@ -1004,18 +995,8 @@ fn sarif_error_tokens_flag_controls_result_level() {
             out.to_str().unwrap(),
         ];
         args.extend_from_slice(extra_args);
-        let output = Command::new(&bin)
-            .args(&args)
-            .current_dir(&root)
-            .output()
-            .expect("failed to run cpd");
-        assert!(
-            output.status.success(),
-            "cpd must succeed, stderr: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let sarif = std::fs::read_to_string(out.join("jscpd-report.sarif")).expect("sarif exists");
-        let parsed: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+        run_ok_in(&root, &args);
+        let parsed = read_json(&out.join("jscpd-report.sarif"));
         parsed["runs"][0]["results"][0]["level"]
             .as_str()
             .unwrap_or("")
@@ -1055,8 +1036,7 @@ fn sarif_error_tokens_flag_controls_result_level() {
         !output.status.success(),
         "cpd must exit non-zero when duplication exceeds --threshold"
     );
-    let sarif = std::fs::read_to_string(out.join("jscpd-report.sarif")).expect("sarif exists");
-    let parsed: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+    let parsed = read_json(&out.join("jscpd-report.sarif"));
     assert_eq!(
         parsed["runs"][0]["results"][0]["level"], "error",
         "results must be errors when duplication exceeds --threshold"
@@ -1087,28 +1067,15 @@ fn cli_both_ignore_flags_work_together() {
 
 #[test]
 fn blame_populated_when_scan_root_differs_from_cwd() {
-    let bin = match maybe_bin() {
-        Some(b) => b,
-        None => return,
-    };
+    if maybe_bin().is_none() {
+        return;
+    }
     // Requires git on PATH; skip quietly if unavailable.
     if Command::new("git").arg("--version").output().is_err() {
         return;
     }
 
-    let root = std::env::temp_dir().join(format!("cpd-blame-subdir-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    let pkg = root.join("pkg");
-    std::fs::create_dir_all(&pkg).expect("create pkg dir");
-
-    let dup = "function greet(name) {\n  \
-        const message = \"Hello, \" + name + \"!\";\n  \
-        console.log(message);\n  \
-        console.log(\"Welcome to the system\");\n  \
-        console.log(\"Have a nice day now\");\n  \
-        return message;\n}\n";
-    std::fs::write(pkg.join("a.js"), dup).expect("write a.js");
-    std::fs::write(pkg.join("b.js"), dup).expect("write b.js");
+    let (root, _) = greet_root("blame-subdir", "pkg");
 
     // Init a git repo at `root` and commit, so `git blame` has data.
     let git = |args: &[&str]| {
@@ -1134,8 +1101,9 @@ fn blame_populated_when_scan_root_differs_from_cwd() {
 
     // Scan the `pkg` subdirectory from the repo root (scan root != file dirs
     // relative to CWD after scan-root relativization).
-    let output = Command::new(&bin)
-        .args([
+    run_ok_in(
+        &root,
+        &[
             "pkg",
             "--min-tokens",
             "10",
@@ -1144,18 +1112,10 @@ fn blame_populated_when_scan_root_differs_from_cwd() {
             "json",
             "--output",
             out.to_str().unwrap(),
-        ])
-        .current_dir(&root)
-        .output()
-        .expect("failed to run cpd");
-    assert!(
-        output.status.success(),
-        "cpd must succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        ],
     );
 
-    let json = std::fs::read_to_string(out.join("jscpd-report.json")).expect("json report");
-    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let parsed = read_json(&out.join("jscpd-report.json"));
     let first_file = &parsed["duplicates"][0]["firstFile"];
     assert!(
         first_file.get("blame").is_some(),
@@ -1173,30 +1133,19 @@ fn blame_populated_when_scan_root_differs_from_cwd() {
 
 #[test]
 fn single_file_scan_preserves_filename() {
-    let bin = match maybe_bin() {
-        Some(b) => b,
-        None => return,
-    };
+    if maybe_bin().is_none() {
+        return;
+    }
 
-    let root = std::env::temp_dir().join(format!("cpd-single-file-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    std::fs::create_dir_all(&root).expect("create dir");
-
-    let dup = "function greet(name) {\n  \
-        const message = \"Hello, \" + name + \"!\";\n  \
-        console.log(message);\n  \
-        console.log(\"Welcome to the system\");\n  \
-        console.log(\"Have a nice day now\");\n  \
-        return message;\n}\n";
-    std::fs::write(root.join("a.js"), dup).expect("write a.js");
-    std::fs::write(root.join("b.js"), dup).expect("write b.js");
+    let (root, _) = greet_root("single-file", "");
 
     let out = root.join("report");
     let a_path = root.join("a.js");
     let b_path = root.join("b.js");
 
-    let output = Command::new(&bin)
-        .args([
+    run_ok_in(
+        &root,
+        &[
             a_path.to_str().unwrap(),
             b_path.to_str().unwrap(),
             "--min-tokens",
@@ -1205,18 +1154,10 @@ fn single_file_scan_preserves_filename() {
             "json",
             "--output",
             out.to_str().unwrap(),
-        ])
-        .current_dir(&root)
-        .output()
-        .expect("failed to run cpd");
-    assert!(
-        output.status.success(),
-        "cpd must succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        ],
     );
 
-    let json = std::fs::read_to_string(out.join("jscpd-report.json")).expect("json report");
-    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let parsed = read_json(&out.join("jscpd-report.json"));
     let first_name = parsed["duplicates"][0]["firstFile"]["name"]
         .as_str()
         .unwrap_or("");
@@ -1237,10 +1178,9 @@ fn single_file_scan_preserves_filename() {
 
 #[test]
 fn sarif_multi_root_distinct_artifact_indexes() {
-    let bin = match maybe_bin() {
-        Some(b) => b,
-        None => return,
-    };
+    if maybe_bin().is_none() {
+        return;
+    }
 
     let root = std::env::temp_dir().join(format!("cpd-multi-sarif-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);
@@ -1261,8 +1201,9 @@ fn sarif_multi_root_distinct_artifact_indexes() {
 
     let out = root.join("report");
 
-    let output = Command::new(&bin)
-        .args([
+    run_ok_in(
+        &root,
+        &[
             "alpha",
             "beta",
             "--min-tokens",
@@ -1271,18 +1212,10 @@ fn sarif_multi_root_distinct_artifact_indexes() {
             "sarif",
             "--output",
             out.to_str().unwrap(),
-        ])
-        .current_dir(&root)
-        .output()
-        .expect("failed to run cpd");
-    assert!(
-        output.status.success(),
-        "cpd must succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        ],
     );
 
-    let sarif = std::fs::read_to_string(out.join("jscpd-report.sarif")).expect("sarif exists");
-    let parsed: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+    let parsed = read_json(&out.join("jscpd-report.sarif"));
     let artifacts = parsed["runs"][0]["artifacts"]
         .as_array()
         .expect("artifacts array");
@@ -1580,15 +1513,22 @@ fn dup_function(name: &str) -> String {
     )
 }
 
-/// Scan dir with one duplicated function shared by a.js and b.js.
-/// Returns (scan_dir, baseline_path); the baseline file lives outside the
-/// scan dir so it is never scanned itself.
-fn setup_baseline_scan(suffix: &str) -> (PathBuf, PathBuf) {
+/// Temp root whose `src/` holds a.js and b.js sharing one duplicated
+/// function. Returns (root, src).
+fn baseline_root_with_pair(suffix: &str) -> (PathBuf, PathBuf) {
     let root = baseline_tmp_dir(suffix);
     let scan = root.join("src");
     std::fs::create_dir_all(&scan).unwrap();
     std::fs::write(scan.join("a.js"), dup_function("known")).unwrap();
     std::fs::write(scan.join("b.js"), dup_function("known")).unwrap();
+    (root, scan)
+}
+
+/// Scan dir with one duplicated function shared by a.js and b.js.
+/// Returns (scan_dir, baseline_path); the baseline file lives outside the
+/// scan dir so it is never scanned itself.
+fn setup_baseline_scan(suffix: &str) -> (PathBuf, PathBuf) {
+    let (root, scan) = baseline_root_with_pair(suffix);
     (scan, root.join("baseline.json"))
 }
 
@@ -1818,11 +1758,7 @@ fn git_in(dir: &std::path::Path, args: &[&str]) -> Output {
 /// Git repo whose HEAD commit contains src/a.js and src/b.js sharing one
 /// duplicated function. Returns the repo root.
 fn setup_git_baseline_repo(suffix: &str) -> PathBuf {
-    let root = baseline_tmp_dir(suffix);
-    let scan = root.join("src");
-    std::fs::create_dir_all(&scan).unwrap();
-    std::fs::write(scan.join("a.js"), dup_function("known")).unwrap();
-    std::fs::write(scan.join("b.js"), dup_function("known")).unwrap();
+    let (root, _scan) = baseline_root_with_pair(suffix);
     assert!(git_in(&root, &["init", "-q"]).status.success());
     assert!(git_in(&root, &["add", "-A"]).status.success());
     let commit = git_in(&root, &["commit", "-q", "-m", "base"]);
@@ -2009,14 +1945,8 @@ fn write_comment_only_js(dir: &std::path::Path) {
 fn nonexistent_path_is_an_error() {
     let missing = std::env::temp_dir().join(format!("cpd-missing-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&missing);
-    let output = run_cpd([
-        missing.as_os_str(),
-        std::ffi::OsStr::new("--reporters"),
-        std::ffi::OsStr::new("silent"),
-    ])
-    .expect("cpd binary must exist");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
+    let (code, stderr) = run_scratch(&missing, &["--reporters", "silent"]);
+    assert_eq!(code, Some(1), "stderr: {}", stderr);
     assert!(
         stderr.contains("Error: path does not exist:"),
         "missing path must be an error, got stderr: {}",
@@ -2028,15 +1958,8 @@ fn nonexistent_path_is_an_error() {
 fn empty_scan_warns_and_exits_zero() {
     let dir = scratch_dir("empty-warn");
     write_comment_only_js(&dir);
-    let output = run_cpd([
-        dir.as_os_str(),
-        std::ffi::OsStr::new("--reporters"),
-        std::ffi::OsStr::new("silent"),
-    ])
-    .expect("cpd binary must exist");
-    std::fs::remove_dir_all(&dir).ok();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(0), "stderr: {}", stderr);
+    let (code, stderr) = run_scratch(&dir, &["--reporters", "silent"]);
+    assert_eq!(code, Some(0), "stderr: {}", stderr);
     assert!(
         stderr.contains("Warning: jscpd analyzed no files"),
         "empty scan must warn, got stderr: {}",
@@ -2048,16 +1971,8 @@ fn empty_scan_warns_and_exits_zero() {
 fn fail_on_empty_exits_one_when_nothing_analyzed() {
     let dir = scratch_dir("empty-fail");
     write_comment_only_js(&dir);
-    let output = run_cpd([
-        dir.as_os_str(),
-        std::ffi::OsStr::new("--fail-on-empty"),
-        std::ffi::OsStr::new("--reporters"),
-        std::ffi::OsStr::new("silent"),
-    ])
-    .expect("cpd binary must exist");
-    std::fs::remove_dir_all(&dir).ok();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
+    let (code, stderr) = run_scratch(&dir, &["--fail-on-empty", "--reporters", "silent"]);
+    assert_eq!(code, Some(1), "stderr: {}", stderr);
     assert!(
         stderr.contains("ERROR: jscpd analyzed no files (--fail-on-empty)"),
         "got stderr: {}",
@@ -2071,17 +1986,16 @@ fn fail_on_empty_from_config_file() {
     write_comment_only_js(&dir);
     let config = dir.join("jscpd.json");
     std::fs::write(&config, r#"{"failOnEmpty": true}"#).unwrap();
-    let output = run_cpd([
-        dir.as_os_str(),
-        std::ffi::OsStr::new("--config"),
-        config.as_os_str(),
-        std::ffi::OsStr::new("--reporters"),
-        std::ffi::OsStr::new("silent"),
-    ])
-    .expect("cpd binary must exist");
-    std::fs::remove_dir_all(&dir).ok();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
+    let (code, stderr) = run_scratch(
+        &dir,
+        &[
+            "--config",
+            config.to_str().unwrap(),
+            "--reporters",
+            "silent",
+        ],
+    );
+    assert_eq!(code, Some(1), "stderr: {}", stderr);
     assert!(
         !stderr.contains("unknown field"),
         "failOnEmpty must be a known config key, got stderr: {}",
@@ -2098,16 +2012,8 @@ fn fail_on_empty_passes_when_files_are_analyzed() {
         })
         .collect();
     std::fs::write(dir.join("code.js"), body).unwrap();
-    let output = run_cpd([
-        dir.as_os_str(),
-        std::ffi::OsStr::new("--fail-on-empty"),
-        std::ffi::OsStr::new("--reporters"),
-        std::ffi::OsStr::new("silent"),
-    ])
-    .expect("cpd binary must exist");
-    std::fs::remove_dir_all(&dir).ok();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(0), "stderr: {}", stderr);
+    let (code, stderr) = run_scratch(&dir, &["--fail-on-empty", "--reporters", "silent"]);
+    assert_eq!(code, Some(0), "stderr: {}", stderr);
     assert!(
         !stderr.contains("analyzed no files"),
         "got stderr: {}",
@@ -2124,17 +2030,11 @@ fn reporter_write_failure_exits_one() {
     let blocker = dir.join("blocker");
     std::fs::write(&blocker, "not a directory").unwrap();
     let out_dir = blocker.join("report");
-    let output = run_cpd([
-        dir.as_os_str(),
-        std::ffi::OsStr::new("--reporters"),
-        std::ffi::OsStr::new("json"),
-        std::ffi::OsStr::new("--output"),
-        out_dir.as_os_str(),
-    ])
-    .expect("cpd binary must exist");
-    std::fs::remove_dir_all(&dir).ok();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr);
+    let (code, stderr) = run_scratch(
+        &dir,
+        &["--reporters", "json", "--output", out_dir.to_str().unwrap()],
+    );
+    assert_eq!(code, Some(1), "stderr: {}", stderr);
     assert!(
         stderr.contains("Reporter 'json' error:")
             && stderr.contains("ERROR: a reporter failed to write its output"),
@@ -2192,6 +2092,17 @@ fn setup_history_repo() -> PathBuf {
     root
 }
 
+/// Dates of the committed points of a `history` report, working tree excluded.
+fn commit_dates(report: &serde_json::Value) -> Vec<String> {
+    report["history"]["points"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|p| p["commit"] != "working tree")
+        .map(|p| p["date"].as_str().unwrap().to_string())
+        .collect()
+}
+
 fn run_history_cpd(root: &std::path::Path, extra: &[&str]) -> Output {
     let scan = root.join("src");
     let mut args = vec!["--min-tokens", "20", "--no-colors", "--no-tips"];
@@ -2218,9 +2129,7 @@ fn history_json_has_one_point_per_commit_plus_working_tree() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "stderr: {stderr}");
-    let report: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(out_dir.join("jscpd-report.json")).unwrap())
-            .unwrap();
+    let report = read_json(&out_dir.join("jscpd-report.json"));
     std::fs::remove_dir_all(&root).ok();
     let history = &report["history"];
     assert_eq!(history["range"], "since 2026-01-01");
@@ -2290,16 +2199,8 @@ fn history_every_and_limit_thin_the_series() {
         ],
     );
     assert!(output.status.success());
-    let report: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(out_dir.join("jscpd-report.json")).unwrap())
-            .unwrap();
-    let dates: Vec<String> = report["history"]["points"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .filter(|p| p["commit"] != "working tree")
-        .map(|p| p["date"].as_str().unwrap().to_string())
-        .collect();
+    let report = read_json(&out_dir.join("jscpd-report.json"));
+    let dates = commit_dates(&report);
     assert_eq!(
         dates,
         vec!["2026-08-08", "2026-08-22"],
@@ -2320,17 +2221,9 @@ fn history_every_and_limit_thin_the_series() {
         ],
     );
     assert!(output.status.success());
-    let report: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(out_dir.join("jscpd-report.json")).unwrap())
-            .unwrap();
+    let report = read_json(&out_dir.join("jscpd-report.json"));
     std::fs::remove_dir_all(&root).ok();
-    let dates: Vec<String> = report["history"]["points"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .filter(|p| p["commit"] != "working tree")
-        .map(|p| p["date"].as_str().unwrap().to_string())
-        .collect();
+    let dates = commit_dates(&report);
     assert_eq!(
         dates,
         vec!["2026-08-01", "2026-08-22"],
@@ -2357,17 +2250,8 @@ fn history_outside_a_git_repository_is_an_error() {
     let Some(_) = maybe_bin() else { return };
     let dir = scratch_dir("history-nogit");
     std::fs::write(dir.join("a.js"), dup_function("x")).unwrap();
-    let output = run_cpd([
-        dir.as_os_str(),
-        std::ffi::OsStr::new("--history"),
-        std::ffi::OsStr::new("HEAD"),
-        std::ffi::OsStr::new("--reporters"),
-        std::ffi::OsStr::new("silent"),
-    ])
-    .expect("cpd binary must exist");
-    std::fs::remove_dir_all(&dir).ok();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    let (code, stderr) = run_scratch(&dir, &["--history", "HEAD", "--reporters", "silent"]);
+    assert_eq!(code, Some(1), "stderr: {}", stderr);
     assert!(
         stderr.contains("is not inside a git repository"),
         "{stderr}"

--- a/rust/crates/cpd/tests/integration.rs
+++ b/rust/crates/cpd/tests/integration.rs
@@ -2175,6 +2175,28 @@ fn history_console_prints_chart_table_and_threshold_hint() {
 }
 
 #[test]
+fn history_block_is_printed_by_console_full_too() {
+    let Some(_) = maybe_bin() else { return };
+    let root = setup_history_repo();
+    let output = run_history_cpd(
+        &root,
+        &["--history", "HEAD~1..HEAD", "--reporters", "console-full"],
+    );
+    std::fs::remove_dir_all(&root).ok();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("History (HEAD~1..HEAD: 1 commits + working tree)"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("CHANGE  SUBJECT"), "{stdout}");
+}
+
+#[test]
 fn history_every_and_limit_thin_the_series() {
     let Some(_) = maybe_bin() else { return };
     let root = setup_history_repo();

--- a/rust/crates/cpd/tests/mcp_stdio.rs
+++ b/rust/crates/cpd/tests/mcp_stdio.rs
@@ -8,6 +8,44 @@ fn cpd_bin() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_BIN_EXE_cpd"))
 }
 
+const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}"#;
+const INITIALIZED: &str = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+
+/// Spawn `cpd --mcp <extra> <dir>` with every stream piped.
+fn spawn_mcp(dir: &std::path::Path, extra: &[&str]) -> std::process::Child {
+    Command::new(cpd_bin())
+        .arg("--mcp")
+        .args(extra)
+        .arg(dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cpd --mcp")
+}
+
+/// Write one request per line, close stdin so the server exits, and parse
+/// every stdout line as JSON. Returns the responses and the raw output.
+fn drive(
+    mut child: std::process::Child,
+    requests: &[String],
+) -> (Vec<serde_json::Value>, std::process::Output) {
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        for req in requests {
+            writeln!(stdin, "{req}").unwrap();
+        }
+    } // drop stdin → EOF → clean exit
+    let output = child.wait_with_output().expect("cpd --mcp must exit");
+    assert!(output.status.success(), "exit 0 on stdin EOF");
+    let responses = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("every stdout line must be valid JSON"))
+        .collect();
+    (responses, output)
+}
+
 fn fixture_dir() -> std::path::PathBuf {
     let dir = std::env::temp_dir().join(format!("cpd-mcp-stdio-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
@@ -23,18 +61,11 @@ fn fixture_dir() -> std::path::PathBuf {
 #[test]
 fn mcp_stdio_session_end_to_end() {
     let dir = fixture_dir();
-    let mut child = Command::new(cpd_bin())
-        .args(["--mcp", "--min-tokens", "15", "--min-lines", "1"])
-        .arg(&dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn cpd --mcp");
+    let child = spawn_mcp(&dir, &["--min-tokens", "15", "--min-lines", "1"]);
 
     let requests = [
-        r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}"#.to_string(),
-        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.to_string(),
+        INITIALIZE.to_string(),
+        INITIALIZED.to_string(),
         r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#.to_string(),
         format!(
             r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"check_duplication","arguments":{{"code":{},"format":"javascript"}}}}}}"#,
@@ -47,22 +78,8 @@ fn mcp_stdio_session_end_to_end() {
         r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"check_current_directory","arguments":{}}}"#.to_string(),
         r#"{"jsonrpc":"2.0","id":5,"method":"ping"}"#.to_string(),
     ];
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        for req in &requests {
-            writeln!(stdin, "{req}").unwrap();
-        }
-    } // drop stdin → EOF → clean exit
-
-    let output = child.wait_with_output().expect("cpd --mcp must exit");
-    assert!(output.status.success(), "exit 0 on stdin EOF");
-
+    let (responses, output) = drive(child, &requests);
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let responses: Vec<serde_json::Value> = stdout
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(|l| serde_json::from_str(l).expect("every stdout line must be valid JSON"))
-        .collect();
     // 7 messages sent, 1 is a notification → 6 responses.
     assert_eq!(responses.len(), 6, "stdout: {stdout}");
 
@@ -127,18 +144,11 @@ fn mcp_check_duplication_similarity() {
     )
     .unwrap();
     let snippet = "export function buildCreditNote(refund, account, vatRate) {\n  const entries = [];\n  for (const item of refund.items) {\n    if (!item.refundable) continue;\n    const net = item.price * item.quantity;\n    entries.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = entries.reduce((sum, entry) => sum + entry.net, 0);\n  const vat = Math.round(subtotal * vatRate * 100) / 100;\n  logger.info('credit note', { account: account.id, subtotal });\n  return { number: nextCreditNoteNumber(), account: account.id, entries, subtotal, vat, total: subtotal + vat };\n}\n";
-    let mut child = Command::new(cpd_bin())
-        .args(["--mcp"])
-        .arg(&dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn cpd --mcp");
+    let child = spawn_mcp(&dir, &[]);
     let code = serde_json::to_string(snippet).unwrap();
     let requests = [
-        r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}"#.to_string(),
-        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.to_string(),
+        INITIALIZE.to_string(),
+        INITIALIZED.to_string(),
         format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"check_duplication","arguments":{{"code":{code},"format":"javascript","similarity":0.7}}}}}}"#
         ),
@@ -152,20 +162,8 @@ fn mcp_check_duplication_similarity() {
             r#"{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"check_duplication","arguments":{{"code":{code},"format":"javascript","similarity":1}}}}}}"#
         ),
     ];
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        for req in &requests {
-            writeln!(stdin, "{req}").unwrap();
-        }
-    }
-    let output = child.wait_with_output().expect("cpd --mcp must exit");
-    assert!(output.status.success());
+    let (responses, output) = drive(child, &requests);
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let responses: Vec<serde_json::Value> = stdout
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(|l| serde_json::from_str(l).expect("valid JSON per line"))
-        .collect();
     assert_eq!(responses.len(), 5, "stdout: {stdout}");
     let payload = |i: usize| -> serde_json::Value {
         serde_json::from_str(

--- a/rust/crates/cpd/tests/mcp_stdio.rs
+++ b/rust/crates/cpd/tests/mcp_stdio.rs
@@ -1,6 +1,8 @@
 // mcp_stdio.rs — end-to-end test of `cpd --mcp`: spawn the real binary and
 // speak newline-delimited JSON-RPC over its stdin/stdout (issue #891).
 
+mod common;
+
 use std::io::Write;
 use std::process::{Command, Stdio};
 
@@ -138,12 +140,8 @@ fn mcp_check_duplication_similarity() {
     let dir = std::env::temp_dir().join(format!("cpd-mcp-similarity-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        dir.join("invoice.js"),
-        "export function buildInvoice(order, customer, taxRate) {\n  const lines = [];\n  for (const item of order.items) {\n    const net = item.price * item.quantity;\n    lines.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = lines.reduce((sum, line) => sum + line.net, 0);\n  const tax = Math.round(subtotal * taxRate * 100) / 100;\n  return { number: nextInvoiceNumber(), customer: customer.id, lines, subtotal, tax, total: subtotal + tax };\n}\n",
-    )
-    .unwrap();
-    let snippet = "export function buildCreditNote(refund, account, vatRate) {\n  const entries = [];\n  for (const item of refund.items) {\n    if (!item.refundable) continue;\n    const net = item.price * item.quantity;\n    entries.push({ sku: item.sku, quantity: item.quantity, net });\n  }\n  const subtotal = entries.reduce((sum, entry) => sum + entry.net, 0);\n  const vat = Math.round(subtotal * vatRate * 100) / 100;\n  logger.info('credit note', { account: account.id, subtotal });\n  return { number: nextCreditNoteNumber(), account: account.id, entries, subtotal, vat, total: subtotal + vat };\n}\n";
+    std::fs::write(dir.join("invoice.js"), common::INVOICE_JS).unwrap();
+    let snippet = common::CREDIT_NOTE_JS;
     let child = spawn_mcp(&dir, &[]);
     let code = serde_json::to_string(snippet).unwrap();
     let requests = [


### PR DESCRIPTION
Closing part of the `--history` work (#1050, #1052) and `--fail-on-empty` (#1049). Those features added integration suites the way the existing ones were written, by copying the neighbouring test, and the first `jscpd --history` run on the repository itself showed the cost: `rust/crates` went from 54 to 69 clones between 2026-09-10 and 2026-09-12, with `cpd/tests/integration.rs` at 23% duplication. This PR is the DRY pass that the `dry-refactoring` skill prescribes after such a scan: read both sides of every clone, extract the shared piece, re-scan.

| | Clones | Duplication |
|---|---|---|
| Before | 69 | 2.4% |
| After | 12 | 0.4% |

Three commits, each green on the full workspace (971 tests, clippy `-D warnings`, fmt), no behavior change intended.

## What was extracted

**cpd-core**: `Location::new`, `Fragment::new` / `with_blame`, `CpdClone::exact`. The 20-line `CpdClone { .. }` literal was copied across six test files.

**cpd-reporter**
- `ReportContext::new` replaces the copied struct literal in every test (the `history` field added by #1050 had doubled it).
- `shared::fixtures::report_to_file` / `report_to_file_timed` replace seven near-identical `run_<reporter>_report` helpers; `report_result` covers the stdout reporters' "returns Ok" tests.
- `shared::print_appendices` prints the `--summary` and `--history` blocks for both console reporters from one place.
- sarif tests: `rule_ids`, `first_result_properties`.

**cpd-tokenizer**: `embedded::html_only_maps` and `tokenize_blocks_shifted` hold the code `razor.rs` and `sfc.rs` had copied from each other (production code, behavior unchanged, covered by the existing razor/sfc tests).

**cpd (CLI) tests**: `GREET_DUP` / `greet_root` / `write_greet_pair`, `run_ok_in`, `read_json`, `scan_json`, `run_scratch`, `config_dir` / `stderr_in_dir`, `commit_dates` and `baseline_root_with_pair` (the `--history` and baseline suites), `spawn_mcp` / `drive` and request constants in `mcp_stdio.rs`, `tests/common` with the shared invoice/credit-note snippets, `scratch_dir` in the mcp unit tests, `cross_formats_with` in the cli unit tests.

**cpd-finder tests**: `tests/common` (`temp_dir`, `duplicate_js`, `fixtures`) shared by the five integration test binaries; `run_isolating` in the skip-isolated tests.

## Left on purpose

Fixture corpora that must contain duplicates (`invoice.ts`/`pricing.ts`, the markdown guides, `cross_formats/b.js`), plain `use` blocks, the typed TypeScript source and its untyped JavaScript twin, the two `impl Reporter` headers, and the `visit_method_definition` / `visit_property_definition` pair in `ts_strip.rs`, where a shared helper would hide the AST logic.

With this merged, the 5.3.0 changelog entry for `--history` can cite the repository's own trend as the example: the feature found the regression its own tests introduced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1053)
<!-- Reviewable:end -->
