### PR TITLE
docs(skills): teach the agents about clone kinds and the summary

### DIFF
--- a/skills/dry-refactoring/SKILL.md
+++ b/skills/dry-refactoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dry-refactoring
-description: Guided workflow to eliminate copy-paste duplication detected by jscpd. Refactor clones using extract function, module, constant, or base class strategies.
+description: Guided workflow to eliminate copy-paste duplication detected by jscpd. Refactor exact, renamed and near-miss clones using extract function, parameterize, module, constant, or base class strategies, starting from the hotspots the summary ranks.
 ---
 
 # dry-refactoring
@@ -27,18 +27,29 @@ On larger codebases, add `--summary` to get a refactoring-hotspot overview along
 npx jscpd --reporters ai --summary <path>
 ```
 
-See the **[jscpd](../jscpd/SKILL.md)** skill for full option reference, including cross-format group syntax and how to read the summary.
+The default scan reports only **exact** copies. Two more passes find the copies that were edited after pasting; run them once the exact clones are dealt with, because they report more and longer clones:
+
+```bash
+# Type-2: renamed copies (other variable names, other constants), reported as "(renamed)"
+npx jscpd --reporters ai --ignore-identifiers --ignore-literals <path>
+
+# Type-3: near-miss copies (a few inserted lines, or JS/TS functions with the same structure),
+# reported as "[~0.91 gap]" and "[~0.75 ast]"
+npx jscpd --reporters ai --max-gap-lines 2 --similarity 0.8 <path>
+```
+
+See the **[jscpd](../jscpd/SKILL.md)** skill for full option reference, including cross-format group syntax, the clone-kind suffixes and how to read the summary.
 
 ## Workflow
 
 1. Run jscpd with `--reporters ai` on the target path (add `--summary` on larger codebases to pick a starting point: files with high `dup%` and high token counts pay off most)
-2. Parse each clone line to identify the two duplicated locations (file + line range)
+2. Parse each clone line to identify the two duplicated locations (file + line range) and its kind: no suffix is an exact copy, `(renamed)` differs only in names or values, `[~N gap]` has a few edited lines in the middle, `[~N ast]` is a function pair with the same structure
 3. Read both code fragments from the source files
-4. Understand what the duplicated code does
-5. Design a refactoring: extract a shared function, class, module, or constant
+4. Understand what the duplicated code does, and for renamed and similar clones list exactly what differs between the two sides
+5. Design a refactoring: extract a shared function, class, module, or constant; the kind decides the strategy (below)
 6. Apply the refactoring — update both locations and all other usages
-7. Re-run jscpd to confirm the clone is eliminated
-8. Repeat for remaining clones, highest-impact first
+7. Re-run jscpd **with the same flags** to confirm the clone is eliminated and the `dup%` of the touched files went down; a clone that was `(renamed)` will not show in a default run, so check with `--ignore-identifiers` again
+8. Repeat for remaining clones, highest-impact first: exact clones, then renamed, then similar
 
 ## Refactoring Strategies
 
@@ -57,15 +68,45 @@ See the **[jscpd](../jscpd/SKILL.md)** skill for full option reference, includin
 
 **Template/base class** — when the duplicate is structural (e.g., repeated class shape).
 
+**Parameterize** — for `(renamed)` clones. The two sides are the same algorithm over different names or values, so the things that differ become parameters:
+```ts
+// Before: computeCartTotal(items) and computeBasketTotal(entries), same body, other names;
+//         limits-dev.js and limits-prod.js, same shape, other numbers
+// After: one function whose parameters are the identifiers that differed,
+//        or one function reading the values that differed from a config object
+```
+A renamed clone whose only difference is a literal is a missing constant or config entry, not a missing function.
+
+**Unify near-miss copies** — for `[~N gap]` clones. Read the unmatched lines: the gap is the one place the copies diverged, typically a guard, a log call or an extra field. Extract the common body and pass the divergence in:
+```ts
+// Before: saveUser and saveAccount, identical except one inserted validation line
+// After: one saveRecord(record, { validate }) with the inserted line behind the option,
+//        or the inserted line moved to the caller before the shared call
+```
+If the gap changes the meaning rather than adding a step, keep two functions but extract the shared halves.
+
+**Merge similar functions** — for `[~N ast]` clones. The structure matches but names, literals and some statements do not. Diff the two functions first; the `ast` score tells how much is shared (`0.9` is a copy with one edit, `0.75` a copy with a couple of added statements plus renames). Extract the shared skeleton and inject what differs, as arguments, a strategy object, or a callback:
+```ts
+// Before: buildInvoice(order, customer, taxRate) and buildCreditNote(refund, account, vatRate):
+//         same loop, same rounding, one extra guard and one extra log call in the second
+// After: buildDocument(source, party, rate, { filter, onBuilt }) used by both
+```
+Below about `0.7` the pair usually shares an idiom, not an implementation; leave those alone unless the summary shows the file is a hotspot anyway.
+
 Always ensure:
 - All call sites are updated, not just the two reported by jscpd
 - Tests still pass after refactoring
 - The extracted abstraction has a clear, descriptive name
+- The re-run uses the same detection flags as the run that found the clone
 
 ## Tips
 
 - Start with clones that have the highest line count — they have the most impact
+- Use the summary's `dup%` column to order the work: a large file with a high share of duplicated lines pays back first
 - A clone between test files may indicate a missing test helper
 - Clones across unrelated modules may signal a missing shared utility
 - A cross-format clone (same logic in a `.js` and a `.ts` file, found with `--cross-formats`) often means code was ported without deleting the original — consolidate into one implementation (usually the TypeScript one) and update imports, rather than extracting a third shared copy
+- Many `(renamed)` clones in one file usually mean one abstraction is missing, not many: look for the shared shape before extracting pair by pair
+- `--similarity` only covers JavaScript and TypeScript today; for other languages rely on the exact and `--max-gap-lines` passes
 - Use `--min-lines 10` to filter noise and focus on meaningful duplications
+- Keep a separate `--baseline` per set of detection flags when gating CI: renamed and similar runs fingerprint clones differently from exact runs

--- a/skills/jscpd/SKILL.md
+++ b/skills/jscpd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jscpd
-description: Copy-paste detector for 220+ languages. Detect duplicated code and measure duplication percentages.
+description: Copy-paste detector for 220+ languages. Detect exact, renamed and near-miss duplicated code, measure duplication percentages, and find refactoring hotspots with the codebase summary.
 ---
 
 # jscpd
@@ -18,6 +18,15 @@ npx jscpd --reporters ai --ignore "**/node_modules/**,**/dist/**" <path>
 
 # Scope to specific formats
 npx jscpd --reporters ai --format "javascript,typescript" <path>
+
+# Also find copies that only differ in names and values (Type-2, reported as "renamed")
+npx jscpd --reporters ai --ignore-identifiers --ignore-literals <path>
+
+# Also find copies with a few edited lines or the same function structure (Type-3, "similar")
+npx jscpd --reporters ai --max-gap-lines 2 --similarity 0.8 <path>
+
+# Where to refactor first: clone list plus a hotspot summary
+npx jscpd --reporters ai --summary <path>
 ```
 
 ## AI Reporter Output Format
@@ -28,14 +37,22 @@ The `ai` reporter produces compact, token-efficient output designed for agent co
 Clones:
 src/ foo.ts:10-25 ~ bar.ts:42-57
 src/utils/helpers.ts:100-120 ~ src/utils/other.ts:5-25
+src/cart/ basket.js:1-9 ~ cart.js:1-9 (renamed)
+src/api/ save-account.js:1-12 ~ save-user.js:1-11 [~0.91 gap]
+src/billing/ credit-note.js:1-19 ~ invoice.js:1-17 [~0.75 ast]
 ---
-3 clones · 4.2% duplication
+5 clones · 4.2% duplication
 ```
 
 Each line represents one clone pair:
 - **Same file**: `path/file.ts 10-25 ~ 45-60` (shared path shown once)
 - **Same directory**: `shared/prefix/ file-a.ts:10-25 ~ file-b.ts:42-57` (common prefix factored out)
 - **Different paths**: `path/a.ts:10-25 ~ path/b.ts:42-57`
+
+A suffix tells the **kind** of clone; no suffix means an exact copy:
+- `(renamed)`: the two blocks differ only in identifier names, literal values or annotations (Type-2). Only appears with `--ignore-identifiers`, `--ignore-literals` or `--ignore-annotations`.
+- `[~0.91 gap]`: two exact clones merged across up to `--max-gap-lines` unmatched lines (Type-3). The number is matched tokens over the merged span.
+- `[~0.75 ast]`: two functions whose syntax-tree structure overlaps at least `--similarity` (Type-3). The number is the structural similarity, names and literal values do not count.
 
 ## Options
 
@@ -50,6 +67,11 @@ Each line represents one clone pair:
 | `--ignore "glob"` | Ignore patterns (comma-separated) |
 | `--format "list"` | Limit to specific languages (e.g. `typescript,javascript`) |
 | `--cross-formats "groups"` | Detect clones across related formats (e.g. `javascript,typescript` or the `js-ts` preset) |
+| `--ignore-identifiers` | Treat all identifiers as equal, so blocks that differ only in variable, function or type names match (Type-2, reported as `renamed`) |
+| `--ignore-literals` | Treat all string literals as equal and all numeric literals as equal (Type-2) |
+| `--ignore-annotations` | Drop `@Name` / `@Name(...)` annotations and decorators before matching, in languages where `@` means one (Type-2) |
+| `--max-gap-lines N` | Merge clones of one file pair separated by at most N unmatched lines into one `similar` clone (Type-3, default: 0 = off) |
+| `--similarity RATIO` | Report JavaScript/TypeScript function pairs whose syntax-tree similarity reaches RATIO, in `(0, 1]`, as `similar` clones (Type-3, default: 1 = exact only) |
 | `--summary` | Append a codebase summary: top files/folders by tokens, lines, size, complexity, with duplication share |
 | `--summary-top N` | Number of entries in each summary top list (default: 10) |
 | `--summary-by metric` | Summary ranking metric: `tokens`, `lines`, `size`, `complexity` (default: `tokens`) |
@@ -60,6 +82,61 @@ Each line represents one clone pair:
 | `--list` | List all supported formats and exit |
 | `--no-tips` | Disable tips in output (skipped automatically when stdout is not a TTY or `CI` or `JSCPD_NO_TIPS` is set) |
 | `--config "path"` | Path to .jscpd.json config file |
+
+## Clone Kinds: Exact, Renamed, Similar
+
+By default jscpd reports **exact** clones only: the token sequences are identical (whitespace, layout and, depending on the mode, comments do not count). Two opt-in families widen the net. Run them as separate passes after the default scan, because they find more and longer clones and change what a "clone" means.
+
+### Type-2: renamed clones (`--ignore-identifiers`, `--ignore-literals`, `--ignore-annotations`)
+
+Copies where someone renamed the variables or changed the constants:
+
+```bash
+npx jscpd --reporters ai --ignore-identifiers <path>                      # function a(x) {…} matches function b(y) {…}
+npx jscpd --reporters ai --ignore-identifiers --ignore-literals <path>    # …and 10 matches 25, 'dev' matches 'prod'
+npx jscpd --reporters ai --ignore-annotations <path>                      # @Override / @Deprecated no longer split a clone
+```
+
+```
+Clones:
+basket.js:1-9 ~ cart.js:1-9 (renamed)
+limits-dev.js:1-13 ~ limits-prod.js:1-13 (renamed)
+---
+```
+
+- Keywords keep their meaning (`return` never matches `retry`), so structure still has to match.
+- `--ignore-annotations` only acts in Java, Kotlin, Scala, Groovy, Python, Dart, Swift, JavaScript and TypeScript; in Ruby, Perl, T-SQL, Razor and CSS `@` means something else and is left alone.
+- Positions in the report still point at the original source.
+- Config keys: `ignoreIdentifiers`, `ignoreLiterals`, `ignoreAnnotations`.
+
+### Type-3: near-miss clones (`--max-gap-lines`, `--similarity`)
+
+Copies with a few edited lines, or functions rewritten with the same shape:
+
+```bash
+npx jscpd --reporters ai --max-gap-lines 2 <path>      # a copy with up to 2 inserted/changed lines becomes one clone
+npx jscpd --reporters ai --similarity 0.8 <path>       # JS/TS functions with ≥80% shared syntax-tree structure
+```
+
+```
+Clones:
+save-account.js:1-12 ~ save-user.js:1-11 [~0.91 gap]
+credit-note.js:1-19 ~ invoice.js:1-17 [~0.75 ast]
+---
+```
+
+- `--max-gap-lines N` only joins clones the exact run already found, so it removes fragmentation rather than inventing matches; it works in every language. A merge is refused when the gap holds more tokens than the halves share (similarity would drop under `0.5`).
+- `--similarity RATIO` compares whole functions by the bag of 4-grams over their syntax-tree node types, so a renamed copy scores `1.0`, one inserted line about `0.9`, two added statements plus renames about `0.75`. Today it applies to JavaScript, TypeScript, JSX and TSX only; other formats are a silent no-op. Start at `0.85` for near-identical structure and lower to `0.7` for looser matches; below that the pairs are rarely worth merging.
+- `similar` takes precedence over `renamed` when both apply (a merged clone is no longer identical even after normalization).
+- Config keys: `maxGapLines`, `similarity`.
+
+### Where the kind shows up
+
+- `console`: `Clone found (javascript, renamed)`, `Clone found (javascript, similar (gap) ~0.91)`, `Clone found (javascript, similar (ast) ~0.75)`.
+- `json`: `"kind": "exact" | "renamed" | "similar"`, plus `"similarity"` and `"method": "gap" | "ast"` for similar clones.
+- `sarif`: rules `jscpd/duplicate-code`, `jscpd/renamed-code`, `jscpd/similar-code`; Code Climate uses the same three `check_name` values.
+- A default run reports only `exact` clones and its output is unchanged by these features.
+- Normalized runs produce different clone fingerprints than exact runs: keep a separate `--baseline` file per configuration.
 
 ## Codebase Summary (`--summary`)
 
@@ -79,6 +156,7 @@ With the `ai` reporter the summary is one line per entry:
 Summary by tokens (321 files, 129 folders):
 files (tokens/lines/size/cx/dup%):
 src/files.ts 2052/363/11662/80/0.0%
+long-line/theme-branded.js 498/15/2.5K/10/93.3%
 ...
 folders (files/tokens/lines/size):
 src/core 8/5264/843/27136
@@ -88,7 +166,7 @@ src/core 8/5264/843/27136
 How to read it:
 - **Top files** are ranked by the `--summary-by` metric, but every row carries all metrics — `tokens/lines/size/cx/dup%`.
 - **cx** is a language-agnostic cyclomatic-complexity estimate from the token stream (1 + decision-point tokens like `if`/`while`/`&&`); treat it as a ranking signal, not an exact metric.
-- **dup%** is the share of the file's lines covered by detected clones — a large file with high `dup%` is the best refactoring target.
+- **dup%** is the share of the file's lines covered by detected clones — a large file with high `dup%` is the best refactoring target. It reflects the clones of the current run, so with the Type-2/Type-3 flags it rises accordingly.
 - **Folders** aggregate files into their direct parent directory (no cumulative ancestor totals).
 - In `console` reporters the summary renders as aligned tables; in the `json` report it appears as an additive `summary` key (absent when the flag is off).
 
@@ -127,13 +205,18 @@ Create a `.jscpd.json` in your project root:
   "format": ["typescript", "javascript"],
   "minLines": 5,
   "minTokens": 50,
+  "ignoreIdentifiers": false,
+  "ignoreLiterals": false,
+  "maxGapLines": 0,
+  "similarity": 1,
+  "summary": false,
   "output": "./reports/jscpd"
 }
 ```
 
 ## Refactoring Duplicated Code
 
-Once you've detected clones, use the **dry-refactoring** skill for a guided workflow to eliminate them:
+Once you've detected clones, use the **dry-refactoring** skill for a guided workflow to eliminate them, with a strategy per clone kind:
 
 → **dry-refactoring** — step-by-step refactoring strategies and workflow for removing duplication. Install with:
   ```bash


### PR DESCRIPTION
Both agent skills only knew exact clones.

**jscpd skill**: the Type-2 flags (`--ignore-identifiers`, `--ignore-literals`, `--ignore-annotations`) and Type-3 flags (`--max-gap-lines`, `--similarity`) in the options table and the quick start; a **Clone Kinds** section explaining the `ai` reporter suffixes with real output lines (`(renamed)`, `[~0.91 gap]`, `[~0.75 ast]` from the type2/type3 demos), calibration for the scores, language coverage of `--similarity`, precedence of `similar` over `renamed`, how kinds appear in json/sarif/codeclimate, and the baseline caveat. The summary section notes that `dup%` follows the run's flags; the config example lists the new keys.

**dry-refactoring skill**: the two extra detection passes as prerequisites, workflow steps that identify the kind and re-run with the same flags, and three new strategies keyed to the kinds: *parameterize* for renamed clones, *unify near-miss copies* for gap merges, *merge similar functions* for ast pairs, plus tips on ordering by the summary's `dup%` and keeping one baseline per flag set.

Docs only; the skill text is not mirrored elsewhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1056)
<!-- Reviewable:end -->
