### PR TITLE
docs(skills): Type-2/Type-3 passes are noisy, triage before refactoring

### DIFF
--- a/skills/dry-refactoring/SKILL.md
+++ b/skills/dry-refactoring/SKILL.md
@@ -27,15 +27,16 @@ On larger codebases, add `--summary` to get a refactoring-hotspot overview along
 npx jscpd --reporters ai --summary <path>
 ```
 
-The default scan reports only **exact** copies. Two more passes find the copies that were edited after pasting; run them once the exact clones are dealt with, because they report more and longer clones:
+The default scan reports only **exact** copies, and those are the ones to refactor first: an exact clone is almost always a real copy-paste. Two more passes find copies that were edited after pasting. They are **noisier**: they ignore names, values or a few statements on purpose, so they also surface blocks that merely look alike (models and DTOs, config tables, test setup, generated code, shared idioms). Run them only after the exact clones are dealt with, one family at a time, with tight settings, and treat what they report as leads to read rather than defects to fix:
 
 ```bash
-# Type-2: renamed copies (other variable names, other constants), reported as "(renamed)"
-npx jscpd --reporters ai --ignore-identifiers --ignore-literals <path>
+# Type-2: renamed copies (other variable names, other constants), reported as "(renamed)".
+# Raise --min-tokens: with identifiers ignored, a short block is mostly placeholders.
+npx jscpd --reporters ai --ignore-identifiers --min-tokens 70 <path>
 
-# Type-3: near-miss copies (a few inserted lines, or JS/TS functions with the same structure),
-# reported as "[~0.91 gap]" and "[~0.75 ast]"
-npx jscpd --reporters ai --max-gap-lines 2 --similarity 0.8 <path>
+# Type-3: near-miss copies (one or two edited lines, or JS/TS functions with the same structure),
+# reported as "[~0.91 gap]" and "[~0.85 ast]". Widen only if the tight run finds nothing.
+npx jscpd --reporters ai --max-gap-lines 1 --similarity 0.85 <path>
 ```
 
 See the **[jscpd](../jscpd/SKILL.md)** skill for full option reference, including cross-format group syntax, the clone-kind suffixes and how to read the summary.
@@ -46,10 +47,11 @@ See the **[jscpd](../jscpd/SKILL.md)** skill for full option reference, includin
 2. Parse each clone line to identify the two duplicated locations (file + line range) and its kind: no suffix is an exact copy, `(renamed)` differs only in names or values, `[~N gap]` has a few edited lines in the middle, `[~N ast]` is a function pair with the same structure
 3. Read both code fragments from the source files
 4. Understand what the duplicated code does, and for renamed and similar clones list exactly what differs between the two sides
-5. Design a refactoring: extract a shared function, class, module, or constant; the kind decides the strategy (below)
-6. Apply the refactoring — update both locations and all other usages
-7. Re-run jscpd **with the same flags** to confirm the clone is eliminated and the `dup%` of the touched files went down; a clone that was `(renamed)` will not show in a default run, so check with `--ignore-identifiers` again
-8. Repeat for remaining clones, highest-impact first: exact clones, then renamed, then similar
+5. **Triage renamed and similar clones before touching them.** Skip the pair, and say so, when any of these holds: the two sides do different things despite the same shape (a `switch` over different enums, two reducers with unrelated semantics); the sameness is intentional boilerplate (models, DTOs, config, route tables, test fixtures); the code is generated; a shared abstraction would need a vague name like `processData`; or the pair is under about 10 lines. Only a pair that would let you delete code and give the extraction a precise name goes on to the next step
+6. Design a refactoring: extract a shared function, class, module, or constant; the kind decides the strategy (below)
+7. Apply the refactoring — update both locations and all other usages
+8. Re-run jscpd **with the same flags** to confirm the clone is eliminated and the `dup%` of the touched files went down; a clone that was `(renamed)` will not show in a default run, so check with `--ignore-identifiers` again
+9. Repeat for remaining clones, highest-impact first: exact clones, then renamed, then similar. Report the skipped candidates separately from the refactored ones, with the reason, so nobody mistakes a normalized run's count for real duplication
 
 ## Refactoring Strategies
 
@@ -91,7 +93,7 @@ If the gap changes the meaning rather than adding a step, keep two functions but
 //         same loop, same rounding, one extra guard and one extra log call in the second
 // After: buildDocument(source, party, rate, { filter, onBuilt }) used by both
 ```
-Below about `0.7` the pair usually shares an idiom, not an implementation; leave those alone unless the summary shows the file is a hotspot anyway.
+Below about `0.8` the pair usually shares an idiom, not an implementation; leave those alone unless the summary shows the file is a hotspot anyway.
 
 Always ensure:
 - All call sites are updated, not just the two reported by jscpd
@@ -106,7 +108,8 @@ Always ensure:
 - A clone between test files may indicate a missing test helper
 - Clones across unrelated modules may signal a missing shared utility
 - A cross-format clone (same logic in a `.js` and a `.ts` file, found with `--cross-formats`) often means code was ported without deleting the original — consolidate into one implementation (usually the TypeScript one) and update imports, rather than extracting a third shared copy
-- Many `(renamed)` clones in one file usually mean one abstraction is missing, not many: look for the shared shape before extracting pair by pair
+- Many `(renamed)` clones in one file usually mean one abstraction is missing, not many: look for the shared shape before extracting pair by pair. Many `(renamed)` clones across *test* files usually mean nothing: test cases are supposed to look alike
+- Do not gate CI (`--threshold`, `--fail-on-new-clones`) on the Type-2/Type-3 passes until the team has reviewed what they report on this codebase; gate on the exact run
 - `--similarity` only covers JavaScript and TypeScript today; for other languages rely on the exact and `--max-gap-lines` passes
 - Use `--min-lines 10` to filter noise and focus on meaningful duplications
 - Keep a separate `--baseline` per set of detection flags when gating CI: renamed and similar runs fingerprint clones differently from exact runs

--- a/skills/jscpd/SKILL.md
+++ b/skills/jscpd/SKILL.md
@@ -19,11 +19,13 @@ npx jscpd --reporters ai --ignore "**/node_modules/**,**/dist/**" <path>
 # Scope to specific formats
 npx jscpd --reporters ai --format "javascript,typescript" <path>
 
-# Also find copies that only differ in names and values (Type-2, reported as "renamed")
-npx jscpd --reporters ai --ignore-identifiers --ignore-literals <path>
+# Second pass, noisier: copies that only differ in names and values (Type-2, "renamed").
+# Review each hit before acting on it.
+npx jscpd --reporters ai --ignore-identifiers --min-tokens 70 <path>
 
-# Also find copies with a few edited lines or the same function structure (Type-3, "similar")
-npx jscpd --reporters ai --max-gap-lines 2 --similarity 0.8 <path>
+# Third pass, noisier still: copies with a few edited lines or the same function
+# structure (Type-3, "similar"). Keep the settings tight.
+npx jscpd --reporters ai --max-gap-lines 1 --similarity 0.85 <path>
 
 # Where to refactor first: clone list plus a hotspot summary
 npx jscpd --reporters ai --summary <path>
@@ -87,6 +89,21 @@ A suffix tells the **kind** of clone; no suffix means an exact copy:
 
 By default jscpd reports **exact** clones only: the token sequences are identical (whitespace, layout and, depending on the mode, comments do not count). Two opt-in families widen the net. Run them as separate passes after the default scan, because they find more and longer clones and change what a "clone" means.
 
+**These passes are noisy by design.** An exact clone is almost always a real copy. A renamed or similar clone is a *candidate*: the flags deliberately ignore the very things (names, values, a statement or two) that often make two blocks different in meaning. Expect false positives from:
+
+- boilerplate that is supposed to look alike: DTOs and models, config tables, enum-like maps, route or handler registrations, builders
+- test files: `describe`/`it` blocks, fixtures and setup code repeat the same shape on purpose
+- generated code, migrations, serializers, protocol bindings
+- language idioms: two `reduce` loops or two `switch` statements that share structure but not logic
+- small blocks: with `--ignore-identifiers` a 50-token block is mostly placeholders, so raise `--min-tokens`
+
+Rules that keep the noise manageable:
+
+- Run them **after** the exact clones are handled, one family at a time, so every hit is attributable to one flag.
+- Start conservative: `--ignore-identifiers` alone (add `--ignore-literals` only when constants are the known problem), `--max-gap-lines 1` or `2`, `--similarity 0.85` or higher, and `--min-tokens 70` or more for the identifier pass. Widen only when the tight run comes back empty.
+- Treat every `(renamed)` or `[~…]` line as a lead to read, not a defect to fix. Do not gate CI (`--threshold`, `--fail-on-new-clones`) on these passes unless the team has reviewed what they report on the codebase.
+- Never claim "N duplicates found" from a normalized run without saying which flags produced them.
+
 ### Type-2: renamed clones (`--ignore-identifiers`, `--ignore-literals`, `--ignore-annotations`)
 
 Copies where someone renamed the variables or changed the constants:
@@ -126,7 +143,7 @@ credit-note.js:1-19 ~ invoice.js:1-17 [~0.75 ast]
 ```
 
 - `--max-gap-lines N` only joins clones the exact run already found, so it removes fragmentation rather than inventing matches; it works in every language. A merge is refused when the gap holds more tokens than the halves share (similarity would drop under `0.5`).
-- `--similarity RATIO` compares whole functions by the bag of 4-grams over their syntax-tree node types, so a renamed copy scores `1.0`, one inserted line about `0.9`, two added statements plus renames about `0.75`. Today it applies to JavaScript, TypeScript, JSX and TSX only; other formats are a silent no-op. Start at `0.85` for near-identical structure and lower to `0.7` for looser matches; below that the pairs are rarely worth merging.
+- `--similarity RATIO` compares whole functions by the bag of 4-grams over their syntax-tree node types, so a renamed copy scores `1.0`, one inserted line about `0.9`, two added statements plus renames about `0.75`. Today it applies to JavaScript, TypeScript, JSX and TSX only; other formats are a silent no-op. Start at `0.85` for near-identical structure and lower to `0.7` only when looking for leads; below `0.8` a large share of pairs merely share an idiom, so read both functions before believing the score.
 - `similar` takes precedence over `renamed` when both apply (a merged clone is no longer identical even after normalization).
 - Config keys: `maxGapLines`, `similarity`.
 


### PR DESCRIPTION
Follow-up to #1056. The normalized passes trade precision for recall, and the skills presented them as just more flags.

**jscpd skill**: a "noisy by design" paragraph in the Clone Kinds section listing the usual false positives (models/DTOs, config tables, test setup, generated code, shared idioms, short blocks), conservative defaults (`--ignore-identifiers` alone with `--min-tokens 70`, `--max-gap-lines 1` or `2`, `--similarity 0.85` or higher, one family per run), no CI gating on these passes until reviewed, and a rule never to report a normalized count without naming the flags. Quick start uses the tight settings.

**dry-refactoring skill**: exact clones first; the extra passes are framed as leads, not defects. The workflow gains a triage step for renamed/similar candidates with explicit skip criteria (different meaning behind the same shape, intentional boilerplate, generated code, no precise name for the extraction, tiny pairs) and asks the agent to report skipped candidates separately from refactored ones. Tips: renamed clones across test files usually mean nothing; gate CI on the exact run only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kucherenko/jscpd/1057)
<!-- Reviewable:end -->
